### PR TITLE
save FED GSI diagnostics

### DIFF
--- a/scripts/exrrfs_run_gsidiag.sh
+++ b/scripts/exrrfs_run_gsidiag.sh
@@ -243,7 +243,7 @@ for loop in $loops; do
       done
     fi
 
-    listall="conv_dbz"
+    listall="conv_dbz conv_fed"
     if [ -r ${analworkdir_dbz} ]; then
       cd ${analworkdir_dbz}
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
Add Flash Extent Density "conv_fed" as a variable to save diagnostic data from the stmp analysis directory to prod (this is already done for other fields)

## TESTS CONDUCTED: 
tested in Hera retro

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ X] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ X] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #271 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

