### PR TITLE
Shift to pointing at emc.lam owned input directory

### DIFF
--- a/ush/sample_configs/RRFSFW/config.rrfsfw.wcoss2.sh
+++ b/ush/sample_configs/RRFSFW/config.rrfsfw.wcoss2.sh
@@ -68,5 +68,5 @@ FV3_NML_YAML_CONFIG_FN=""
 FV3_NML_BASE_SUITE_FN="input.nml.RRFSFW"
 
 USE_USER_STAGED_EXTRN_FILES="TRUE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data/RRFS/2023111118"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data/RRFS/2023111118"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/RRFS/2023111118"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/RRFS/2023111118"

--- a/ush/sample_configs/RRFSFW/config.rrfsfw.wcoss2.sh
+++ b/ush/sample_configs/RRFSFW/config.rrfsfw.wcoss2.sh
@@ -68,5 +68,5 @@ FV3_NML_YAML_CONFIG_FN=""
 FV3_NML_BASE_SUITE_FN="input.nml.RRFSFW"
 
 USE_USER_STAGED_EXTRN_FILES="TRUE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/RRFS/2023111118"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/RRFS/2023111118"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_input/input_model_data/RRFS/2023111118"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_input/input_model_data/RRFS/2023111118"

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.wcoss2.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.wcoss2.sh
@@ -51,5 +51,5 @@ WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 
 USE_USER_STAGED_EXTRN_FILES="TRUE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/2019061500"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/2019061500"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/grib2/2019061500"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/grib2/2019061500"

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.wcoss2.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.wcoss2.sh
@@ -51,5 +51,5 @@ WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 
 USE_USER_STAGED_EXTRN_FILES="TRUE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/grib2/2019061500"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/grib2/2019061500"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_input/input_model_data/FV3GFS/grib2/2019061500"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_input/input_model_data/FV3GFS/grib2/2019061500"

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.wcoss2.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.wcoss2.sh
@@ -52,5 +52,5 @@ WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 
 USE_USER_STAGED_EXTRN_FILES="TRUE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/netcdf/2023021706"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/netcdf/2023021706"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_input/input_model_data/FV3GFS/netcdf/2023021706"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_input/input_model_data/FV3GFS/netcdf/2023021706"

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.wcoss2.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.wcoss2.sh
@@ -52,5 +52,5 @@ WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 
 USE_USER_STAGED_EXTRN_FILES="TRUE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data/FV3GFS/netcdf/2023021706"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data/FV3GFS/netcdf/2023021706"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/netcdf/2023021706"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/lam/noscrub/RRFS_inputs/input_model_data/FV3GFS/netcdf/2023021706"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -840,10 +840,10 @@ PARM_IODACONV=${PARM_IODACONV:-"${HOMErrfs}/parm/iodaconv"}
 case $MACHINE in
 
   "WCOSS2")
-    FIXgsm=${FIXgsm:-"/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_am"}
-    TOPO_DIR=${TOPO_DIR:-"/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_orog"}
-    SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_sfc_climo"}
-    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/FV3LAM_pregen"}
+    FIXgsm=${FIXgsm:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/fix/fix_am"}
+    TOPO_DIR=${TOPO_DIR:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/fix/fix_orog"}
+    SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/FV3LAM_pregen"}
     ;;
 
   "HERA")

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -840,10 +840,10 @@ PARM_IODACONV=${PARM_IODACONV:-"${HOMErrfs}/parm/iodaconv"}
 case $MACHINE in
 
   "WCOSS2")
-    FIXgsm=${FIXgsm:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/fix/fix_am"}
-    TOPO_DIR=${TOPO_DIR:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/fix/fix_orog"}
-    SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/fix/fix_sfc_climo"}
-    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/lfs/h2/emc/lam/noscrub/RRFS_inputs/FV3LAM_pregen"}
+    FIXgsm=${FIXgsm:-"/lfs/h2/emc/lam/noscrub/RRFS_input/fix/fix_am"}
+    TOPO_DIR=${TOPO_DIR:-"/lfs/h2/emc/lam/noscrub/RRFS_input/fix/fix_orog"}
+    SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs/h2/emc/lam/noscrub/RRFS_input/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/lfs/h2/emc/lam/noscrub/RRFS_input/FV3LAM_pregen"}
     ;;
 
   "HERA")


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

Changes some WCOSS2 setup and configuration files to point at `/lfs/h2/emc/lam/noscrub/RRFS_input` (emc.lam owned) rather than  `/lfs/h2/emc/lam/noscrub/UFS_SRW_App` (chan-hoo owned) to allow for future updates of content there.

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- UFS_SRW_App/develop --> RRFS_input in four different USH scripts.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #227 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@BenjaminBlake-NOAA aided with this PR.