### PR TITLE
Turn on GLM analysis and option to pick observation source

### DIFF
--- a/jobs/JRRFS_PROCESS_GLMFED
+++ b/jobs/JRRFS_PROCESS_GLMFED
@@ -27,7 +27,7 @@
 #
 #-----------------------------------------------------------------------
 #
-{ save_shell_opts; set -u +x; } > /dev/null 2>&1
+{ save_shell_opts; set -u -x; } > /dev/null 2>&1
 #
 #-----------------------------------------------------------------------
 #
@@ -79,7 +79,7 @@ cd ${workdir}
 export FIX_GSI=$FIX_GSI
 export OBS_EAST=$GLMFED_EAST_ROOT
 export OBS_WEST=$GLMFED_WEST_ROOT
-export RRFSE_NWGES_BASEDIR=$RRFSE_NWGES_BASEDIR
+export RRFSE_NWGES_BASEDIR=$NWGES
 export NUM_ENS_MEMBERS=$NUM_ENS_MEMBERS
 export DA_CYCLE_INTERV=$DA_CYCLE_INTERV
 export MODE=$GLMFED_DATA_MODE

--- a/parm/FV3.input.yml
+++ b/parm/FV3.input.yml
@@ -46,6 +46,7 @@ FV3_HRRR:
     do_ugwp_v0_nst_only : false
     do_ugwp_v0_orog_only : false
     dt_inner : 36
+    ebb_dcycle : 1
     effr_in: true
     gwd_opt: 3
     fhlwr: 900.0
@@ -84,19 +85,24 @@ FV3_HRRR:
     rrfs_smoke_debug : false
     seas_opt : 0
     mix_chem : true
-    enh_mix : true
-    dust_opt : 5
-    drydep_opt : 1
+    enh_mix : false
+    dust_opt : 1
+    drydep_opt : 3
     coarsepm_settling : 1
+    smoke_conv_wet_coef : [0.5, 0.5, 0.5]
     smoke_forecast : 0
     aero_ind_fdb : false
     aero_dir_fdb : true
     addsmoke_flag : 1
     wetdep_ls_opt : 1
     do_plumerise : true
+    do_smoke_transport : true
     plumerisefire_frq : 60
-    dust_alpha : 0.01
+    plume_wind_eff : 1
+    dust_alpha : 10.0
     dust_gamma : 1.3
+    dust_drylimit_factor : 0.5
+    dust_moist_correction : 2.0
   fv_diagnostics_nml:
     do_hailcast: true
 
@@ -143,6 +149,7 @@ FV3_HRRR_gf:
     do_ugwp_v0_nst_only : false
     do_ugwp_v0_orog_only : false
     dt_inner : 36
+    ebb_dcycle : 1
     effr_in: true
     gwd_opt: 3
     fhlwr: 900.0
@@ -181,19 +188,24 @@ FV3_HRRR_gf:
     rrfs_smoke_debug : false
     seas_opt : 0
     mix_chem : true
-    enh_mix : true
-    dust_opt : 5
-    drydep_opt : 1
+    enh_mix : false
+    dust_opt : 1
+    drydep_opt : 3
     coarsepm_settling : 1
+    smoke_conv_wet_coef : [0.5, 0.5, 0.5]
     smoke_forecast : 0
     aero_ind_fdb : false
     aero_dir_fdb : true
     addsmoke_flag : 1
     wetdep_ls_opt : 1
     do_plumerise : true
+    do_smoke_transport : true
     plumerisefire_frq : 60
-    dust_alpha : 0.01
+    plume_wind_eff : 1
+    dust_alpha : 10.0
     dust_gamma : 1.3
+    dust_drylimit_factor : 0.5
+    dust_moist_correction : 2.0
   fv_diagnostics_nml:
     do_hailcast: true
 
@@ -238,6 +250,7 @@ FV3_RAP:
     do_ugwp_v0_orog_only : false
     do_deep : true
     dt_inner : 30
+    ebb_dcycle : 1
     effr_in: true
     gwd_opt: 3
     fhlwr: 900.0
@@ -276,19 +289,24 @@ FV3_RAP:
     rrfs_smoke_debug : false
     seas_opt : 0
     mix_chem : true
-    enh_mix : true
-    dust_opt : 5
-    drydep_opt : 1
+    enh_mix : false
+    dust_opt : 1
+    drydep_opt : 3
     coarsepm_settling : 1
+    smoke_conv_wet_coef : [0.5, 0.5, 0.5]
     smoke_forecast : 0
     aero_ind_fdb : false
     aero_dir_fdb : false
     addsmoke_flag : 1
     wetdep_ls_opt : 1
     do_plumerise : true
+    do_smoke_transport : true
     plumerisefire_frq : 60
-    dust_alpha : 0.01
+    plume_wind_eff : 1
+    dust_alpha : 10.0
     dust_gamma : 1.3
+    dust_drylimit_factor : 0.5
+    dust_moist_correction : 2.0
 
 FV3_RRFS_v1beta:
   gfs_physics_nml:

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -2339,8 +2339,8 @@ MODULES_RUN_TASK_FP script.
          <taskdep task="&PROCESS_RADAR_REF_TN;_prod"/>
          {%- endif %}
 	 <or>
-           <datadep age="02:00"><cyclestr>&OBSPATH;/@Y@m@d@H.rap.t@Hz.prepbufr.tm00</cyclestr></datadep>
-	   <datadep age="02:00"><cyclestr>&OBSPATH;/rap.@Y@m@d/rap.t@Hz.prepbufr.tm00</cyclestr></datadep>
+           <datadep age="02:00"><cyclestr>&OBSPATH;/@Y@m@d@H.{{obstype_source}}.t@Hz.prepbufr.tm00</cyclestr></datadep>
+	   <datadep age="02:00"><cyclestr>&OBSPATH;/{{obstype_source}}.@Y@m@d/{{obstype_source}}.t@Hz.prepbufr.tm00</cyclestr></datadep>
 	 </or>
        </and>
     </dependency>

--- a/scripts/exrrfs_process_bufr.sh
+++ b/scripts/exrrfs_process_bufr.sh
@@ -159,9 +159,9 @@ if [[ "${NET}" = "RTMA"* ]] && [[ "${RTMA_OBS_FEED}" = "NCO" ]]; then
   obspath_tmp=${OBSPATH}/${obs_source}.${YYYYMMDD}
 else
   SUBH=""
-  obs_source=rap
+  obs_source=${OBSTYPE_SOURCE}
   if [[ ${HH} -eq '00' || ${HH} -eq '12' ]]; then
-    obs_source=rap_e
+    obs_source=${OBSTYPE_SOURCE}_e
   fi
 
   case $MACHINE in

--- a/scripts/exrrfs_run_analysis.sh
+++ b/scripts/exrrfs_run_analysis.sh
@@ -446,9 +446,9 @@ if [[ "${NET}" = "RTMA"* ]] && [[ "${RTMA_OBS_FEED}" = "NCO" ]]; then
   obspath_tmp=${OBSPATH}/${obs_source}.${YYYYMMDD}
 else
   SUBH=""
-  obs_source=rap
+  obs_source=${OBSTYPE_SOURCE}
   if [ ${HH} -eq '00' ] || [ ${HH} -eq '12' ]; then
-    obs_source=rap_e
+    obs_source=${OBSTYPE_SOURCE}_e
   fi
 
   case $MACHINE in
@@ -466,8 +466,8 @@ else
      obspath_tmp=${OBSPATH}
     ;;
   "ORION" | "HERCULES")
-     obs_source=rap
-     obsfileprefix=${YYYYMMDDHH}.${obs_source}               # rap observation from JET.
+     obs_source=${OBSTYPE_SOURCE}
+     obsfileprefix=${YYYYMMDDHH}.${obs_source}               # observation from JET.
      #obsfileprefix=${obs_source}.${YYYYMMDD}/${obs_source}    # observation from operation.
      obspath_tmp=${OBSPATH}
     ;;

--- a/scripts/exrrfs_run_prepstart.sh
+++ b/scripts/exrrfs_run_prepstart.sh
@@ -486,10 +486,10 @@ if [ ${HH} -eq ${SNOWICE_update_hour} ] && [ "${CYCLE_TYPE}" = "prod" ] ; then
       cp ${IMSSNOW_ROOT}/latest.SNOW_IMS .
    elif [ -r "${IMSSNOW_ROOT}/${YYJJJ2200000000}" ]; then
       cp ${IMSSNOW_ROOT}/${YYJJJ2200000000} latest.SNOW_IMS
-   elif [ -r "${IMSSNOW_ROOT}/rap.${YYYYMMDD}/rap.t${HH}z.imssnow.grib2" ]; then
-      cp ${IMSSNOW_ROOT}/rap.${YYYYMMDD}/rap.t${HH}z.imssnow.grib2  latest.SNOW_IMS
-   elif [ -r "${IMSSNOW_ROOT}/rap.${YYYYMMDD}/rap_e.t${HH}z.imssnow.grib2" ]; then
-      cp ${IMSSNOW_ROOT}/rap_e.${YYYYMMDD}/rap_e.t${HH}z.imssnow.grib2  latest.SNOW_IMS
+   elif [ -r "${IMSSNOW_ROOT}/${OBSTYPE_SOURCE}.${YYYYMMDD}/${OBSTYPE_SOURCE}.t${HH}z.imssnow.grib2" ]; then
+      cp ${IMSSNOW_ROOT}/${OBSTYPE_SOURCE}.${YYYYMMDD}/${OBSTYPE_SOURCE}.t${HH}z.imssnow.grib2  latest.SNOW_IMS
+   elif [ -r "${IMSSNOW_ROOT}/${OBSTYPE_SOURCE}_e.${YYYYMMDD}/rap_e.t${HH}z.imssnow.grib2" ]; then
+      cp ${IMSSNOW_ROOT}/${OBSTYPE_SOURCE}_e.${YYYYMMDD}/${OBSTYPE_SOURCE}_e.t${HH}z.imssnow.grib2  latest.SNOW_IMS
    else
      echo "${IMSSNOW_ROOT} data does not exist!!"
      echo "WARNING: No snow update at ${HH}!!!!"

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -255,6 +255,7 @@ if (BUILD_UPP)
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
     "-Dexec_dir=${CMAKE_INSTALL_BINDIR}"
 #    "-DINTERNAL_IFI=ON"
+#    "-DBUILD_WITH_GTG=ON"
   )
 
   ExternalProject_Add(UPP

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -288,6 +288,7 @@ EXPT_SUBDIR=""
 # 
 # Setup default observation locations for data assimilation:
 #
+#    OBSTYPE_SOURCE: observation file source: rap or rrfs
 #    OBSPATH:   observation BUFR file path
 #    OBSPATH_NSSLMOSIAC: location of NSSL radar reflectivity 
 #    LIGHTNING_ROOT: location of lightning observations
@@ -343,6 +344,7 @@ NCL_HOME="/home/rtrr/RRFS/graphics"
 NCL_REGION="conus"
 MODEL="NO MODEL CHOSEN"
 
+OBSTYPE_SOURCE="rap"
 OBSPATH="/public/data/grids/rap/obs"
 OBSPATH_NSSLMOSIAC="/public/data/radar/mrms"
 OBSPATH_PM="/mnt/lfs1/BMC/wrfruc/hwang/rrfs_sd/pm"

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -448,6 +448,7 @@ settings="\
   'ensctrl_comout_basedir': ${ENSCTRL_COMOUT_BASEDIR:-}
   'ensctrl_comout_dir': ${ENSCTRL_COMOUT_DIR:-}
   'rrfse_nwges_basedir': ${RRFSE_NWGES_BASEDIR:-}
+  'obstype_source': ${OBSTYPE_SOURCE}
   'obspath': ${OBSPATH}
   'obspath_pm': ${OBSPATH_PM}
   'global_var_defns_fp': ${GLOBAL_VAR_DEFNS_FP}

--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3
@@ -1,6 +1,6 @@
 MACHINE="wcoss2"
 MACHINETYPE="primary"
-version="v0.7.9"
+version="v0.8.1"
 ACCOUNT="RRFS_DEV"
 #RESERVATION="rrfsdet"
 EXPT_BASEDIR="/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/${version}"
@@ -31,6 +31,8 @@ DO_PM_DA="FALSE"
 #DO_BUFRSND="TRUE"
 #USE_FVCOM="TRUE"
 #PREP_FVCOM="TRUE"
+DO_GLM_FED_DA="TRUE"
+GLMFED_DATA_MODE="EMC"
 USE_CLM="TRUE"
 DO_PARALLEL_PRDGEN="TRUE"
 DO_GSIDIAG_OFFLINE="FALSE"
@@ -62,7 +64,7 @@ BOUNDARY_PROC_GROUP_NUM="12"
 
 # avaialble retro period:
 # 20210511-20210531; 20210718-20210801
-DATE_FIRST_CYCL="20240101"
+DATE_FIRST_CYCL="20240201"
 DATE_LAST_CYCL="20240228"
 CYCL_HRS=( "00" "12" )
 CYCL_HRS=( "18" )
@@ -72,7 +74,7 @@ if [[ ${DO_ENSFCST} == "TRUE" ]] ; then
   CYCL_HRS_STOCH=("00" "06" "12" "18")
 fi
 #CYCL_HRS_RECENTER=("19")
-CYCLEMONTH="01-02"
+CYCLEMONTH="02"
 CYCLEDAY="*"
 
 STARTYEAR=${DATE_FIRST_CYCL:0:4}
@@ -200,10 +202,10 @@ fi
 
 RUN_ensctrl="rrfs"
 RUN="enkfrrfs"
-TAG="n3enkf79"
+TAG="n3enkf81"
 if [[ ${DO_ENSFCST} == "TRUE" ]] ; then
   RUN="refs"
-  TAG="n3enfcst79"
+  TAG="n3enfcst81"
 fi
 COMINgfs=""
 

--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_n3
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_n3
@@ -1,6 +1,6 @@
 MACHINE="wcoss2"
 MACHINETYPE="primary"
-version="v0.7.9"
+version="v0.8.1"
 ACCOUNT="RRFS_DEV"
 #RESERVATION="rrfsdet"
 EXPT_BASEDIR="/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/${version}"
@@ -45,12 +45,12 @@ BOUNDARY_PROC_GROUP_NUM="72"
 
 # avaialble retro period:
 # 20210511-20210531; 20210718-20210801
-DATE_FIRST_CYCL="20240101"
+DATE_FIRST_CYCL="20240201"
 DATE_LAST_CYCL="20240228"
 CYCL_HRS=( "00" "12" )
 CYCL_HRS_SPINSTART=("03" "15")
 CYCL_HRS_PRODSTART=("09" "21")
-CYCLEMONTH="01-02"
+CYCLEMONTH="02"
 CYCLEDAY="*"
 
 STARTYEAR=${DATE_FIRST_CYCL:0:4}
@@ -100,7 +100,6 @@ WRTCMP_output_file="netcdf_parallel"
 WRTCMP_ideflate="1"
 WRTCMP_quantize_nsd="18"
 
-
 regional_ensemble_option=5
 
 EXTRN_MDL_NAME_ICS="FV3GFS"
@@ -109,7 +108,7 @@ EXTRN_MDL_NAME_LBCS="FV3GFS"
 envir="para"
 
 NET="rrfs_a"
-TAG="n3v79"
+TAG="n3v81"
 
 ARCHIVEDIR="/NCEPDEV/emc-meso/1year/emc.lam/${TAG}"
 NCL_REGION="conus"

--- a/ush/set_rrfs_config.sh
+++ b/ush/set_rrfs_config.sh
@@ -49,6 +49,12 @@ if [[ $MACHINE == "wcoss2" ]] ; then
   FVCOM_DIR="/lfs/h1/ops/prod/com/nosofs/v3.5"
   FVCOM_FILE="fvcom"
   RAPHRR_SOIL_ROOT="/lfs/h1/ops/prod/com"
+  GLMFED_EAST_ROOT="/lfs/h1/ops/prod/dcom/ldmdata/obs/GOES-16/GLM/tiles"
+  GLMFED_WEST_ROOT="/lfs/h1/ops/prod/dcom/ldmdata/obs/GOES-17/GLM/tiles"
+  if [[ $OBSTYPE_SOURCE == "rrfs" ]]; then
+    OBSPATH=/lfs/h2/emc/lam/noscrub/emc.lam/obsproc.DATA/CRON/rrfs/com/obsproc/v1.0
+    IMSSNOW_ROOT=/lfs/h2/emc/lam/noscrub/emc.lam/obsproc.DATA/CRON/rrfs/com/obsproc/v1.0
+  fi
 fi
 
 # set up for retrospective test:


### PR DESCRIPTION
1) Turn on GLM analysis in EnKF
2) Add option (OBSTYPE_SOURCE) to decide which observation resource (rap or rrfs) should be used.
3) update namelist options for smoke and dust.

