### PR TITLE
Replaces rotate13km with na13km to make consistent with other grids.

### DIFF
--- a/ush/prdgen/rrfs_prdgen_faa_subpiece.sh
+++ b/ush/prdgen/rrfs_prdgen_faa_subpiece.sh
@@ -78,9 +78,9 @@ USHrrfs=$8
       wgrib2 -i ${COMOUT}/${prslev} -set_bitmap 1 -set_grib_type c3 \
          -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
          -new_grid_interpolation bilinear \
-         -new_grid ${grid_specs_rrfs_13km} rrfs.t${cyc}z.prslevfaa.f${fhr}.rotate13km.grib2
-      mv rrfs.t${cyc}z.prslevfaa.f${fhr}.rotate13km.grib2 ${COMOUT}
-      wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslevfaa.f${fhr}.rotate13km.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslevfaa.f${fhr}.rotate13km.grib2.idx
+         -new_grid ${grid_specs_rrfs_13km} rrfs.t${cyc}z.prslevfaa.f${fhr}.na13km.grib2
+      mv rrfs.t${cyc}z.prslevfaa.f${fhr}.na13km.grib2 ${COMOUT}
+      wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslevfaa.f${fhr}.na13km.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslevfaa.f${fhr}.na13km.grib2.idx
     fi
 
     #-- GRID 237: PR 32 km
@@ -110,17 +110,17 @@ USHrrfs=$8
       wgrib2 -i ${COMOUT}/${natlev} -set_bitmap 1 -set_grib_type c3 \
          -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
          -new_grid_interpolation bilinear \
-         -new_grid ${grid_specs_rrfs_13km} rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.grib2
+         -new_grid ${grid_specs_rrfs_13km} rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.grib2
 
       wgrib2 ${COMOUT}/${natlev} -s | grep ":LTNG:entire atmosphere:" | \
       wgrib2 -i ${COMOUT}/${natlev} -set_bitmap 1 -set_grib_type c3 \
          -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
          -new_grid_interpolation bilinear \
-         -new_grid ${grid_specs_rrfs_13km} rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.tmp.grib2
-      cat rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.tmp.grib2 >> rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.grib2
-      rm rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.tmp.grib2
-      mv rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.grib2 ${COMOUT}
-      wgrib2 ${COMOUT}/rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.natlevfaa.f${fhr}.rotate13km.grib2.idx
+         -new_grid ${grid_specs_rrfs_13km} rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.tmp.grib2
+      cat rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.tmp.grib2 >> rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.grib2
+      rm rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.tmp.grib2
+      mv rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.grib2 ${COMOUT}
+      wgrib2 ${COMOUT}/rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.natlevfaa.f${fhr}.na13km.grib2.idx
     fi
 
     #-- GRID 237


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->

- Simple update to change rotate13km to na13km within the FAA subpiece processing.  Makes it consistent with conus13km and pr32km products (described by region and resolution within the filename).

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- Not tested
### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

