### PR TITLE
Updating UPP to include GSL precip type bug fix

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 40a67b9
+hash = 775e6ed
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updating UPP hash to use recently merged code that includes GSL precip type bug fix for spurious freezing rain in the Arctic.

## TESTS CONDUCTED: 
The new UPP was tested for RRFS_NA_3km on Jet.

### Machines/Platforms:
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

