### PR TITLE
Change data location for DA ensemble engineering test

### DIFF
--- a/ush/sample_configs/DA_eng/config.DA.ens.hera.sh
+++ b/ush/sample_configs/DA_eng/config.DA.ens.hera.sh
@@ -194,7 +194,7 @@ if [[ ${DO_ENSFCST} == "TRUE" ]] ; then
   STMP="${PTMP}/stmp_ensfcst"
 fi
 NWGES="${PTMP}/nwges"
-ENSCTRL_STMP="/scratch2/NCEPDEV/fv3-cam/Chan-hoo.Jeon/DATA_RRFS"
+ENSCTRL_STMP="/scratch2/NCEPDEV/fv3-cam/UFS_SRW_App/develop/input_model_data/DAeng_ens_restart"
 ENSCTRL_PTMP="${PTMP}"
 ENSCTRL_NWGES="${NWGES}"
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The path to the input files for the DA ensemble engineering test is changed to the centralized location on Hera.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [ ] Retro
    - [x] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #213 
