### PR TITLE
Add EnKF update to 07 & 19Z spinup cycles

### DIFF
--- a/modulefiles/tasks/wcoss2/blend_ics.local.lua
+++ b/modulefiles/tasks/wcoss2/blend_ics.local.lua
@@ -18,5 +18,3 @@ load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 load(pathJoin("udunits", os.getenv("udunits_ver")))
 load(pathJoin("gsl", os.getenv("gsl_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
-
-setenv("BLENDINGPYTHON","/apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk/bin/python")

--- a/modulefiles/tasks/wcoss2/make_ics.local.lua
+++ b/modulefiles/tasks/wcoss2/make_ics.local.lua
@@ -19,5 +19,3 @@ load(pathJoin("wgrib2", os.getenv("wgrib2_ver")))
 load(pathJoin("udunits", os.getenv("udunits_ver")))
 load(pathJoin("gsl", os.getenv("gsl_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
-
-setenv("BLENDINGPYTHON","/apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk/bin/python")

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -1507,7 +1507,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>&WALLTIME_RUN_RECENTER;</walltime>
     &NODESIZE_ALL;
     <jobname><cyclestr>&TAG;_&RUN_RECENTER_TN;_spinup</cyclestr></jobname>
-    <join><cyclestr>&LOGDIR;/&RUN_RECENTER_TN;_spinup__&TAG;@Y@m@d@H.log</cyclestr></join>
+    <join><cyclestr>&LOGDIR;/&RUN_RECENTER_TN;_spinup_&TAG;@Y@m@d@H.log</cyclestr></join>
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
 
     <envar><name>nens</name><value>{{ num_ens_members }}</value></envar>
@@ -1532,6 +1532,287 @@ MODULES_RUN_TASK_FP script.
       </and>
     </dependency>
   </task>
+<!--
+************************************************************************
+************************************************************************
+-->
+  <task name="&CALC_ENSMEAN_TN;_spinup" cycledefs="spinupcyc" maxtries="{{ maxtries_run_prepstart }}">
+
+    &RSRV_ENKF;
+    &WALL_LIMIT_RECENTER;
+
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_RECENTER_TN;" "&JOBSdir;/JRRFS_CALC_ENSMEAN"</command>
+    &RESOURCES_RUN_RECENTER;
+    &NATIVE_ALL;
+    <walltime>&WALLTIME_RUN_RECENTER;</walltime>
+    &NODESIZE_ALL;
+    <jobname>&TAG;_&CALC_ENSMEAN_TN;_spinup</jobname>
+    <join><cyclestr>&LOGDIR;/&CALC_ENSMEAN_TN;_spinup_&TAG;_@Y@m@d@H.log</cyclestr></join>
+
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
+    <envar><name>nens</name><value>{{ num_ens_members }}</value></envar>
+    <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+
+    <dependency>
+         <and>
+         <taskdep task="&RUN_RECENTER_TN;_spinup"/>
+         <datadep age="00:00:00:05"><cyclestr>&FG_ROOT;/@Y@m@d@H/run_blending</cyclestr></datadep>
+         <or>
+           <streq><left>07</left><right><cyclestr>@H</cyclestr></right></streq>
+           <streq><left>19</left><right><cyclestr>@H</cyclestr></right></streq>
+         </or>
+         </and>
+    </dependency>
+
+  </task>
+<!--
+************************************************************************
+************************************************************************
+-->
+  <task name="&OBSERVER_GSI_ENSMEAN_TN;_spinup" cycledefs="spinupcyc" maxtries="{{ maxtries_analysis_gsi }}">
+
+    &RSRV_ANALYSIS;
+    &WALL_LIMIT_ANALYSIS;
+
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_ANALYSIS_TN;" "&JOBSdir;/JRRFS_RUN_ANALYSIS"</command>
+    &RESOURCES_ANALYSIS_GSI;
+    &NATIVE_ANALYSIS_GSI;
+    <walltime>&WALLTIME_ANALYSIS_GSI;</walltime>
+    &NODESIZE_ALL;
+    <jobname>&TAG;_&OBSERVER_GSI_ENSMEAN_TN;_spinup</jobname>
+    <join><cyclestr>&LOGDIR;/&OBSERVER_GSI_ENSMEAN_TN;_spinup_&TAG;_@Y@m@d@H.log</cyclestr></join>
+
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_ROOT</name><value><cyclestr>&CYCLE_BASEDIR;</cyclestr></value></envar>
+    <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>GSI_TYPE</name><value><cyclestr>OBSERVER</cyclestr></value></envar>
+    <envar><name>MEM_TYPE</name><value><cyclestr>MEAN</cyclestr></value></envar>
+    <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
+    <envar><name>SATBIAS_DIR</name><value><cyclestr>&NWGES_BASEDIR;/satbias</cyclestr></value></envar>
+
+    <dependency>
+       <and>
+         <taskdep task="&CALC_ENSMEAN_TN;_spinup"/>
+         {%- if do_enkf_radar_ref %}
+         <taskdep task="&PROCESS_RADAR_REF_TN;_spinup"/>
+         {%- endif %}
+         <or>
+           <datadep age="02:00"><cyclestr>&OBSPATH;/@Y@m@d@H.rap.t@Hz.prepbufr.tm00</cyclestr></datadep>
+           <datadep age="02:00"><cyclestr>&OBSPATH;/rap.@Y@m@d/rap.t@Hz.prepbufr.tm00</cyclestr></datadep>
+         </or>
+       </and>
+    </dependency>
+
+  </task>
+<!--
+************************************************************************
+************************************************************************
+-->
+ {%- if do_ensemble %}
+ <metatask name="run_ensemble_observer_spinup">
+   <var name="{{ ensmem_indx_name }}">
+    {%- for m in range(1, num_ens_members+1) -%}
+    {%- set fmtstr=" %0"~ndigits_ensmem_names~"d" -%}
+    {{- fmtstr%m -}}
+   {%- endfor %} </var>
+ {%- endif %}
+
+  <task name="&OBSERVER_GSI_TN;_spinup{{ uscore_ensmem_name }}" cycledefs="spinupcyc" maxtries="{{ maxtries_analysis_gsi }}">
+
+    &RSRV_ANALYSIS;
+    &WALL_LIMIT_ANALYSIS;
+
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_ANALYSIS_TN;" "&JOBSdir;/JRRFS_RUN_ANAL"</command>
+    &RESOURCES_ANALYSIS_GSI;
+    &NATIVE_ANALYSIS_GSI;
+    <walltime>&WALLTIME_ANALYSIS_GSI;</walltime>
+    &NODESIZE_ALL;
+    <jobname>&TAG;_&OBSERVER_GSI_TN;_spinup{{ uscore_ensmem_name }}</jobname>
+    <join><cyclestr>&LOGDIR;/&OBSERVER_GSI_TN;_spinup_&TAG;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
+
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_ROOT</name><value><cyclestr>&CYCLE_BASEDIR;</cyclestr></value></envar>
+    <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>GSI_TYPE</name><value><cyclestr>OBSERVER</cyclestr></value></envar>
+    <envar><name>MEM_TYPE</name><value><cyclestr>MEMBER</cyclestr></value></envar>
+    <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
+    <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+    <envar><name>SATBIAS_DIR</name><value><cyclestr>&NWGES_BASEDIR;/satbias</cyclestr></value></envar>
+
+    <dependency>
+       <and>
+         <taskdep task="&OBSERVER_GSI_ENSMEAN_TN;_spinup"/>
+       </and>
+    </dependency>
+
+  </task>
+
+{%- if do_ensemble %}
+  </metatask>{%- endif %}{%- endif %}
+
+{%- if do_enkfupdate %}
+<!--
+************************************************************************
+************************************************************************
+-->
+  <task name="&RUN_ENKFUPDT_TN;_spinup" cycledefs="spinupcyc" maxtries="{{ maxtries_analysis_enkf }}">
+    &RSRV_ENKF;
+    &WALL_LIMIT_ANALYSIS;
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_ENKFUPDT_TN;" &JOBSdir;/JRRFS_RUN_ENKF</command>
+
+    &RESOURCES_RUN_ENKF;
+    <walltime>&WALLTIME_RUN_ENKF;</walltime>
+    &NODESIZE_ALL;
+    <jobname><cyclestr>&TAG;_&RUN_ENKFUPDT_TN;_spinup</cyclestr></jobname>
+    <join><cyclestr>&LOGDIR;/&RUN_ENKFUPDT_TN;_spinup_&TAG;_@Y@m@d@H.log</cyclestr></join>
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+
+    <envar><name>nens</name><value>{{ num_ens_members }}</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_ROOT</name><value><cyclestr>&CYCLE_BASEDIR;</cyclestr></value></envar>
+    <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
+    <envar><name>OB_TYPE</name><value>conv</value></envar>
+
+    <dependency>
+        <metataskdep metatask="run_ensemble_observer_spinup"/>
+    </dependency>
+  </task>
+
+{%- endif %}
+
+{%- if do_enkf_radar_ref %}
+<!--
+************************************************************************
+************************************************************************
+-->
+  <task name="&ENKF_RADAR_REF_TN;_spinup" cycledefs="spinupcyc" maxtries="{{ maxtries_analysis_enkf }}">
+    &RSRV_ENKF;
+    &WALL_LIMIT_ANALYSIS;
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&ENKF_RADAR_REF_TN;" &JOBSdir;/JRRFS_RUN_ENKF</command>
+
+    &RESOURCES_RUN_ENKF;
+    <walltime>&WALLTIME_RUN_ENKF;</walltime>
+    &NODESIZE_ALL;
+    <jobname><cyclestr>&TAG;_&ENKF_RADAR_REF_TN;_spinup</cyclestr></jobname>
+    <join><cyclestr>&LOGDIR;/&ENKF_RADAR_REF_TN;_spinup_&TAG;_@Y@m@d@H.log</cyclestr></join>
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+
+    <envar><name>nens</name><value>{{ num_ens_members }}</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_ROOT</name><value><cyclestr>&CYCLE_BASEDIR;</cyclestr></value></envar>
+    <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
+    <envar><name>OB_TYPE</name><value>radardbz</value></envar>
+
+    <dependency>
+      <and>
+        <taskdep task="&RUN_ENKFUPDT_TN;_spinup"/>
+        {%- if do_retro %}
+        <and> 
+        {%- for m in range(1, num_ens_members+1) %}
+          <datadep age="00:00:00:01"><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H/mem{{ "%04d" % m }}/observer_gsi/diag_conv_dbz_ges.@Y@m@d@H.nc4.gz</cyclestr></datadep>
+        {%- endfor %}
+        </and> 
+        {%- endif %}
+      </and>
+    </dependency>
+  </task>
+
+{%- endif %}
+
+{% if do_ensemble %}
+ <metatask name="run_ensemble">
+  <var name="{{ ensmem_indx_name }}">
+    {%- for m in range(1, num_ens_members+1) -%}{%- set fmtstr=" %0"~ndigits_ensmem_names~"d" -%}{{- fmtstr%m -}}{%- endfor %} </var>
+{%- endif %}
+
+{%- if do_nonvar_cldanal %}
+<!--
+************************************************************************
+************************************************************************
+-->
+  <task name="&CLDANL_NONVAR_TN;_spinup{{ uscore_ensmem_name }}" cycledefs="spinupcyc"  maxtries="{{ maxtries_cldanl_nonvar }}">
+
+    &RSRV_DEFAULT;
+    &WALL_LIMIT_ANALYSIS;
+
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_ANALYSIS_TN;" "&JOBSdir;/JRRFS_NONVARCLD"</command>
+
+    &RESOURCES_NONVAR_CLD;
+    <walltime>&WALLTIME_NONVAR_CLD;</walltime>
+    &NATIVE_ALL;
+    &NODESIZE_ALL;
+
+    <jobname>&TAG;_&CLDANL_NONVAR_TN;_spinup{{ uscore_ensmem_name }}</jobname>
+    <join><cyclestr>&LOGDIR;/&CLDANL_NONVAR_TN;_spinup_&TAG;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
+
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
+    <envar><name>MEM_TYPE</name><value><cyclestr>MEMBER</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+
+    <dependency>
+      <and>
+        <taskdep task="&PROCESS_BUFR_TN;_spinup"/>
+        {%- if do_enkfupdate %}
+        <and>
+           {%- if do_enkf_radar_ref %}
+             <taskdep task="&ENKF_RADAR_REF_TN;_spinup"/>
+           {%- else %}
+             <taskdep task="&RUN_ENKFUPDT_TN;"/>
+           {%- endif %}
+        </and>
+        {%- elif do_envar_radar_ref and not do_envar_radar_ref_once %}
+        <or>
+          <and>
+            <taskdep task="&POSTANAL_TN;_prod{{ uscore_ensmem_name }}"/>
+             {%- for h in cycl_hrs_hyb_fv3lam_ens %}
+                <strneq><left>{{ h }}</left><right><cyclestr>@H</cyclestr></right></strneq>
+             {%- endfor %}
+          </and>
+          <and>
+            <taskdep task="&HYBRID_RADAR_REF_TN;_prod"/>
+            <or>    
+             {%- for h in cycl_hrs_hyb_fv3lam_ens %}
+                <streq><left>{{ h }}</left><right><cyclestr>@H</cyclestr></right></streq>
+             {%- endfor %}
+            </or>   
+          </and>
+        </or>
+        {%- else %}
+        <taskdep task="&POSTANAL_TN;_prod{{ uscore_ensmem_name }}"/>
+        {%- endif %}
+      </and>
+    </dependency>
+
+  </task>
+{%- if do_ensemble %}
+ </metatask>
+{%- endif %}
 {%- endif %}
 
 {%- if not do_ensemble %}
@@ -1991,7 +2272,14 @@ MODULES_RUN_TASK_FP script.
           </or>
           <or>
           {%- if do_ensinit or do_ens_blending %}
-          <taskdep task="&RUN_RECENTER_TN;_spinup"/>
+            <and>
+              <datadep age="00:00:00:05"><cyclestr>&FG_ROOT;/@Y@m@d@H/run_ensinit</cyclestr></datadep>
+              <taskdep task="&RUN_RECENTER_TN;_spinup"/>
+            </and>
+            <and>
+              <datadep age="00:00:00:05"><cyclestr>&FG_ROOT;/@Y@m@d@H/run_blending</cyclestr></datadep>
+              <taskdep task="&CLDANL_NONVAR_TN;_spinup_mem#mem#"/>
+            </and>
           {%- else  %}
           <taskdep task="&PREP_CYC_TN;_spinup{{ uscore_ensmem_name }}"/>
           {%- endif %}

--- a/scripts/exrrfs_blend_ics.sh
+++ b/scripts/exrrfs_blend_ics.sh
@@ -195,7 +195,7 @@ if [[ $DO_ENS_BLENDING == "TRUE" ]]; then
      use_host_enkf=${USE_HOST_ENKF} # ignored if blend="TRUE".
                                     # TRUE:  Final EnKF will be GDAS (no blending)
                                     # FALSE: Final EnKF will be RRFS (no blending)
-     ${BLENDINGPYTHON} exrrfs_blending_fv3.py $Lx $glb $reg $trcr $blend $use_host_enkf
+     python exrrfs_blending_fv3.py $Lx $glb $reg $trcr $blend $use_host_enkf
      cp ./fv_core.res.tile1.nc ${ics_dir}/.
      cp ./fv_tracer.res.tile1.nc ${ics_dir}/.
 

--- a/scripts/exrrfs_make_ics.sh
+++ b/scripts/exrrfs_make_ics.sh
@@ -744,7 +744,7 @@ if [[ $DO_ENS_BLENDING == "TRUE" && $EXTRN_MDL_NAME_ICS = "GDASENKF" ]]; then
   bndy=./gfs.bndy.nc
 
   # Run convert coldstart files to fv3 restart (rotate winds and remap).
-  ${BLENDINGPYTHON} exrrfs_chgres_cold2fv3.py $cold $grid $akbk $akbkcold $orog
+  python exrrfs_chgres_cold2fv3.py $cold $grid $akbk $akbkcold $orog
 
 fi
 #

--- a/scripts/exrrfs_run_analysis.sh
+++ b/scripts/exrrfs_run_analysis.sh
@@ -511,7 +511,11 @@ if [[ ${gsi_type} == "OBSERVER" || ${anav_type} == "conv" || ${anav_type} == "co
 
   if [ "${DO_ENKF_RADAR_REF}" = "TRUE" ]; then
     obs_number=${#obs_files_source[@]}
-    obs_files_source[${obs_number}]=${cycle_dir}/process_radarref_enkf/00/Gridded_ref.nc
+    if [ "${CYCLE_TYPE}" = "spinup" ]; then
+      obs_files_source[${obs_number}]=${cycle_dir}/process_radarref_spinup_enkf/00/Gridded_ref.nc
+    else
+      obs_files_source[${obs_number}]=${cycle_dir}/process_radarref_enkf/00/Gridded_ref.nc
+    fi
     obs_files_target[${obs_number}]=dbzobs.nc
     if [ "${DO_GLM_FED_DA}" = "TRUE" ]; then
       obs_number=${#obs_files_source[@]}
@@ -957,7 +961,11 @@ if [ "${gsi_type}" = "OBSERVER" ]; then
   else
     lread_obs_save=.false.
     lread_obs_skip=.true.
-    ln -s ../../ensmean/observer_gsi/obs_input.* .
+    if [ "${CYCLE_TYPE}" = "spinup" ]; then
+      ln -s ../../ensmean/observer_gsi_spinup/obs_input.* .
+    else
+      ln -s ../../ensmean/observer_gsi/obs_input.* .
+    fi
   fi
 fi
 if [ ${BKTYPE} -eq 1 ]; then

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -48,7 +48,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = 74edce4
+hash = 40a9f72
 local_path = rrfs_utl
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Added EnKF update to 07 & 19Z spinup cycles with blending active.
- Removed the BLENDINGPYTHON variable.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [x] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes an issue(s) mentioned in #108

