### PR TITLE
Renaming RRFS output files

### DIFF
--- a/scripts/exrrfs_archive_emc.ksh
+++ b/scripts/exrrfs_archive_emc.ksh
@@ -25,15 +25,15 @@ echo $runcount
 
 if [[ $runcount -gt 0 ]];then
   hsi mkdir -p $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod
-  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.prslev.conus_3km.grib2.tar rrfs.t${hour}z.prslev.f*.conus_3km.grib2
-  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.natlev.conus_3km.grib2.tar rrfs.t${hour}z.natlev.f*.conus_3km.grib2
-  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.testbed.conus_3km.grib2.tar rrfs.t${hour}z.testbed.f*.conus_3km.grib2
+  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.prslev.conus.grib2.tar rrfs.t${hour}z.prslev.f*.conus.grib2
+  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.natlev.conus.grib2.tar rrfs.t${hour}z.natlev.f*.conus.grib2
+  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.testbed.conus.grib2.tar rrfs.t${hour}z.testbed.f*.conus.grib2
 fi
 
 files3=`ls -1 rrfs.*.conusfv3*`
 runcount3=${#files3}
 if [[ $runcount3 -gt 0 ]];then
-  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.conus_3km.bufrsnd.tar rrfs.t${hour}z.conusfv3.bufrsnd.tar.gz rrfs.t${hour}z.conusfv3.class1.bufr rrfs.t${hour}z.conusfv3.profilm.c1
+  htar -chvf $ARCHIVEDIR/rh$year/$year$month/$year$month$day/$hour/prod/rrfs.t${hour}z.conus.bufrsnd.tar rrfs.t${hour}z.conusfv3.bufrsnd.tar.gz rrfs.t${hour}z.conusfv3.class1.bufr rrfs.t${hour}z.conusfv3.profilm.c1
 fi
 
 files4=`ls -1 rrfs.*.fits*`

--- a/scripts/exrrfs_run_fcst.sh
+++ b/scripts/exrrfs_run_fcst.sh
@@ -506,8 +506,8 @@ fi
 
 if [ "${STOCH}" = "TRUE" ]; then
   if [ ${BKTYPE} -eq 0 ] && [ ${DO_ENSFCST_MULPHY} = "TRUE" ]; then
-    ensmem_indx_sgl=$(echo "${ensmem_indx}" | awk '{print $1+0}')
-    cp ${FV3_NML_RESTART_STOCH_FP}_ensphy${ensmem_indx_sgl} ${run_dir}/${FV3_NML_FN}_base 
+    ensmem_num=$(echo "${ensmem_indx}" | awk '{print $1+0}')
+    cp ${FV3_NML_RESTART_STOCH_FP}_ensphy${ensmem_num} ${run_dir}/${FV3_NML_FN}_base 
     rm -fr ${run_dir}/field_table
     cp ${PARMdir}/field_table.rrfsens_phy${ensmem_indx} ${run_dir}/field_table
   else

--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -373,7 +373,7 @@ net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 
 # Include member number with ensemble forecast output
 if [ ${DO_ENSFCST} = "TRUE" ]; then
-  ensmem_indx_sgl=$(echo "${ENSMEM_INDX}" | qwk '{print $1+0}')	  # 1,2,3,4,5 for REFS
+  ensmem_indx_sgl=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')	  # 1,2,3,4,5 for REFS
   bgdawp=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${gridname}grib2
   bgrd3d=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.natlev.f${fhr}.${gridname}grib2
   bgifi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.ififip.f${fhr}.${gridname}grib2

--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -373,11 +373,11 @@ net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 
 # Include member number with ensemble forecast output
 if [ ${DO_ENSFCST} = "TRUE" ]; then
-  ensmem_indx_sgl=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')	  # 1,2,3,4,5 for REFS
-  bgdawp=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${gridname}grib2
-  bgrd3d=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.natlev.f${fhr}.${gridname}grib2
-  bgifi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.ififip.f${fhr}.${gridname}grib2
-  bgavi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.aviati.f${fhr}.${gridname}grib2
+  ensmem_num=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')	  # 1,2,3,4,5 for REFS
+  bgdawp=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${gridname}grib2
+  bgrd3d=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.natlev.f${fhr}.${gridname}grib2
+  bgifi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.ififip.f${fhr}.${gridname}grib2
+  bgavi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.aviati.f${fhr}.${gridname}grib2
 else
   bgdawp=${postprd_dir}/${net4}.t${cyc}z.prslev.f${fhr}.${gridname}grib2
   bgrd3d=${postprd_dir}/${net4}.t${cyc}z.natlev.f${fhr}.${gridname}grib2

--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -366,19 +366,24 @@ echo "fhr=${fhr} and subh_fhr=${subh_fhr}"
 fhr=${subh_fhr}
 
 gridname=""
-if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ]; then
-  gridname="conus_3km."
-elif [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
+if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
   gridname="firewx."
-elif  [ ${PREDEF_GRID_NAME} = "RRFS_NA_3km" ]; then
-  gridname=""
 fi
 net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 
-bgdawp=${postprd_dir}/${net4}.t${cyc}z.prslev.f${fhr}.${gridname}grib2
-bgrd3d=${postprd_dir}/${net4}.t${cyc}z.natlev.f${fhr}.${gridname}grib2
-bgifi=${postprd_dir}/${net4}.t${cyc}z.ififip.f${fhr}.${gridname}grib2
-bgavi=${postprd_dir}/${net4}.t${cyc}z.aviati.f${fhr}.${gridname}grib2
+# Include member number with ensemble forecast output
+if [ ${DO_ENSFCST} = "TRUE" ]; then
+  ensmem_indx_sgl=$(echo "${ENSMEM_INDX}" | qwk '{print $1+0}')	  # 1,2,3,4,5 for REFS
+  bgdawp=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${gridname}grib2
+  bgrd3d=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.natlev.f${fhr}.${gridname}grib2
+  bgifi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.ififip.f${fhr}.${gridname}grib2
+  bgavi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_indx_sgl}.aviati.f${fhr}.${gridname}grib2
+else
+  bgdawp=${postprd_dir}/${net4}.t${cyc}z.prslev.f${fhr}.${gridname}grib2
+  bgrd3d=${postprd_dir}/${net4}.t${cyc}z.natlev.f${fhr}.${gridname}grib2
+  bgifi=${postprd_dir}/${net4}.t${cyc}z.ififip.f${fhr}.${gridname}grib2
+  bgavi=${postprd_dir}/${net4}.t${cyc}z.aviati.f${fhr}.${gridname}grib2
+fi
 
 if [ -f PRSLEV.GrbF${post_fhr} ]; then
   wgrib2 PRSLEV.GrbF${post_fhr} -set center 7 -grib ${bgdawp} >>$pgmout 2>>errfile

--- a/scripts/exrrfs_run_prdgen.sh
+++ b/scripts/exrrfs_run_prdgen.sh
@@ -191,12 +191,12 @@ net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 #
 # Include member number with ensemble forecast output
 if [ ${DO_ENSFCST} = "TRUE" ]; then
-  ensmem_indx_sgl=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')   # 1,2,3,4,5 for REFS
-  prslev=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${gridname}grib2
-  natlev=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.natlev.f${fhr}.${gridname}grib2
-  ififip=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.ififip.f${fhr}.${gridname}grib2
-  aviati=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.aviati.f${fhr}.${gridname}grib2
-  testbed=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.testbed.f${fhr}.${gridname}grib2
+  ensmem_num=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')   # 1,2,3,4,5 for REFS
+  prslev=${net4}.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${gridname}grib2
+  natlev=${net4}.t${cyc}z.m0${ensmem_num}.natlev.f${fhr}.${gridname}grib2
+  ififip=${net4}.t${cyc}z.m0${ensmem_num}.ififip.f${fhr}.${gridname}grib2
+  aviati=${net4}.t${cyc}z.m0${ensmem_num}.aviati.f${fhr}.${gridname}grib2
+  testbed=${net4}.t${cyc}z.m0${ensmem_num}.testbed.f${fhr}.${gridname}grib2
 else
   prslev=${net4}.t${cyc}z.prslev.f${fhr}.${gridname}grib2
   natlev=${net4}.t${cyc}z.natlev.f${fhr}.${gridname}grib2
@@ -333,9 +333,9 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
       if [ ${DO_ENSFCST} = "TRUE" ]; then
         for task in $(seq ${tasks[count]})
         do
-          cat $DATAprdgen/prdgen_${domain}_${task}/${domain}_${task}.grib2 >> ${COMOUT}/rrfs.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${domain}.grib2
+          cat $DATAprdgen/prdgen_${domain}_${task}/${domain}_${task}.grib2 >> ${COMOUT}/rrfs.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${domain}.grib2
         done
-        wgrib2 ${COMOUT}/rrfs.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.${domain}.grib2.idx
+        wgrib2 ${COMOUT}/rrfs.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${domain}.grib2.idx
       else
         for task in $(seq ${tasks[count]})
         do
@@ -348,8 +348,8 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
 
     # create testbed files on 3-km CONUS grid
     if [ ${DO_ENSFCST} = "TRUE" ]; then
-      prslev_conus=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.prslev.f${fhr}.conus_3km.grib2
-      testbed_conus=${net4}.t${cyc}z.m0${ensmem_indx_sgl}.testbed.f${fhr}.conus_3km.grib2
+      prslev_conus=${net4}.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.conus_3km.grib2
+      testbed_conus=${net4}.t${cyc}z.m0${ensmem_num}.testbed.f${fhr}.conus_3km.grib2
     else
       prslev_conus=${net4}.t${cyc}z.prslev.f${fhr}.conus_3km.grib2
       testbed_conus=${net4}.t${cyc}z.testbed.f${fhr}.conus_3km.grib2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the RRFS grib2 output files are renamed as follows:
- `rrfs.tCCz.prslev.fFFF.conus_3km.grib2 ==> rrfs.tCCz.prslev.fFFF.conus.grib2`
- `rrfs.tCCz.prslev.fFFF.grib2 ==> rrfs.tCCz.mMM.prslev.fFFF.grib2`
- The block of code for setting gridname="conus_3km." for PREDEF_GRID_NAME = "RRFS_CONUS_3km" is removed.
- The changes to rename the CONUS output files have been tested, but the changes for adding the ensemble member number **have not been tested**.  If we want to include them in v0.9.1 then we should test them there.
- The exrrfs_archive_emc.ksh script was also updated to remove all instances of "conus_3km."  However I do not think we use this script and we should consider removing it, but maybe not with this PR.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #281 
