### PR TITLE
Update STMP path and version number for RRFS firewx

### DIFF
--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_firewx
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_firewx
@@ -1,5 +1,5 @@
 MACHINE="wcoss2"
-version="v0.8.9"
+version="v0.9.1"
 ACCOUNT="RRFS-DEV"
 HPSS_ACCOUNT="RRFS-DEV"
 EXPT_BASEDIR="/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/${version}"
@@ -7,11 +7,11 @@ EXPT_SUBDIR="rrfs_firewx"
 
 envir="para"
 NET="rrfs"
-TAG="n3v89"
+TAG="n3v91"
 MODEL="rrfs"
 RUN="rrfs"
 
-STMP="/lfs/h2/emc/stmp/emc.lam/rrfs/${version}/rrfsfw"
+STMP="/lfs/f2/t2o/ptmp/emc/stmp/emc.lam/rrfsfw/${version}"
 PTMP="/lfs/h2/emc/ptmp/emc.lam/rrfs/${version}"
 
 VERBOSE="TRUE"
@@ -33,8 +33,8 @@ LBC_SPEC_INTVL_HRS="1"
 BOUNDARY_LEN_HRS="36"
 BOUNDARY_PROC_GROUP_NUM="36"
 
-DATE_FIRST_CYCL="20240404"
-DATE_LAST_CYCL="20240428"
+DATE_FIRST_CYCL="20240410"
+DATE_LAST_CYCL="20240510"
 CYCL_HRS=( "00" "06" "12" "18" )
 PROD_CYCLEDEF="${DATE_FIRST_CYCL}0000 ${DATE_LAST_CYCL}1800 06:00:00"
 
@@ -88,5 +88,5 @@ FV3_NML_YAML_CONFIG_FN=""
 FV3_NML_BASE_SUITE_FN="input.nml.RRFSFW"
 
 USE_USER_STAGED_EXTRN_FILES="FALSE"
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/ptmp/emc.lam/rrfs/na/prod"
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/ptmp/emc.lam/rrfs/na/prod"
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lfs/h2/emc/ptmp/emc.lam/rrfs/${version}/prod"
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lfs/h2/emc/ptmp/emc.lam/rrfs/${version}/prod"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the config file for the RRFS fire weather nest is updated.  The disk quota of /lfs/h2/emc/stmp was exceeded last night, and the cycle-specific run directories will now be located in /lfs/f2/t2o/ptmp/emc/stmp/emc.lam/rrfsfw/${version}.  I am using rrfsfw/${version} instead of rrfs/${version} so that the run directories are not in the same place as those from RRFS_A.  However I will be starting to work on updating the run directory structure soon, so this will not be the long term solution.
- The version number is updated from v0.8.9 to v0.9.1, which is the version this will be tested with.  I also updated the paths for EXTRN_MDL_SOURCE_BASEDIR to use ${version} instead of the symbolic "na" link to ensure that the correct version of input data is used.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
The STMP changes were made locally on Dogwood and they will be tested in v0.9.1.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others: