### PR TITLE
Updates to the diag table

### DIFF
--- a/parm/diag_table.FV3_HRRR_gf_clm
+++ b/parm/diag_table.FV3_HRRR_gf_clm
@@ -351,6 +351,8 @@
 "gfs_sfc",     "acsnow_land",       "accswe_land",  "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_sfc",     "snowfall_acc_ice",  "snacc_ice",    "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_sfc",     "acsnow_ice",        "accswe_ice",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xlaixy",            "xlaixy",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "sfalb",             "sfalb",        "fv3_history2d",  "all",  .false.,  "none",  2
 # Stochastic physics
 #"gfs_phys",    "sppt_wts",      "sppt_wts",      "fv3_history",  "all", .false., "none", 2
 #"gfs_phys",    "skebu_wts",     "skebu_wts",     "fv3_history",  "all", .false., "none", 2

--- a/parm/diag_table.FV3_HRRR_gf_clm
+++ b/parm/diag_table.FV3_HRRR_gf_clm
@@ -149,6 +149,7 @@
 "gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFItoa",     "ulwrf_toa",   "fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2


### PR DESCRIPTION
Updating diag table to enable output of xlaixy, sfalb, and ULWRF at top of atmosphere.

## DESCRIPTION OF CHANGES: 
Changes to diag table.

## TESTS CONDUCTED: 
None

### Machines/Platforms:
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 

