### PR TITLE
Fix error with run_post task in engineering tests

### DIFF
--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -244,10 +244,10 @@ to the post forecast hour directory (fhr_dir):
   fhr_dir = \"${fhr_dir}\"
 ===================================================================="
 else
-  post_config_fp="${UPP_DIR}/parm/postxconfig-NT-rrfs.txt"
-  post_params_fp="${UPP_DIR}/parm/params_grib2_tbl_new"
+  post_config_fp="${FIX_UPP}/postxconfig-NT-rrfs.txt"
+  post_params_fp="${FIX_UPP}/params_grib2_tbl_new"
   if [ ${post_min} -ge ${nsout_min} ]; then
-     post_config_fp="${UPP_DIR}/parm/postxconfig-NT-rrfs_subh.txt"
+     post_config_fp="${FIX_UPP}/postxconfig-NT-rrfs_subh.txt"
   fi
   print_info_msg "
 ====================================================================


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The run_post tasks were failing due to the post config text file not being found.  When USE_CUSTOM_POST_CONFIG_FILE is set to false, default files in sorc/UPP/parm are used.  These post control files were renamed in the workflow several weeks ago with PR #269 .  To fix this issue, post files in rrfs-workflow/fix/upp are used as the default files instead.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
@MatthewPyle-NOAA successfully tested this change on Dogwood with the non-DA engineering test.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #326 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@MatthewPyle-NOAA 
