### PR TITLE
Various bug fixes for blending

### DIFF
--- a/scripts/exrrfs_make_ics.sh
+++ b/scripts/exrrfs_make_ics.sh
@@ -735,16 +735,16 @@ if [ $DO_ENS_BLENDING = "TRUE" ] &&
    cp ${NWGES_BASEDIR}/${cdate_crnt_fhr_m1}${SLASH_ENSMEM_SUBDIR}/fcst_fv3lam/RESTART/${yyyymmdd}.${hh}0000.fv_core.res.nc ./fv_core.res.nc
 
    # Required FIX files
-   cp $FIXLAM/C3359_grid.tile7.nc .
-   cp $FIXLAM/C3359_oro_data.tile7.halo0.nc .
+   cp $FIXLAM/${CRES}_grid.tile7.nc .
+   cp $FIXLAM/${CRES}_oro_data.tile7.halo0.nc .
 
    # Shortcut the file names
    warm=./fv_core.res.tile1.nc
    cold=./out.atm.tile7.nc
-   grid=./C3359_grid.tile7.nc
+   grid=./${CRES}_grid.tile7.nc
    akbk=./fv_core.res.nc
    akbkcold=./gfs_ctrl.nc
-   orog=./C3359_oro_data.tile7.halo0.nc
+   orog=./${CRES}_oro_data.tile7.halo0.nc
    bndy=./gfs.bndy.nc
 
    # Run convert coldstart files to fv3 restart (rotate winds and remap).

--- a/scripts/exrrfs_run_prepstart.sh
+++ b/scripts/exrrfs_run_prepstart.sh
@@ -122,6 +122,7 @@ YYYYMMDD=${YYYYMMDDHH:0:8}
 YYYYJJJHH=${YYYY}${JJJ}${HH}
 
 current_time=$(date "+%T")
+cdate_crnt_fhr=$( date --utc --date "${YYYYMMDD} ${HH} UTC" "+%Y%m%d%H" )
 
 YYYYMMDDm1=$(date +%Y%m%d -d "${START_DATE} 1 days ago")
 YYYYMMDDm2=$(date +%Y%m%d -d "${START_DATE} 2 days ago")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Various bug fixes as we find them in setting up the real-time parallel (v0.7.9)
- Fix hardcoded CRES value in make_ics.
- Add cdate_crnt_fhr to run_prepstart. This was in my original PR but somehow didn't make the transition from GSL to EMC workflow.
- 

## TESTS CONDUCTED: 
Tests are done in the real-time parallel
- On machines/platforms:
- [x] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Jet

- Test cases: 
- [ ] Non-DA engineering test
- [x] DA engineering test
- [ ] Other sample scripts:

## CONTRIBUTORS (optional): 
Shun Liu testing in real-time parallel.

