### PR TITLE
Updating hash for python_graphics

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -29,7 +29,7 @@ externals = None
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/pygraf
-hash = ee94748
+hash = f1dd868
 local_path = ../python_graphics
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- This updates "Externals.cfg" to use the latest python_graphics hash

## TESTS CONDUCTED: 
Have confirmed that running "checkout_externals" retrieves the latest code from the pygraf repository. Other testing is described in the associated "pygraf" PR at https://github.com/NOAA-GSL/pygraf/pull/233
- On machines/platforms:
- [ ] WCOSS2
- [ x] Hera
- [ ] Orion
- [ ] Hercules
- [ ] Jet

- Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [ ] Other sample scripts:

## CONTRIBUTORS (optional): 
The associated pygraf changes were developed by @Brian-Jamison

