### PR TITLE
Use hash number instead of branch name for the rrfs_utl release.

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -48,8 +48,8 @@ externals = None
 protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl
 # Specify either a branch name or a hash but not both.
-branch = production/RRFS.v1
-#hash = 40a9f72
+#branch = production/RRFS.v1
+hash = 40a9f72
 local_path = rrfs_utl
 required = True
 


### PR DESCRIPTION
We need to use hash number to control which version of the code is used. When we make the tag, the same tag will always checkout the same code. We cannot control this with the branch name.

