### PR TITLE
Blending and smoke fixes

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -1100,7 +1100,9 @@ MODULES_RUN_TASK_FP script.
       <and>
         <taskdep task="&MAKE_ICS_TN;{{ uscore_ensmem_name }}"/>
         <or>
+        {%- if not do_retro %}
           <timedep><cyclestr offset="&START_TIME_BLENDING;">@Y@m@d@H@M00</cyclestr></timedep>
+        {%- endif %}
           <and>
           <datadep age="00:00:00:05"><cyclestr offset="-1:00:00">&FG_ROOT;/@Y@m@d@H/mem0001/fcst_fv3lam/RESTART/</cyclestr><cyclestr>@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
           <datadep age="00:00:00:05"><cyclestr offset="-1:00:00">&FG_ROOT;/@Y@m@d@H/mem0002/fcst_fv3lam/RESTART/</cyclestr><cyclestr>@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
@@ -1519,10 +1521,6 @@ MODULES_RUN_TASK_FP script.
          <and>
          <taskdep task="&RUN_RECENTER_TN;_spinup"/>
          <datadep age="00:00:00:05"><cyclestr>&FG_ROOT;/@Y@m@d@H/run_blending</cyclestr></datadep>
-         <or>
-           <streq><left>07</left><right><cyclestr>@H</cyclestr></right></streq>
-           <streq><left>19</left><right><cyclestr>@H</cyclestr></right></streq>
-         </or>
          </and>
     </dependency>
 
@@ -1574,14 +1572,12 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
- {%- if do_ensemble %}
  <metatask name="run_ensemble_observer_spinup">
    <var name="{{ ensmem_indx_name }}">
     {%- for m in range(1, num_ens_members+1) -%}
     {%- set fmtstr=" %0"~ndigits_ensmem_names~"d" -%}
     {{- fmtstr%m -}}
    {%- endfor %} </var>
- {%- endif %}
 
   <task name="&OBSERVER_GSI_TN;_spinup{{ uscore_ensmem_name }}" cycledefs="spinupcyc" maxtries="{{ maxtries_analysis_gsi }}">
 
@@ -1617,8 +1613,8 @@ MODULES_RUN_TASK_FP script.
 
   </task>
 
-{%- if do_ensemble %}
-  </metatask>{%- endif %}{%- endif %}
+  </metatask>
+{%- endif %}
 
 {%- if do_enkfupdate %}
 <!--

--- a/scripts/exrrfs_process_smoke.sh
+++ b/scripts/exrrfs_process_smoke.sh
@@ -93,12 +93,24 @@ do
       echo "${rave_nwges_dir}/${intp_fname} interoplated file non available to reuse"  
    fi
 done
+
+#
+#  link RAVE data to work directory  $workdir
+#
+previous_2day=`${DATE} '+%C%y%m%d' -d "$current_day-2 days"`
+YYYYMMDDm1=${previous_day:0:8}
+YYYYMMDDm2=${previous_2day:0:8}
+fire_rave_dir_work=${workdir}
+ln -s ${FIRE_RAVE_DIR}/${YYYYMMDD}/rave/RAVE-HrlyEmiss-3km_* ${fire_rave_dir_work}/.
+ln -s ${FIRE_RAVE_DIR}/${YYYYMMDDm1}/rave/RAVE-HrlyEmiss-3km_* ${fire_rave_dir_work}/.
+ln -s ${FIRE_RAVE_DIR}/${YYYYMMDDm2}/rave/RAVE-HrlyEmiss-3km_* ${fire_rave_dir_work}/.
+
 #
 #-----------------------------------------------------------------------
 #
 python -u  ${USHdir}/generate_fire_emissions.py \
   "${FIX_SMOKE_DUST}/${PREDEF_GRID_NAME}" \
-  "${FIRE_RAVE_DIR}" \
+  "${fire_rave_dir_work}" \
   "${workdir}" \
   "${PREDEF_GRID_NAME}" \
   "${EBB_DCYCLE}" 

--- a/ush/set_rrfs_config.sh
+++ b/ush/set_rrfs_config.sh
@@ -45,7 +45,7 @@ if [[ $MACHINE == "wcoss2" ]] ; then
   SST_ROOT=/lfs/h1/ops/prod/com/nsst/v1.2
   GVF_ROOT=/lfs/h1/ops/prod/dcom/viirs
   IMSSNOW_ROOT=/lfs/h1/ops/prod/com/obsproc/v1.1
-  FIRE_RAVE_DIR=/lfs/h2/emc/lam/noscrub/emc.lam/RAVE_rawdata/RAVE_NA
+  FIRE_RAVE_DIR=/lfs/h1/ops/prod/dcom
   FVCOM_DIR="/lfs/h1/ops/prod/com/nosofs/v3.5"
   FVCOM_FILE="fvcom"
   FVCOM_DIR="/lfs/h2/emc/lam/noscrub/emc.lam/OWAQ_fv3"


### PR DESCRIPTION
1) Update workflow to run blending in retros
2) Update smoke process to use operational feed RVAE data.

Tested with v0.8.5 on Cactus and retros.