### PR TITLE
Move build-related directories into sorc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,7 @@
-bin/
-build/
 exec/
-include/
-lib/
-lib64/
 python_graphics/
-share/
 sorc/*
 !sorc/CMakeLists.txt
-save/
 ush/config.sh
 ush/*.swp
 ush/__pycache__/

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -33,8 +33,6 @@ OPTIONS
       does a "make clean"
   --build
       does a "make" (build only)
-  --move
-      move binaries to final location.
   --build-dir=BUILD_DIR
       build directory
   --install-dir=INSTALL_DIR
@@ -102,9 +100,9 @@ usage_error () {
 # default settings
 LCL_PID=$$
 HOME_DIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
-BUILD_DIR="${HOME_DIR}/build"
-INSTALL_DIR=${HOME_DIR}
-BIN_DIR="exec"
+BUILD_DIR="${HOME_DIR}/sorc/build"
+INSTALL_DIR="${HOME_DIR}/sorc/build"
+BIN_DIR="${HOME_DIR}/exec"
 COMPILER=""
 APPLICATION=""
 CCPP_SUITES=""
@@ -129,7 +127,6 @@ BUILD_AQM_UTILS="off"
 # Make options
 CLEAN=false
 BUILD=false
-MOVE=false
 USE_SUB_MODULES=false #change default to true later
 
 # process required arguments
@@ -160,7 +157,6 @@ while :; do
     --continue=?*|--continue=) usage_error "$1 argument ignored." ;;
     --clean) CLEAN=true ;;
     --build) BUILD=true ;;
-    --move) MOVE=true ;;
     --build-dir=?*) BUILD_DIR=${1#*=} ;;
     --build-dir|--build-dir=) usage_error "$1 requires argument." ;;
     --install-dir=?*) INSTALL_DIR=${1#*=} ;;
@@ -456,14 +452,6 @@ else
 
     printf "... Compile and install executables ...\n"
     make ${MAKE_SETTINGS} install 2>&1 | tee log.make
-
-    if [ "${MOVE}" = true ]; then
-       if [[ ! ${HOME_DIR} -ef ${INSTALL_DIR} ]]; then
-           printf "... Moving executables to final locations ...\n"
-           mkdir -p ${HOME_DIR}/${BIN_DIR}
-           mv ${INSTALL_DIR}/${BIN_DIR}/* ${HOME_DIR}/${BIN_DIR}
-       fi
-    fi
 fi
 
 exit 0

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -33,6 +33,8 @@ OPTIONS
       does a "make clean"
   --build
       does a "make" (build only)
+  --move
+      move binaries to final location.
   --build-dir=BUILD_DIR
       build directory
   --install-dir=INSTALL_DIR
@@ -102,7 +104,7 @@ LCL_PID=$$
 HOME_DIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 BUILD_DIR="${HOME_DIR}/sorc/build"
 INSTALL_DIR="${HOME_DIR}/sorc/build"
-BIN_DIR="${HOME_DIR}/exec"
+BIN_DIR="exec"
 COMPILER=""
 APPLICATION=""
 CCPP_SUITES=""
@@ -127,6 +129,7 @@ BUILD_AQM_UTILS="off"
 # Make options
 CLEAN=false
 BUILD=false
+MOVE=true
 USE_SUB_MODULES=false #change default to true later
 
 # process required arguments
@@ -157,6 +160,7 @@ while :; do
     --continue=?*|--continue=) usage_error "$1 argument ignored." ;;
     --clean) CLEAN=true ;;
     --build) BUILD=true ;;
+    --move) MOVE=true ;;
     --build-dir=?*) BUILD_DIR=${1#*=} ;;
     --build-dir|--build-dir=) usage_error "$1 requires argument." ;;
     --install-dir=?*) INSTALL_DIR=${1#*=} ;;
@@ -452,6 +456,14 @@ else
 
     printf "... Compile and install executables ...\n"
     make ${MAKE_SETTINGS} install 2>&1 | tee log.make
+
+    if [ "${MOVE}" = true ]; then
+       if [[ ! ${HOME_DIR} -ef ${INSTALL_DIR} ]]; then
+           printf "... Moving executables to final locations ...\n"
+           mkdir -p ${HOME_DIR}/${BIN_DIR}
+           mv ${INSTALL_DIR}/${BIN_DIR}/* ${HOME_DIR}/${BIN_DIR}
+       fi
+    fi
 fi
 
 exit 0

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -84,7 +84,7 @@ if (BUILD_UFS)
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
     INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS ${UFS_WEATHER_MODEL_ARGS}
-    INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_BINDIR} && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model/src/ufs-weather-model-build/ufs_model ${CMAKE_INSTALL_BINDIR}
+    INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR} && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model/src/ufs-weather-model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}
     BUILD_ALWAYS TRUE
     STEP_TARGETS build
     )

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -84,7 +84,7 @@ if (BUILD_UFS)
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
     INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS ${UFS_WEATHER_MODEL_ARGS}
-    INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR} && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model/src/ufs-weather-model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}
+    INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_BINDIR} && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model/src/ufs-weather-model-build/ufs_model ${CMAKE_INSTALL_BINDIR}
     BUILD_ALWAYS TRUE
     STEP_TARGETS build
     )


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES:
<!-- One or more bullet points describing the changes. -->
- Move the `build` directory into the `sorc` directory.
- Make the build output directories such as `include`, `lib`, `lib64`, and `share` created under the `build` directory.
- As a result, the `exec` directory is only added to the home directory once the build step is complete.

## TESTS CONDUCTED:
<!-- Explicitly state what tests were run on these changes. -->
- On machines/platforms:
<!-- Add 'x' inside the brackets (without space). -->
- [x] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Jet

- Test cases:
<!-- Add 'x' inside the brackets (without space). -->
- [x] Non-DA engineering test
- [ ] Sample script:

## ISSUE:
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #19 
