### PR TITLE
Update to the latest hash for python_graphics

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -29,7 +29,7 @@ externals = None
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/pygraf
-hash = 29fd63c
+hash = ee94748
 local_path = ../python_graphics
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- This updates "Externals.cfg" with the latest python_graphics hash 

## TESTS CONDUCTED: 
- Have confirmed that running "checkout_externals" retrieves the latest code from the pygraf repository.  Other testing is described in the associated "pygraf" PR at https://github.com/NOAA-GSL/pygraf/pull/232
- [ ] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Hercules
- [ x] Jet

## CONTRIBUTORS (optional): 
The associated pygraf changes were developed by @Brian-Jamison 