### PR TITLE
Fix anavinfo not to use vertical velocity for CRTM

### DIFF
--- a/fix/gsi/anavinfo.enkf.rrfs_dbz
+++ b/fix/gsi/anavinfo.enkf.rrfs_dbz
@@ -4,7 +4,7 @@ met_guess::
   z         1      -1         geopotential_height  phis
   u        65       2         zonal_wind           u
   v        65       2         meridional_wind      v
-  w        65       2         vertical_velocity    w
+  w        65      -1         vertical_velocity    w
   tv       65       2         virtual_temperature  tv
   q        65       2         specific_humidity    sphu
   oz       65       2         ozone                ozone

--- a/fix/gsi/anavinfo.rrfs_conv_dbz
+++ b/fix/gsi/anavinfo.rrfs_conv_dbz
@@ -4,7 +4,7 @@ met_guess::
   z         1      -1         geopotential_height  phis
   u        65       2         zonal_wind           u
   v        65       2         meridional_wind      v
-  w        65       2         vertical velocity    w
+  w        65      -1         vertical velocity    w
   tv       65       2         virtual_temperature  tv
   q        65       2         specific_humidity    sphu
   oz       65       2         ozone                ozone

--- a/fix/gsi/anavinfo.rrfs_dbz
+++ b/fix/gsi/anavinfo.rrfs_dbz
@@ -4,7 +4,7 @@ met_guess::
   z         1      -1         geopotential_height  phis
   u        65       2         zonal_wind           u
   v        65       2         meridional_wind      v
-  w        65       2         vertical velocity    w
+  w        65      -1         vertical velocity    w
   tv       65       2         virtual_temperature  tv
   q        65       2         specific_humidity    sphu
   oz       65       2         ozone                ozone


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR is to prevent SDL/VDL failure (NaN is sometimes detected in the 2nd outer loop) in GSI. This failure is caused by adding w (vertical velocity) to one of the variables for calculating radiance, so crtm_use for w in anavinfo is changed from 2 to -1.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- On machines/platforms:
<!-- Add 'x' inside the brackets (without space). -->
- [ ] WCOSS2
- [ ] Hera
- [x] Orion
- [ ] Jet

- Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [x] Other sample scripts: I confirmed that this fix of anavinfo files doesn't change the analysis and prevents NaN in several reruns as we expected.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #125
