### PR TITLE
Updating hash for RRFS UPP.

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = d7ab9b8
+hash = 40a67b9
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updating UPP hash for RRFS.  We are already using the latest postxconfig-NT file for RRFS.

## TESTS CONDUCTED: 
The latest UPP was tested for RRFS-A on Jet.  The only update is a small change in the name of CPOFP, percent of frozen precipitation.  No change to GRIB2 values.
- [ ] WCOSS2
- [ ] Hera
- [ ] Orion
- [ ] Hercules
- [X] Jet

- Test cases: 
- [ ] Non-DA engineering test
- [ ] DA engineering test
- [X] Other sample scripts: Stand-alone UPP tests.

## ISSUE: 
None