### PR TITLE
Remove nsclgrp=1 and ngvarloc=1 from set_rrfs_config_SDL_VDL_MixEn.sh

### DIFF
--- a/ush/set_rrfs_config_SDL_VDL_MixEn.sh
+++ b/ush/set_rrfs_config_SDL_VDL_MixEn.sh
@@ -1,7 +1,5 @@
 
 l_both_fv3sar_gfs_ens=.false. #if true, ensemble size is increased with GDAS ensemble (MixEn)
-nsclgrp=1                     #number of scales for scale-dependent localization (SDL)
-ngvarloc=1                    #number of scales for variable-dependent localization (VDL)
 assign_vdl_nml=.false.        #if true, vdl_scale and vloc_varlist are used to set VDL
 
 if [ ${l_both_fv3sar_gfs_ens} = ".true." ]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Remove nsclgrp=1 and ngvarloc=1 from set_rrfs_config_SDL_VDL_MixEn.sh (already defined in config_defaults.sh).
If needed to activate SDLVDL, add nsclgrp=2 and ngvarloc=2 to target config.sh, before calling set_rrfs_config_SDL_VDL_MixEn.sh

## TESTS CONDUCTED: 

## ISSUE: 
- Fixes the issue #169 

## CONTRIBUTORS (optional): 

