### PR TITLE
Add 3 winter weather fields to RRFS testbed files

### DIFF
--- a/fix/upp/testbed_fields_bgdawp.txt
+++ b/fix/upp/testbed_fields_bgdawp.txt
@@ -36,6 +36,8 @@ HLCY:3000-0 m above ground:
 HLCY:1000-0 m above ground:
 UPHL:5000-2000 m above ground:
 RETOP:entire atmosphere (considered as a single layer):
+VIL:entire atmosphere:
+VIL:entire atmosphere (considered as a single layer):
 HGT:300 mb:
 UGRD:300 mb:
 VGRD:300 mb:

--- a/fix/upp/testbed_fields_bgdawp.txt
+++ b/fix/upp/testbed_fields_bgdawp.txt
@@ -36,8 +36,6 @@ HLCY:3000-0 m above ground:
 HLCY:1000-0 m above ground:
 UPHL:5000-2000 m above ground:
 RETOP:entire atmosphere (considered as a single layer):
-VIL:entire atmosphere:
-VIL:entire atmosphere (considered as a single layer):
 HGT:300 mb:
 UGRD:300 mb:
 VGRD:300 mb:
@@ -77,6 +75,9 @@ CICEP:surface:
 CFRZR:surface:
 CRAIN:surface:
 CPOFP:surface:
+HGT:0C isotherm:
+HGT:highest tropospheric freezing level:
+LAYTH:261 K level - 256 K level:
 TMP:30-0 mb above ground:
 RH:30-0 mb above ground:
 DPT:30-0 mb above ground:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- WPC requested that we add 3 more winter weather fields to the RRFS testbed files:

1. Height of 0C isotherm (HGT:0C isotherm)
2. Height of highest tropospheric freezing level (HGT:highest tropospheric freezing level)
3. Dendritic growth zone depth (LAYTH: 261 K level - 256 K level)

The testbed_fields_bgdawp.txt file was updated and the changes were successfully tested with the real-time RRFS parallel (v0.7.3).

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- On machines/platforms:
<!-- Add 'x' inside the brackets (without space). -->
- [x] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Jet

- Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [x] Other sample scripts: Tested with real-time RRFS parallel.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

