### PR TITLE
Adding some needed irradiance variables to the RRFS diag_table.

### DIFF
--- a/parm/diag_table.FV3_HRRR
+++ b/parm/diag_table.FV3_HRRR
@@ -308,6 +308,10 @@
 "gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
 # "gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirbmdi",      "nirbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirdfdi",      "nirdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visbmdi",      "visbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visdfdi",      "visdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/diag_table.FV3_HRRR_gf
+++ b/parm/diag_table.FV3_HRRR_gf
@@ -308,6 +308,10 @@
 "gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
 # "gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirbmdi",      "nirbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirdfdi",      "nirdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visbmdi",      "visbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visdfdi",      "visdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/diag_table.FV3_HRRR_gf_clm
+++ b/parm/diag_table.FV3_HRRR_gf_clm
@@ -308,6 +308,10 @@
 "gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
 # "gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirbmdi",      "nirbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirdfdi",      "nirdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visbmdi",      "visbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visdfdi",      "visdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adding irradiance variables (needed for downstream users) to the diag table used for RRFS.  

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- On machines/platforms:
<!-- Add 'x' inside the brackets (without space). -->
- [ ] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Jet

- Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [ ] Other sample scripts:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #123

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

