### PR TITLE
source /etc/profile before 'module load' in run_rocoto.sh on platforms other than wcoss2

### DIFF
--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -650,6 +650,7 @@ if [[ "${MACHINE,,}" == "wcoss2" ]] ; then
   echo "module use /apps/ops/test/nco/modulefiles" >> ${EXPTDIR}/run_rocoto.sh
   echo "module load core/rocoto/${rocoto_ver}" >> ${EXPTDIR}/run_rocoto.sh
 else
+  echo "source /etc/profile" >> ${EXPTDIR}/run_rocoto.sh
   echo "module load rocoto" >> ${EXPTDIR}/run_rocoto.sh
 fi
 echo "rocotorun -w ${WFLOW_XML_FN} -d ${WFLOW_XML_FN%.*}.db" >> ${EXPTDIR}/run_rocoto.sh


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
The new Rocky 8 system on Hera/Jet does not support "SHELL=/bin/bash -l" in the crontab and run_rocoto.sh fails at the "module load rocoto" step. We need to add "source /etc/profile" before "module load rocoto" to make it work. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested generate_FV3LAM_wflow.sh and ran realtime RRFS_B on Jet. It worked as expected.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [x] Jet
  - [x] Orion
  - [x] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [x] RRFS_B:
- [x] RTMA:
- [ ] Others:

