### PR TITLE
Add winter weather fields to testbed files

### DIFF
--- a/fix/upp/testbed_fields_bgdawp.txt
+++ b/fix/upp/testbed_fields_bgdawp.txt
@@ -61,6 +61,11 @@ PRATE:surface:
 PWAT:entire atmosphere (considered as a single layer):
 WEASD:surface:
 SNOD:surface:
+SNOWC:surface:
+ASNOW:surface:
+FROZR:surface:
+FRZR:surface:
+TSNOWP:surface:
 REFD:4000 m above ground:
 VVEL:700 mb:
 TMAX:2 m above ground:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- WPC requested that we add several additional winter weather fields to the testbed files: SNOWC, ASNOW, FROZR, FRZR, and TSNOWP. The testbed_fields_bgdawp.txt file is updated to include these new fields.
- This updated text file has already been added to the RRFS_A real-time parallel and is working as expected.  No further testing is needed for this PR.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- On machines/platforms:
<!-- Add 'x' inside the brackets (without space). -->
- [ ] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Jet

- Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [ ] Other sample scripts:

