### PR TITLE
update model hash and compilers to Spack stack 1.5.1

### DIFF
--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -12,6 +12,9 @@ load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
 
 load("rrfs_common")
 
+prepend_path("MODULEPATH", "/scratch2/BMC/rtrr/gge/lua")
+load("prod_util/2.0.15")
+
 unload("python/3.10.8")
 
 setenv("CMAKE_C_COMPILER","mpiicc")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -5,7 +5,7 @@ the NOAA RDHPC machine Hera using Intel-2022.1.2
 
 whatis([===[Loads libraries needed for building the RRFS workflow on Hera ]===])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.5.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
@@ -15,8 +15,8 @@ load(pathJoin("zlib", os.getenv("zlib_ver") or "1.2.13"))
 load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
 load(pathJoin("parallelio", os.getenv("pio_ver") or "2.5.10"))
 --loading parallelio will load netcdf_c, netcdf_fortran, hdf5, zlib, etc
-load(pathJoin("esmf", os.getenv("esmf_ver") or "8.4.2"))
-load(pathJoin("fms", os.getenv("fms_ver") or "2023.01"))
+load(pathJoin("esmf", os.getenv("esmf_ver") or "8.5.0"))
+load(pathJoin("fms", os.getenv("fms_ver") or "2023.02.01"))
 
 load(pathJoin("bacio", os.getenv("bacio_ver") or "2.4.1"))
 load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
@@ -25,36 +25,23 @@ load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver") or "1.10.2"))
 load(pathJoin("ip", os.getenv("ip_ver") or "4.3.0"))
 load(pathJoin("sp", os.getenv("sp_ver") or "2.3.3"))
 
-load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.5.0"))
-load(pathJoin("yafyaml", os.getenv("yafyaml_ver") or "0.5.1"))
-load(pathJoin("mapl", os.getenv("mapl_ver") or "2.35.2-esmf-8.4.2"))
+load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.6.1"))
+load(pathJoin("mapl", os.getenv("mapl_ver") or "2.40.3-esmf-8.5.0"))
 load(pathJoin("scotch", os.getenv("scotch_ver") or "7.0.4"))
 
---load(pathJoin("bufr", os.getenv("bufr_ver") or "12.0.0"))
-load(pathJoin("gfsio", os.getenv("gfsio_ver") or "1.4.1"))
-load(pathJoin("landsfcutil", os.getenv("landsfcutil_ver") or "2.4.1"))
-load(pathJoin("nemsiogfs", os.getenv("nemsiogfs_ver") or "2.5.3"))
+load(pathJoin("bufr", os.getenv("bufr_ver") or "11.7.0"))
 load(pathJoin("sigio", os.getenv("sigio_ver") or "2.3.2"))
 load(pathJoin("sfcio", os.getenv("sfcio_ver") or "1.4.1"))
 load(pathJoin("nemsio", os.getenv("nemsio_ver") or "2.5.4"))
---load(pathJoin("wrf_io", os.getenv("wrf_io_ver") or "1.2.0"))
+load(pathJoin("wrf-io", os.getenv("wrf_io_ver") or "1.2.0"))
 load(pathJoin("ncio", os.getenv("ncio_ver") or "1.1.2"))
---load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.1"))
+load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.2"))
 load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
 load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
 
 load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
---load(pathJoin("prod_util", os.getenv("prod_util_ver") or "2.0.14"))
+load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
 load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))
-
-prepend_path("MODULEPATH", "/scratch2/BMC/rtrr/gge/lua")
-load("prod_util/2.0.15")
-load("wrf_io/1.2.0a")
-load("bufr/11.7.0a")
-load("gsi-ncdiag/1.1.2a")
-
-prepend_path("MODULEPATH", "/scratch2/BMC/ifi/modulefiles")
-try_load("ifi/20230511-intel-2022.1.2")
 
 unload("python/3.10.8")
 

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -10,38 +10,7 @@ load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.5.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
 
-load(pathJoin("jasper", os.getenv("jasper_ver") or "2.0.32"))
-load(pathJoin("zlib", os.getenv("zlib_ver") or "1.2.13"))
-load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
-load(pathJoin("parallelio", os.getenv("pio_ver") or "2.5.10"))
---loading parallelio will load netcdf_c, netcdf_fortran, hdf5, zlib, etc
-load(pathJoin("esmf", os.getenv("esmf_ver") or "8.5.0"))
-load(pathJoin("fms", os.getenv("fms_ver") or "2023.02.01"))
-
-load(pathJoin("bacio", os.getenv("bacio_ver") or "2.4.1"))
-load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
-load(pathJoin("g2", os.getenv("g2_ver") or "3.4.5"))
-load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver") or "1.10.2"))
-load(pathJoin("ip", os.getenv("ip_ver") or "4.3.0"))
-load(pathJoin("sp", os.getenv("sp_ver") or "2.3.3"))
-
-load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.6.1"))
-load(pathJoin("mapl", os.getenv("mapl_ver") or "2.40.3-esmf-8.5.0"))
-load(pathJoin("scotch", os.getenv("scotch_ver") or "7.0.4"))
-
-load(pathJoin("bufr", os.getenv("bufr_ver") or "11.7.0"))
-load(pathJoin("sigio", os.getenv("sigio_ver") or "2.3.2"))
-load(pathJoin("sfcio", os.getenv("sfcio_ver") or "1.4.1"))
-load(pathJoin("nemsio", os.getenv("nemsio_ver") or "2.5.4"))
-load(pathJoin("wrf-io", os.getenv("wrf_io_ver") or "1.2.0"))
-load(pathJoin("ncio", os.getenv("ncio_ver") or "1.1.2"))
-load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.2"))
-load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
-load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
-
-load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
-load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
-load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))
+load("rrfs_common")
 
 unload("python/3.10.8")
 

--- a/modulefiles/build_hercules_intel.lua
+++ b/modulefiles/build_hercules_intel.lua
@@ -8,53 +8,16 @@ whatis([===[Loads libraries needed for building the RRFS worfklow on Hercules ]=
 load("contrib")
 load("noaatools")
 
-prepend_path("MODULEPATH","/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.9.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.9.0"))
 load("intel-oneapi-mkl/2022.2.1")
 load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
 
-load(pathJoin("jasper", os.getenv("jasper_ver") or "2.0.32"))
-load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
-load(pathJoin("parallelio", os.getenv("pio_ver") or "2.5.10"))
---loading parallelio will load netcdf_c, netcdf_fortran, hdf5, zlib, etc
-load(pathJoin("esmf", os.getenv("esmf_ver") or "8.4.2"))
-load(pathJoin("fms", os.getenv("fms_ver") or "2023.01"))
-
-load(pathJoin("bacio", os.getenv("bacio_ver") or "2.4.1"))
-load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
-load(pathJoin("g2", os.getenv("g2_ver") or "3.4.5"))
-load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver") or "1.10.2"))
-load(pathJoin("ip", os.getenv("ip_ver") or "4.3.0"))
-load(pathJoin("sp", os.getenv("sp_ver") or "2.3.3"))
-
-load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.5.0"))
---load(pathJoin("yafyaml", os.getenv("yafyaml_ver") or "0.5.1"))
-load(pathJoin("mapl", os.getenv("mapl_ver") or "2.35.2-esmf-8.4.2"))
-load(pathJoin("scotch", os.getenv("scotch_ver") or "7.0.4"))
-
---load(pathJoin("bufr", os.getenv("bufr_ver") or "12.0.0"))
-load(pathJoin("gfsio", os.getenv("gfsio_ver") or "1.4.1"))
-load(pathJoin("landsfcutil", os.getenv("landsfcutil_ver") or "2.4.1"))
-load(pathJoin("nemsiogfs", os.getenv("nemsiogfs_ver") or "2.5.3"))
-load(pathJoin("sigio", os.getenv("sigio_ver") or "2.3.2"))
-load(pathJoin("sfcio", os.getenv("sfcio_ver") or "1.4.1"))
-load(pathJoin("nemsio", os.getenv("nemsio_ver") or "2.5.4"))
---load(pathJoin("wrf_io", os.getenv("wrf_io_ver") or "1.2.0"))
-load(pathJoin("ncio", os.getenv("ncio_ver") or "1.1.2"))
-load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.1"))
-load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
-load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
-
-load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
---load(pathJoin("prod_util", os.getenv("prod_util_ver") or "2.0.14"))
-load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "3.1.1"))
+load("rrfs_common")
 
 prepend_path("MODULEPATH", "/work/noaa/rtrr/gge/hercules/lua")
 load("prod_util/2.0.15")
-load("wrf_io/1.2.0a")
-load("bufr/11.7.0a")
-load("gsi-ncdiag/1.1.2a")
 
 unload("python/3.10.8")
 

--- a/modulefiles/build_jet_intel.lua
+++ b/modulefiles/build_jet_intel.lua
@@ -5,55 +5,13 @@ the NOAA RDHPC machine Jet using Intel-2022.1.2
 
 whatis([===[Loads libraries needed for building the RRFS workflow on Jet ]===])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
+
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.5.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
 
-load(pathJoin("jasper", os.getenv("jasper_ver") or "2.0.32"))
-load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
-load(pathJoin("parallelio", os.getenv("pio_ver") or "2.5.10"))
---loading parallelio will load netcdf_c, netcdf_fortran, hdf5, zlib, etc
-load(pathJoin("esmf", os.getenv("esmf_ver") or "8.4.2"))
-load(pathJoin("fms", os.getenv("fms_ver") or "2023.01"))
-
-load(pathJoin("bacio", os.getenv("bacio_ver") or "2.4.1"))
-load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
-load(pathJoin("g2", os.getenv("g2_ver") or "3.4.5"))
-load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver") or "1.10.2"))
-load(pathJoin("ip", os.getenv("ip_ver") or "4.3.0"))
-load(pathJoin("sp", os.getenv("sp_ver") or "2.3.3"))
-
-load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.5.0"))
-load(pathJoin("yafyaml", os.getenv("yafyaml_ver") or "0.5.1"))
-load(pathJoin("mapl", os.getenv("mapl_ver") or "2.35.2-esmf-8.4.2"))
-load(pathJoin("scotch", os.getenv("scotch_ver") or "7.0.4"))
-
---load(pathJoin("bufr", os.getenv("bufr_ver") or "12.0.0"))
-load(pathJoin("gfsio", os.getenv("gfsio_ver") or "1.4.1"))
-load(pathJoin("landsfcutil", os.getenv("landsfcutil_ver") or "2.4.1"))
-load(pathJoin("nemsiogfs", os.getenv("nemsiogfs_ver") or "2.5.3"))
-load(pathJoin("sigio", os.getenv("sigio_ver") or "2.3.2"))
-load(pathJoin("sfcio", os.getenv("sfcio_ver") or "1.4.1"))
-load(pathJoin("nemsio", os.getenv("nemsio_ver") or "2.5.4"))
---load(pathJoin("wrf_io", os.getenv("wrf_io_ver") or "1.2.0"))
-load(pathJoin("ncio", os.getenv("ncio_ver") or "1.1.2"))
---load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.1"))
-load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
-load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
-
-load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
---load(pathJoin("prod_util", os.getenv("prod_util_ver") or "2.0.14"))
-load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))
-
-prepend_path("MODULEPATH", "/lfs4/BMC/nrtrr/gge/lua")
-load("prod_util/2.0.15")
-load("wrf_io/1.2.0a")
-load("bufr/11.7.0a")
-load("gsi-ncdiag/1.1.2a")
-
-prepend_path("MODULEPATH", "/lfs4/BMC/ifi/modulefiles")
-try_load("ifi/20230511-intel-2022.1.2")
+load("rrfs_common")
 
 unload("python/3.10.8")
 

--- a/modulefiles/build_jet_intel.lua
+++ b/modulefiles/build_jet_intel.lua
@@ -13,6 +13,9 @@ load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
 
 load("rrfs_common")
 
+prepend_path("MODULEPATH", "/lfs4/BMC/nrtrr/FIX_EXEC_MODULE/lua")
+load("prod_util/2.0.15")
+
 unload("python/3.10.8")
 
 setenv("CMAKE_C_COMPILER","mpiicc")

--- a/modulefiles/build_orion_intel.lua
+++ b/modulefiles/build_orion_intel.lua
@@ -8,52 +8,15 @@ whatis([===[Loads libraries needed for building the RRFS worfklow on Orion ]===]
 load("contrib")
 load("noaatools")
 
-prepend_path("MODULEPATH","/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2022.0.2"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
 
-load(pathJoin("jasper", os.getenv("jasper_ver") or "2.0.32"))
-load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
-load(pathJoin("parallelio", os.getenv("pio_ver") or "2.5.10"))
---loading parallelio will load netcdf_c, netcdf_fortran, hdf5, zlib, etc
-load(pathJoin("esmf", os.getenv("esmf_ver") or "8.4.2"))
-load(pathJoin("fms", os.getenv("fms_ver") or "2023.01"))
-
-load(pathJoin("bacio", os.getenv("bacio_ver") or "2.4.1"))
-load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
-load(pathJoin("g2", os.getenv("g2_ver") or "3.4.5"))
-load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver") or "1.10.2"))
-load(pathJoin("ip", os.getenv("ip_ver") or "4.3.0"))
-load(pathJoin("sp", os.getenv("sp_ver") or "2.3.3"))
-
-load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.5.0"))
-load(pathJoin("yafyaml", os.getenv("yafyaml_ver") or "0.5.1"))
-load(pathJoin("mapl", os.getenv("mapl_ver") or "2.35.2-esmf-8.4.2"))
-load(pathJoin("scotch", os.getenv("scotch_ver") or "7.0.4"))
-
---load(pathJoin("bufr", os.getenv("bufr_ver") or "12.0.0"))
-load(pathJoin("gfsio", os.getenv("gfsio_ver") or "1.4.1"))
-load(pathJoin("landsfcutil", os.getenv("landsfcutil_ver") or "2.4.1"))
-load(pathJoin("nemsiogfs", os.getenv("nemsiogfs_ver") or "2.5.3"))
-load(pathJoin("sigio", os.getenv("sigio_ver") or "2.3.2"))
-load(pathJoin("sfcio", os.getenv("sfcio_ver") or "1.4.1"))
-load(pathJoin("nemsio", os.getenv("nemsio_ver") or "2.5.4"))
---load(pathJoin("wrf_io", os.getenv("wrf_io_ver") or "1.2.0"))
-load(pathJoin("ncio", os.getenv("ncio_ver") or "1.1.2"))
-load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.1"))
-load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
-load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
-
-load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
---load(pathJoin("prod_util", os.getenv("prod_util_ver") or "2.0.14"))
-load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))
+load("rrfs_common")
 
 prepend_path("MODULEPATH", "/work/noaa/rtrr/gge/lua")
 load("prod_util/2.0.15")
-load("wrf_io/1.2.0a")
-load("bufr/11.7.0a")
-load("gsi-ncdiag/1.1.2a")
 
 unload("python/3.10.8")
 

--- a/modulefiles/rrfs_common.lua
+++ b/modulefiles/rrfs_common.lua
@@ -1,0 +1,36 @@
+whatis("Description: RRFS build environment common libraries")
+
+help([[Load RRFS Model common libraries]])
+
+load(pathJoin("jasper", os.getenv("jasper_ver") or "2.0.32"))
+load(pathJoin("zlib", os.getenv("zlib_ver") or "1.2.13"))
+load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
+load(pathJoin("parallelio", os.getenv("pio_ver") or "2.5.10"))
+--loading parallelio will load netcdf_c, netcdf_fortran, hdf5, zlib, etc
+load(pathJoin("esmf", os.getenv("esmf_ver") or "8.5.0"))
+load(pathJoin("fms", os.getenv("fms_ver") or "2023.02.01"))
+
+load(pathJoin("bacio", os.getenv("bacio_ver") or "2.4.1"))
+load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
+load(pathJoin("g2", os.getenv("g2_ver") or "3.4.5"))
+load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver") or "1.10.2"))
+load(pathJoin("ip", os.getenv("ip_ver") or "4.3.0"))
+load(pathJoin("sp", os.getenv("sp_ver") or "2.3.3"))
+
+load(pathJoin("gftl-shared", os.getenv("gftl-shared_ver") or "1.6.1"))
+load(pathJoin("mapl", os.getenv("mapl_ver") or "2.40.3-esmf-8.5.0"))
+load(pathJoin("scotch", os.getenv("scotch_ver") or "7.0.4"))
+
+load(pathJoin("bufr", os.getenv("bufr_ver") or "11.7.0"))
+load(pathJoin("sigio", os.getenv("sigio_ver") or "2.3.2"))
+load(pathJoin("sfcio", os.getenv("sfcio_ver") or "1.4.1"))
+load(pathJoin("nemsio", os.getenv("nemsio_ver") or "2.5.4"))
+load(pathJoin("wrf-io", os.getenv("wrf_io_ver") or "1.2.0"))
+load(pathJoin("ncio", os.getenv("ncio_ver") or "1.1.2"))
+load(pathJoin("gsi-ncdiag", os.getenv("gsi-ncdiag_ver") or "1.1.2"))
+load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
+load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
+
+load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
+load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
+load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))

--- a/modulefiles/rrfs_common.lua
+++ b/modulefiles/rrfs_common.lua
@@ -32,5 +32,5 @@ load(pathJoin("w3emc", os.getenv("w3emc_ver") or "2.10.0"))
 load(pathJoin("w3nco", os.getenv("w3nco_ver") or "2.4.1"))
 
 load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
-load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
+--load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
 load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))

--- a/modulefiles/wflow_hera.lua
+++ b/modulefiles/wflow_hera.lua
@@ -7,7 +7,7 @@ whatis([===[Loads libraries needed for running the RRFS workflow on Hera ]===])
 
 load("rocoto")
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.5.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))

--- a/modulefiles/wflow_hercules.lua
+++ b/modulefiles/wflow_hercules.lua
@@ -8,7 +8,7 @@ whatis([===[Loads libraries needed for running RRFS workflow on Hercules ]===])
 load("contrib")
 load("rocoto")
 
-prepend_path("MODULEPATH","/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.9.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.9.0"))
 load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))

--- a/modulefiles/wflow_jet.lua
+++ b/modulefiles/wflow_jet.lua
@@ -7,7 +7,7 @@ whatis([===[Loads libraries needed for running the RRFS workflow on Jet ]===])
 
 load("rocoto")
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.5.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))

--- a/modulefiles/wflow_orion.lua
+++ b/modulefiles/wflow_orion.lua
@@ -9,7 +9,7 @@ load("contrib")
 load("rocoto")
 load("wget")
 
-prepend_path("MODULEPATH","/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.1/envs/gsi-addon/install/modulefiles/Core")
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2022.0.2"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 1492141
+hash = e7380dd
 local_path = ufs-weather-model
 required = True
 

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 991d652
+hash = 1492141
 local_path = ufs-weather-model
 required = True
 


### PR DESCRIPTION
The model is updated to hash use e7380dd (01/17/2024).
Update compilers to use Spack-stack 1.5.1 for Herea/Jet/Orion/Hercules

This version was tested on Hera and Jet with several cycles from winter 2022 retro.  