### PR TITLE
Modify non-DA engineering test to use RRFS vertical level configuration

### DIFF
--- a/parm/FV3.input.nonDA.yml
+++ b/parm/FV3.input.nonDA.yml
@@ -7,7 +7,7 @@ FV3_HRRR:
   diag_manager_nml:
     max_output_fields: 450
   external_ic_nml:
-    levp: 65
+    levp: 66
   fms_nml:
     domains_stack_size: 12000000
   fv_core_nml:
@@ -26,7 +26,7 @@ FV3_HRRR:
     kord_wz: 9
     n_split: 5
     nord_tr: 0
-    npz: 64
+    npz: 65
     nrows_blend: 10
     psm_bc: 1
     range_warn: False
@@ -75,7 +75,7 @@ FV3_HRRR_gf:
   diag_manager_nml:
     max_output_fields: 450
   external_ic_nml:
-    levp: 65
+    levp: 66
   fms_nml:
     domains_stack_size: 12000000
   fv_core_nml:
@@ -94,7 +94,7 @@ FV3_HRRR_gf:
     kord_wz: 9
     n_split: 5
     nord_tr: 0
-    npz: 64
+    npz: 65
     nrows_blend: 10
     psm_bc: 1
     range_warn: False
@@ -143,7 +143,7 @@ FV3_RAP:
   diag_manager_nml:
     max_output_fields: 450
   external_ic_nml:
-    levp: 65
+    levp: 66
   fms_nml:
     domains_stack_size: 12000000
   fv_core_nml:
@@ -152,7 +152,7 @@ FV3_RAP:
     hord_tr: 8
     k_split: 2
     nord_tr: 0
-    npz: 64
+    npz: 65
     nrows_blend: 10
     psm_bc: 1
     regional_bcs_from_gsi: false
@@ -198,14 +198,14 @@ FV3_RRFS_v1beta:
   diag_manager_nml:
     max_output_fields: 450
   external_ic_nml:
-    levp: 65
+    levp: 66
   fms_nml:
     domains_stack_size: 12000000
   fv_core_nml:
     dz_min: 2
     k_split: 2
     n_sponge: 24
-    npz: 64
+    npz: 65
     psm_bc: 1
     vtdm4: 0.02
     write_restart_with_bcs: false
@@ -239,7 +239,7 @@ FV3_GFS_v15_thompson_mynn_lam3km:
   atmos_model_nml:
     avg_max_length: 3600.0
   external_ic_nml:
-    levp: 65
+    levp: 66
   fms_nml:
     domains_stack_size: 12000000
   fv_core_nml:
@@ -251,7 +251,7 @@ FV3_GFS_v15_thompson_mynn_lam3km:
     nggps_ic: false
     nord_tr: 2
     nrows_blend: 10
-    npz: 64
+    npz: 65
     npz_type: ''
     psm_bc: 1
     regional_bcs_from_gsi: false
@@ -312,7 +312,7 @@ FV3_GFS_v16:
   cires_ugwp_nml:
     launch_level: 27
   external_ic_nml:
-    levp: 65
+    levp: 66
   fv_core_nml:
     agrid_vel_rst: False
     d2_bg_k1: 0.2
@@ -337,7 +337,7 @@ FV3_GFS_v16:
     n_sponge: 10
     na_init: 0
     nord_zs_filter: !!python/none
-    npz: 64
+    npz: 65
     nudge_dz: False
     nudge_qv: True
     psm_bc: 1

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.hera.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.hera.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.hercules.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.hercules.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.jet.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.jet.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.orion.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.orion.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.grib2.wcoss2.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.grib2.wcoss2.sh
@@ -46,7 +46,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.hera.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.hera.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.hercules.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.hercules.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.jet.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.jet.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.orion.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.orion.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 

--- a/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.wcoss2.sh
+++ b/ush/sample_configs/non-DA_eng/config.nonDA.netcdf.wcoss2.sh
@@ -47,7 +47,7 @@ PPN_RUN_FCST="12"
 
 DO_NON_DA_RUN="TRUE"
 DO_RETRO="TRUE"
-VCOORD_FILE="global_hyblev.l65.txt"
+VCOORD_FILE="global_hyblev_fcst_rrfsL65.txt"
 WFLOW_XML_TMPL_FN="FV3LAM_wflow_nonDA.xml"
 FV3_NML_YAML_CONFIG_FN="FV3.input.nonDA.yml"
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the non-DA engineering test is modified to use the RRFSL65 vertical level configuration.  Previously an older configuration of 64 vertical levels was used.  This change does not affect any other tests in rrfs-workflow because all the others use the current RRFS vertical levels.  I tested these changes on WCOSS2 and they fixed the error with the run_forecast task that was related to using n_sponge = 65.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #291 
