### PR TITLE
Fix for bufrsnd task on WCOSS2

### DIFF
--- a/modulefiles/tasks/wcoss2/run_bufrsnd.local.lua
+++ b/modulefiles/tasks/wcoss2/run_bufrsnd.local.lua
@@ -1,3 +1,4 @@
 load("python_srw")
 
 load(pathJoin("gempak", os.getenv("gempak_ver")))
+load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The run_bufrsnd task fails with the real-time runs on WCOSS2.  The error message indicates the mpiexec command was not found.  This error can be fixed by loading the cray-pals module.  The modulefile for the run_bufrsnd task was updated, and the fix is currently working in RRFS v0.7.5. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- On machines/platforms:
<!-- Add 'x' inside the brackets (without space). -->
- [x] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Jet

- Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [x] Other sample scripts: RRFS real-time parallel

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #127 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->