### PR TITLE
Updating correct diag table with fields needed for resolved scale precip

### DIFF
--- a/parm/diag_table.FV3_HRRR_gf_clm
+++ b/parm/diag_table.FV3_HRRR_gf_clm
@@ -134,8 +134,8 @@
 "gfs_dyn",   "hailcast_dhail_max", "hailcast_dhail", "fv3_history2d", "all",  .false.,  "none", 2
 
 "gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
-#"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
-#"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
 "gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2


### PR DESCRIPTION
Need to update the correct diag table with fields needed for resolved scale precip.

## TESTS CONDUCTED: 
@ericaligo-NOAA has these fields in his diag table, and gets GRIB2 output of the needed fields.

### Machines/Platforms:
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

