### PR TITLE
Adding hourly-averaged surface smoke/dust to diag tables.

### DIFF
--- a/parm/diag_table.FV3_HRRR
+++ b/parm/diag_table.FV3_HRRR
@@ -413,6 +413,9 @@
 "gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
 
 # Aerosols emission for smoke
 "gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/diag_table.FV3_HRRR_gf
+++ b/parm/diag_table.FV3_HRRR_gf
@@ -413,6 +413,9 @@
 "gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
 
 # Aerosols emission for smoke
 "gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/diag_table.FV3_HRRR_gf_clm
+++ b/parm/diag_table.FV3_HRRR_gf_clm
@@ -507,6 +507,9 @@
 "gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
 
 # Aerosols emission for smoke
 "gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/diag_table.FV3_HRRR_gf_nogwd
+++ b/parm/diag_table.FV3_HRRR_gf_nogwd
@@ -411,6 +411,9 @@
 "gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
 
 # Aerosols emission for smoke
 "gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Adding three new variables to diag tables: hourly-averaged smoke / dust / coarsepm.  These are useful for comparison with observations and other modeling systems.

## TESTS CONDUCTED: 
One-off tests produced the expected new fields on Jet.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None