### PR TITLE
RRFSFW real-time run changes, remove task complete text files

### DIFF
--- a/jobs/JRRFS_MAKE_GRID
+++ b/jobs/JRRFS_MAKE_GRID
@@ -92,30 +92,6 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Create a flag file to make rocoto aware that the make_grid task has 
-# successfully completed (so that other tasks that depend on it can be
-# launched).  
-#
-# Although we can use the <taskdep> tag to make other tasks depend on 
-# the successful completion of make_grid, it turns out that the <task-
-# dep> tag assumes that the task it specifies (in this case make_grid)
-# runs for the same set of cycles as the one in which it appears as a 
-# dependency.  Thus, if we use <taskdep> in a cycle-dependent task in 
-# the workflow to make it depend on the make_grid, then the workflow 
-# will wait for make_grid to run for each cycle for which that cycle-de-
-# pendent task is defined before running the task.  But since make_grid
-# will not run for each cycle (except possibly for the very first one),
-# the cycle-dependent task will not be able to run for any of the cycles
-# except the first one.  For this reason, we cannot use the <taskdep> 
-# tag to make other cycle-dependent tasks depend on make_grid and must
-# instead use a flag file.
-#
-#-----------------------------------------------------------------------
-#
-touch "${LOG_BASEDIR}/make_grid_task_complete.txt"
-#
-#-----------------------------------------------------------------------
-#
 # Print exit message.
 #
 #-----------------------------------------------------------------------

--- a/jobs/JRRFS_MAKE_ICS
+++ b/jobs/JRRFS_MAKE_ICS
@@ -259,20 +259,6 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# For the RRFS fire weather nest, delete the flag files from the
-# make_grid, make_orog, and make_sfc_climo tasks.  These tasks need to
-# run for every cycle.
-#
-#-----------------------------------------------------------------------
-#
-if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
-  rm -f ${LOG_BASEDIR}/make_grid_task_complete.txt
-  rm -f ${LOG_BASEDIR}/make_orog_task_complete.txt
-  rm -f ${LOG_BASEDIR}/make_sfc_climo_task_complete.txt
-fi
-#
-#-----------------------------------------------------------------------
-#
 # Print exit message.
 #
 #-----------------------------------------------------------------------

--- a/jobs/JRRFS_MAKE_OROG
+++ b/jobs/JRRFS_MAKE_OROG
@@ -94,30 +94,6 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Create a flag file to make rocoto aware that the make_orog task has 
-# successfully completed (so that other tasks that depend on it can be
-# launched).  
-#
-# Although we can use the <taskdep> tag to make other tasks depend on 
-# the successful completion of make_orog, it turns out that the <task-
-# dep> tag assumes that the task it specifies (in this case make_orog)
-# runs for the same set of cycles as the one in which it appears as a 
-# dependency.  Thus, if we use <taskdep> in a cycle-dependent task in 
-# the workflow to make it depend on the make_orog, then the workflow 
-# will wait for make_orog to run for each cycle for which that cycle-de-
-# pendent task is defined before running the task.  But since make_orog
-# will not run for each cycle (except possibly for the very first one),
-# the cycle-dependent task will not be able to run for any of the cycles
-# except the first one.  For this reason, we cannot use the <taskdep> 
-# tag to make other cycle-dependent tasks depend on make_orog and must
-# instead use a flag file.
-#
-#-----------------------------------------------------------------------
-#
-touch "${LOG_BASEDIR}/make_orog_task_complete.txt"
-#
-#-----------------------------------------------------------------------
-#
 # Print exit message.
 #
 #-----------------------------------------------------------------------

--- a/jobs/JRRFS_MAKE_SFC_CLIMO
+++ b/jobs/JRRFS_MAKE_SFC_CLIMO
@@ -87,30 +87,6 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Create a flag file to make rocoto aware that the make_sfc_climo task
-# has successfully completed (so that other tasks that depend on it can
-# be launched).  
-#
-# Although we can use the <taskdep> tag to make other tasks depend on 
-# the successful completion of make_sfc_climo, it turns out that the 
-# <taskdep> tag assumes that the task it specifies (in this case make_-
-# sfc_climo) runs for the same set of cycles as the one in which it ap-
-# pears as a dependency.  Thus, if we use <taskdep> in a cycle-dependent
-# task in the workflow to make it depend on the make_sfc_climo, then the
-# workflow will wait for make_sfc_climo to run for each cycle for which
-# that cycle-dependent task is defined before running the task.  But 
-# since make_sfc_climo will not run for each cycle (except possibly for
-# the very first one), the cycle-dependent task will not be able to run
-# for any of the cycles except the first one.  For this reason, we can-
-# not use the <taskdep> tag to make other cycle-dependent tasks depend
-# on make_sfc_climo and must instead use a flag file.
-#
-#-----------------------------------------------------------------------
-#
-touch "${LOG_BASEDIR}/make_sfc_climo_task_complete.txt"
-#
-#-----------------------------------------------------------------------
-#
 # Print exit message.
 #
 #-----------------------------------------------------------------------

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -425,8 +425,7 @@ MODULES_RUN_TASK_FP script.
 
     <dependency>
       <or>
-<!--        <taskdep task="make_grid"/> -->
-        <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
+        <taskdep task="&MAKE_GRID_TN;"/>
         <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
       </or>
     </dependency>
@@ -454,13 +453,11 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
+          <taskdep task="&MAKE_GRID_TN;"/>
           <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
+          <taskdep task="&MAKE_OROG_TN;"/>
           <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
         </or>
       </and>
@@ -799,18 +796,15 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
+          <taskdep task="&MAKE_GRID_TN;"/>
           <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
+          <taskdep task="&MAKE_OROG_TN;"/>
           <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_SFC_CLIMO_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_sfc_climo_task_complete.txt</datadep>
+          <taskdep task="&MAKE_SFC_CLIMO_TN;"/>
           <streq><left>&RUN_TASK_MAKE_SFC_CLIMO;</left><right>FALSE</right></streq>
         </or>
         <or>
@@ -978,18 +972,15 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
+          <taskdep task="&MAKE_GRID_TN;"/>
           <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
+          <taskdep task="&MAKE_OROG_TN;"/>
           <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_SFC_CLIMO_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_sfc_climo_task_complete.txt</datadep>
+          <taskdep task="&MAKE_SFC_CLIMO_TN;"/>
           <streq><left>&RUN_TASK_MAKE_SFC_CLIMO;</left><right>FALSE</right></streq>
         </or>
         <and> 

--- a/parm/FV3LAM_wflow_firewx.xml
+++ b/parm/FV3LAM_wflow_firewx.xml
@@ -62,7 +62,7 @@ Directories and files.
 -->
 <!ENTITY JOBSdir                  "{{ jobsdir }}">
 <!ENTITY LOG_BASEDIR              "{{ log_basedir }}">
-<!ENTITY LOGDIR                   "{{ log_basedir }}/{{ run }}.@Y@m@d/@H">
+<!ENTITY LOGDIR                   "{{ log_basedir }}/rrfsfw.@Y@m@d/@H">
 <!ENTITY CYCLE_BASEDIR            "{{ cycle_basedir }}">
 <!ENTITY NWGES_BASEDIR            "{{ nwges_basedir }}">
 <!ENTITY GLOBAL_VAR_DEFNS_FP      "{{ global_var_defns_fp }}">
@@ -148,7 +148,7 @@ define resources used for each tasks
 <workflow realtime="T" scheduler="&SCHED;" cyclethrottle="1" cyclelifespan="00:12:00:00">
 {%- endif %}
 {# Double quotes are required inside the strftime! Expect an error from reading the template if using single quotes. #}
-  <cycledef group="at_start">{{ cdate_first_cycl.strftime("%M %H %d %m %Y *") }}</cycledef>
+
   <cycledef group="prod"> {{ prod_cycledef }} </cycledef>
 
   <log>
@@ -187,7 +187,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&MAKE_GRID_TN;" cycledefs="at_start" maxtries="{{ maxtries_make_grid }}">
+  <task name="&MAKE_GRID_TN;" cycledefs="prod" maxtries="{{ maxtries_make_grid }}">
 
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&MAKE_GRID_TN;" "&JOBSdir;/JRRFS_MAKE_GRID"</command>
@@ -208,7 +208,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&MAKE_OROG_TN;" cycledefs="at_start" maxtries="{{ maxtries_make_orog }}">
+  <task name="&MAKE_OROG_TN;" cycledefs="prod" maxtries="{{ maxtries_make_orog }}">
 
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&MAKE_OROG_TN;" "&JOBSdir;/JRRFS_MAKE_OROG"</command>
@@ -221,11 +221,7 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
 
     <dependency>
-      <or>
-<!--        <taskdep task="make_grid"/> -->
-        <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
-        <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
-      </or>
+      <taskdep task="&MAKE_GRID_TN;"/>
     </dependency>
 
   </task>
@@ -236,7 +232,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&MAKE_SFC_CLIMO_TN;" cycledefs="at_start" maxtries="{{ maxtries_make_sfc_climo }}">
+  <task name="&MAKE_SFC_CLIMO_TN;" cycledefs="prod" maxtries="{{ maxtries_make_sfc_climo }}">
 
     &RSRV_SFC_CLIMO;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&MAKE_SFC_CLIMO_TN;" "&JOBSdir;/JRRFS_MAKE_SFC_CLIMO"</command>
@@ -250,16 +246,8 @@ MODULES_RUN_TASK_FP script.
 
     <dependency>
       <and>
-        <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
-        </or>
-        <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
-        </or>
+        <taskdep task="&MAKE_GRID_TN;"/>
+        <taskdep task="&MAKE_OROG_TN;"/>
       </and>
     </dependency>
 
@@ -292,26 +280,10 @@ MODULES_RUN_TASK_FP script.
 
     <dependency>
       <and>
-        <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
-        </or>
-        <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
-        </or>
-        <or>
-<!--          <taskdep task="&MAKE_SFC_CLIMO_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_sfc_climo_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_SFC_CLIMO;</left><right>FALSE</right></streq>
-        </or>
-        <or>
-        {%- if extrn_mdl_name_ics in ["RRFS"] %}
-          <datadep age="00:00:05:00"><cyclestr offset="-{{ extrn_mdl_ics_offset_hrs }}:00:00">{{ extrn_mdl_sysbasedir_ics }}/rrfs.@Y@m@d/@H/rrfs.t@Hz.natlev.f{{ "%03d" % extrn_mdl_ics_offset_hrs }}.grib2</cyclestr></datadep>
-        {%- endif %}
-        </or>
+        <taskdep task="&MAKE_GRID_TN;"/>
+        <taskdep task="&MAKE_OROG_TN;"/>
+        <taskdep task="&MAKE_SFC_CLIMO_TN;"/>
+        <datadep age="00:00:05:00"><cyclestr offset="-{{ extrn_mdl_ics_offset_hrs }}:00:00">{{ extrn_mdl_sysbasedir_ics }}/rrfs.@Y@m@d/@H/rrfs.t@Hz.natlev.f{{ "%03d" % extrn_mdl_ics_offset_hrs }}.grib2</cyclestr></datadep>
       </and>
     </dependency>
 
@@ -348,29 +320,12 @@ MODULES_RUN_TASK_FP script.
 
       <dependency>
         <and>
-          <or>
-<!--            <taskdep task="&MAKE_GRID_TN;"/> -->
-            <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
-            <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
-          </or>
-          <or>
-<!--            <taskdep task="&MAKE_OROG_TN;"/> -->
-            <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
-            <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
-          </or>
-          <or>
-<!--            <taskdep task="&MAKE_SFC_CLIMO_TN;"/> -->
-            <datadep age="00:00:00:05">&LOG_BASEDIR;/make_sfc_climo_task_complete.txt</datadep>
-            <streq><left>&RUN_TASK_MAKE_SFC_CLIMO;</left><right>FALSE</right></streq>
-          </or>
-          <or>
-<!-- Dependencies needed for RRFSFW real-time run -->
-          {%- if extrn_mdl_name_lbcs in ["RRFS"] %}
-            {%- for h in range(extrn_mdl_lbcs_offset_hrs, boundary_len_hrs+extrn_mdl_lbcs_offset_hrs+1, 1) %}
-              <datadep age="00:00:05:00"><cyclestr offset="-{{ extrn_mdl_lbcs_offset_hrs }}:00:00">{{ extrn_mdl_sysbasedir_lbcs }}/rrfs.@Y@m@d/@H/rrfs.t@Hz.natlev.f{{ "%03d" % h }}.grib2</cyclestr></datadep>
-            {%- endfor %}
-          {%- endif %}
-          </or>
+          <taskdep task="&MAKE_GRID_TN;"/>
+          <taskdep task="&MAKE_OROG_TN;"/>
+          <taskdep task="&MAKE_SFC_CLIMO_TN;"/>
+          {%- for h in range(extrn_mdl_lbcs_offset_hrs, boundary_len_hrs+extrn_mdl_lbcs_offset_hrs+1, 1) %}
+            <datadep age="00:00:05:00"><cyclestr offset="-{{ extrn_mdl_lbcs_offset_hrs }}:00:00">{{ extrn_mdl_sysbasedir_lbcs }}/rrfs.@Y@m@d/@H/rrfs.t@Hz.natlev.f{{ "%03d" % h }}.grib2</cyclestr></datadep>
+          {%- endfor %}
         </and>
       </dependency>
 

--- a/parm/FV3LAM_wflow_nonDA.xml
+++ b/parm/FV3LAM_wflow_nonDA.xml
@@ -223,11 +223,7 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
 
     <dependency>
-      <or>
-<!--        <taskdep task="make_grid"/> -->
-        <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
-        <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
-      </or>
+      <taskdep task="&MAKE_GRID_TN;"/>
     </dependency>
 
   </task>
@@ -252,16 +248,8 @@ MODULES_RUN_TASK_FP script.
 
     <dependency>
       <and>
-        <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
-        </or>
-        <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
-          <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
-        </or>
+        <taskdep task="&MAKE_GRID_TN;"/>
+        <taskdep task="&MAKE_OROG_TN;"/>
       </and>
     </dependency>
 
@@ -295,18 +283,15 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <or>
-<!--          <taskdep task="&MAKE_GRID_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
+          <taskdep task="&MAKE_GRID_TN;"/>
           <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_OROG_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
+          <taskdep task="&MAKE_OROG_TN;"/>
           <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
         </or>
         <or>
-<!--          <taskdep task="&MAKE_SFC_CLIMO_TN;"/> -->
-          <datadep age="00:00:00:05">&LOG_BASEDIR;/make_sfc_climo_task_complete.txt</datadep>
+          <taskdep task="&MAKE_SFC_CLIMO_TN;"/>
           <streq><left>&RUN_TASK_MAKE_SFC_CLIMO;</left><right>FALSE</right></streq>
         </or>
       </and>
@@ -346,18 +331,15 @@ MODULES_RUN_TASK_FP script.
       <dependency>
         <and>
           <or>
-<!--            <taskdep task="&MAKE_GRID_TN;"/> -->
-            <datadep age="00:00:00:05">&LOG_BASEDIR;/make_grid_task_complete.txt</datadep>
+            <taskdep task="&MAKE_GRID_TN;"/>
             <streq><left>&RUN_TASK_MAKE_GRID;</left><right>FALSE</right></streq>
           </or>
           <or>
-<!--            <taskdep task="&MAKE_OROG_TN;"/> -->
-            <datadep age="00:00:00:05">&LOG_BASEDIR;/make_orog_task_complete.txt</datadep>
+            <taskdep task="&MAKE_OROG_TN;"/>
             <streq><left>&RUN_TASK_MAKE_OROG;</left><right>FALSE</right></streq>
           </or>
           <or>
-<!--            <taskdep task="&MAKE_SFC_CLIMO_TN;"/> -->
-            <datadep age="00:00:00:05">&LOG_BASEDIR;/make_sfc_climo_task_complete.txt</datadep>
+            <taskdep task="&MAKE_SFC_CLIMO_TN;"/>
             <streq><left>&RUN_TASK_MAKE_SFC_CLIMO;</left><right>FALSE</right></streq>
           </or>
         </and>

--- a/scripts/exrrfs_make_grid.sh
+++ b/scripts/exrrfs_make_grid.sh
@@ -93,10 +93,12 @@ if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
   LAT_CTR=`grep ${hh}z $firewx_loc | awk '{print $2}'`
   LON_CTR=`grep ${hh}z $firewx_loc | awk '{print $3}'`
 
-  sed -i -e "s/39.2/${LAT_CTR}/g" ${FV3_NML_FP}
-  sed -i -e "s/39.2/${LAT_CTR}/g" ${GLOBAL_VAR_DEFNS_FP}
-  sed -i -e "s/-106.0/${LON_CTR}/g" ${FV3_NML_FP}
-  sed -i -e "s/-106.0/${LON_CTR}/g" ${GLOBAL_VAR_DEFNS_FP}
+  sed -i "/    target_lat = */c\    target_lat = ${LAT_CTR}" ${FV3_NML_FP}
+  sed -i "/ESGgrid_LAT_CTR=\"*/c\ESGgrid_LAT_CTR=\"${LAT_CTR}\"" ${GLOBAL_VAR_DEFNS_FP}
+  sed -i "/\(^LAT_CTR\)/c\LAT_CTR=\"${LAT_CTR}\"" ${GLOBAL_VAR_DEFNS_FP}
+  sed -i "/    target_lon = */c\    target_lon = ${LON_CTR}" ${FV3_NML_FP}
+  sed -i "/ESGgrid_LON_CTR=\"*/c\ESGgrid_LON_CTR=\"${LON_CTR}\"" ${GLOBAL_VAR_DEFNS_FP}
+  sed -i "/\(^LON_CTR\)/c\LON_CTR=\"${LON_CTR}\"" ${GLOBAL_VAR_DEFNS_FP}
 
   python ${USHdir}/rrfsfw_domain.py $LAT_CTR $LON_CTR
   if [[ $? != 0 ]]; then

--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -350,6 +350,8 @@ fhr=${subh_fhr}
 gridname=""
 if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ]; then
   gridname="conus_3km."
+elif [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
+  gridname="firewx."
 elif  [ ${PREDEF_GRID_NAME} = "RRFS_NA_3km" ]; then
   gridname=""
 fi

--- a/scripts/exrrfs_run_prdgen.sh
+++ b/scripts/exrrfs_run_prdgen.sh
@@ -185,6 +185,8 @@ fhr=${subh_fhr}
 gridname=""
 if [ "${PREDEF_GRID_NAME}" = "RRFS_CONUS_3km" ]; then
   gridname="conus_3km."
+elif [ "${PREDEF_GRID_NAME}" = "RRFS_FIREWX_1.5km" ]; then
+  gridname="firewx."
 elif  [ "${PREDEF_GRID_NAME}" = "RRFS_NA_3km" ]; then
   gridname=""
 fi
@@ -226,31 +228,35 @@ basetime=$( date +%y%j%H%M -d "${yyyymmdd} ${hh}" )
 cp ${postprd_dir}/${prslev} ${COMOUT}/${prslev}
 cp ${postprd_dir}/${natlev} ${COMOUT}/${natlev}
 
-if [ -f  ${postprd_dir}/${ififip} ]; then
-  cp ${postprd_dir}/${ififip} ${COMOUT}/${ififip}
-fi
+if [ "${PREDEF_GRID_NAME}" != "RRFS_FIREWX_1.5km" ]; then
+  if [ -f  ${postprd_dir}/${ififip} ]; then
+    cp ${postprd_dir}/${ififip} ${COMOUT}/${ififip}
+  fi
 
-if [ -f  ${postprd_dir}/${aviati} ]; then
-  cp ${postprd_dir}/${aviati} ${COMOUT}/${aviati}
-fi
+  if [ -f  ${postprd_dir}/${aviati} ]; then
+    cp ${postprd_dir}/${aviati} ${COMOUT}/${aviati}
+  fi
 
-if [ -f  ${postprd_dir}/${testbed} ]; then
-  cp ${postprd_dir}/${testbed}  ${COMOUT}/${testbed}
+  if [ -f  ${postprd_dir}/${testbed} ]; then
+    cp ${postprd_dir}/${testbed}  ${COMOUT}/${testbed}
+  fi
 fi
 
 wgrib2 ${COMOUT}/${prslev} -s > ${COMOUT}/${prslev}.idx
 wgrib2 ${COMOUT}/${natlev} -s > ${COMOUT}/${natlev}.idx
 
-if [ -f ${COMOUT}/${ififip} ]; then
-  wgrib2 ${COMOUT}/${ififip} -s > ${COMOUT}/${ififip}.idx
-fi
+if [ "${PREDEF_GRID_NAME}" != "RRFS_FIREWX_1.5km" ]; then
+  if [ -f ${COMOUT}/${ififip} ]; then
+    wgrib2 ${COMOUT}/${ififip} -s > ${COMOUT}/${ififip}.idx
+  fi
 
-if [ -f ${COMOUT}/${aviati} ]; then
-  wgrib2 ${COMOUT}/${aviati} -s > ${COMOUT}/${aviati}.idx
-fi
+  if [ -f ${COMOUT}/${aviati} ]; then
+    wgrib2 ${COMOUT}/${aviati} -s > ${COMOUT}/${aviati}.idx
+  fi
 
-if [ -f ${COMOUT}/${testbed} ]; then
-  wgrib2 ${COMOUT}/${testbed} -s > ${COMOUT}/${testbed}.idx
+  if [ -f ${COMOUT}/${testbed} ]; then
+    wgrib2 ${COMOUT}/${testbed} -s > ${COMOUT}/${testbed}.idx
+  fi
 fi
 
 # Remap to additional output grids if requested
@@ -369,14 +375,14 @@ EOF
   export err=$?; err_chk
 
   grid_specs_firewx=`head $DATA/copygb_gridnavfw.txt`
-  eval infile=${postprd_dir}/${net4}.t${cyc}z.prslev.f${fhr}.grib2
+  eval infile=${postprd_dir}/${net4}.t${cyc}z.prslev.f${fhr}.firewx.grib2
 
   wgrib2 ${infile} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
    -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
    -new_grid_interpolation neighbor \
    -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.prslev.f${fhr}.firewx.grib2
-  wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.f${fhr}.firewx.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.f${fhr}.firewx.grib2.idx
+   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.prslev.f${fhr}.firewx_lcc.grib2
+  wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.f${fhr}.firewx_lcc.grib2.idx
 
 else
   #

--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_firewx
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_firewx
@@ -6,12 +6,12 @@ EXPT_BASEDIR="/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/${version}"
 EXPT_SUBDIR="rrfs_firewx"
 
 envir="para"
-NET="rrfsfw"
+NET="rrfs"
 TAG="n3v89"
-MODEL="rrfsfw"
-RUN="rrfsfw"
+MODEL="rrfs"
+RUN="rrfs"
 
-STMP="/lfs/h2/emc/stmp/emc.lam/rrfs/${version}"
+STMP="/lfs/h2/emc/stmp/emc.lam/rrfs/${version}/rrfsfw"
 PTMP="/lfs/h2/emc/ptmp/emc.lam/rrfs/${version}"
 
 VERBOSE="TRUE"
@@ -33,7 +33,7 @@ LBC_SPEC_INTVL_HRS="1"
 BOUNDARY_LEN_HRS="36"
 BOUNDARY_PROC_GROUP_NUM="36"
 
-DATE_FIRST_CYCL="20240328"
+DATE_FIRST_CYCL="20240402"
 DATE_LAST_CYCL="20240428"
 CYCL_HRS=( "00" "06" "12" "18" )
 PROD_CYCLEDEF="${DATE_FIRST_CYCL}0000 ${DATE_LAST_CYCL}1800 06:00:00"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, several miscellaneous issues are resolved, mostly relating to the RRFS fire weather nest real-time runs.  The fire weather changes were tested as RRFS version 9.9.9 on Dogwood.  These changes should definitely be included in RRFS version 0.9.1 and should be tested with it.
- Grib2 output from the RRFS fire weather nest is now placed in the deterministic RRFS directory and will be renamed to the following: rrfs.t${cyc}z.prslev.f${fhr}.firewx.grib2 (for rotated lat-lon grid, also a natlev file), rrfs.t${cyc}z.prslev.f${fhr}.firewx_lcc.grib2 (for lambert conformal grid).  This involves changes to the exrrfs_run_post.sh and exrrfs_run_prdgen.sh scripts.  For the fire weather grid, only the prslev and natlev files are copied to ${COMOUT}.
- Log files for RRFSFW are created in a separate rrfsfw.${PDY} directory to distinguish them from the deterministic RRFS_A log files.
- The ${STMP} path for working directories has been modified to /lfs/h2/emc/stmp/emc.lam/rrfs/v0.8.9/rrfsfw, which is more similar to /lfs/h2/emc/stmp/emc.lam/rrfs/v0.8.9/enfcst.
- There was an issue with the logic in exrrfs_make_grid.sh for replacing the center lat/lon in input.nml and var_defns.sh when running real-time cycles.  A solution was tested and it worked successfully.  I encountered a non-reproducible error in the make_sfc_climo task in my tests, but I think it was related to system issues.  Will need to keep an eye on that when testing in the real-time workflow.
- The task_complete text files for the make_grid, make_orog, and make_sfc_climo tasks have been removed.  These changes were specifically tested with the RRFS fire weather and non-DA engineering workflows.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [x] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #299  and issue #244 

