### PR TITLE
Use GSI release branch for RRFS.

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -12,7 +12,7 @@ required = True
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-#branch = develop
+#branch = production/RRFS.v1
 hash = b4a006e 
 local_path = ufs-weather-model
 required = True
@@ -38,8 +38,8 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/GSI
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = f7e93ab
+#branch = release/rrfs.v1.0.0
+hash = b53740a
 local_path = gsi
 required = True
 externals = None
@@ -49,7 +49,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 40a9f72
+hash = a664087
 local_path = rrfs_utl
 required = True
 


### PR DESCRIPTION
Now we can use the GSI release branch for the RRFS application.
We use hash number for GSI release branch and also update the rrfs_utl hash to machine the GSI.
The branch names are also changed to reflect the release branch but we are not using the branch name because we want to tag certain hash for retro runs.