### PR TITLE
Fix the observer diag filenames to be ingested in EnKF

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -2342,7 +2342,7 @@ MODULES_RUN_TASK_FP script.
         {%- if do_retro %}
         <and> 
         {%- for m in range(1, num_ens_members+1) %}
-          <datadep age="00:00:00:01"><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H/mem{{ "%04d" % m }}/observer_gsi/diag_conv_dbz_ges.@Y@m@d@H.nc4</cyclestr></datadep>
+          <datadep age="00:00:00:01"><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H/mem{{ "%04d" % m }}/observer_gsi/diag_conv_dbz_ges.@Y@m@d@H.nc4.gz</cyclestr></datadep>
         {%- endfor %}
         </and> 
         {%- endif %}

--- a/scripts/exrrfs_run_enkf.sh
+++ b/scripts/exrrfs_run_enkf.sh
@@ -192,12 +192,14 @@ for imem in  $(seq 1 $nens) ensmean; do
       fi
     fi
     for sub_ob_type in ${list_ob_type} ; do
-      diagfile0=${observer_nwges_dir}/diag_${sub_ob_type}_ges.${YYYYMMDDHH}.nc4
+      diagfile0=${observer_nwges_dir}/diag_${sub_ob_type}_ges.${YYYYMMDDHH}.nc4.gz
       if [ -s $diagfile0 ]; then
         diagfile=$(basename  $diagfile0)
         cp  $diagfile0  $diagfile
-        ncfile=$(basename -s .nc4 $diagfile)
-        mv $ncfile.nc4 ${ncfile}_${memcharv0}.nc4
+        gzip -d $diagfile && rm -f $diagfile
+        ncfile0=$(basename -s .gz $diagfile)
+        ncfile=$(basename -s .nc4 $ncfile0)
+        mv $ncfile0 ${ncfile}_${memcharv0}.nc4
       fi
     done
   else


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Following recent change to GSI diag filenames (change from *.nc4 to *.nc4.gz), fixing EnKF run script and workflow to adapt to the change.

## TESTS CONDUCTED: 
Tested on Hera and Jet

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ x] Hera
  - [ x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x ] Retro
    - [ x] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
https://github.com/NOAA-EMC/rrfs-workflow/issues/207

## CONTRIBUTORS (optional): 
@hu5970 

