### PR TITLE
Fixes for adding ensemble member number to output filenames (prod)

### DIFF
--- a/jobs/JRRFS_RUN_POST
+++ b/jobs/JRRFS_RUN_POST
@@ -122,7 +122,8 @@ $SCRIPTSdir/exrrfs_run_post.sh \
   cdate="${CDATE}" \
   fhr="${fhr}" \
   tmmark="${TMMARK}" \
-  cycle_type="${CYCLE_TYPE}"
+  cycle_type="${CYCLE_TYPE}" \
+  ensmem_indx="${ENSMEM_INDX}"
 export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then

--- a/jobs/JRRFS_RUN_PRDGEN
+++ b/jobs/JRRFS_RUN_PRDGEN
@@ -122,7 +122,8 @@ env
 $SCRIPTSdir/exrrfs_run_prdgen.sh \
   cdate="${CDATE}" \
   fhr="${fhr}" \
-  tmmark="${TMMARK}"
+  tmmark="${TMMARK}" \
+  ensmem_indx="${ENSMEM_INDX}"
 export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -2170,6 +2170,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+      <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
@@ -2202,6 +2203,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
       <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+      <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
@@ -3423,6 +3425,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+      <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
@@ -3470,6 +3473,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+      <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
@@ -3520,6 +3524,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
       <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+      <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
@@ -3567,6 +3572,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
       <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+      <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>

--- a/parm/FV3LAM_wflow_firewx.xml
+++ b/parm/FV3LAM_wflow_firewx.xml
@@ -385,6 +385,7 @@ MODULES_RUN_TASK_FP script.
         <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
         <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
         <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+        <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
         <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
         <envar><name>fhr</name><value>#fhr#</value></envar>
         <envar><name>TMMARK</name><value>tm00</value></envar>
@@ -423,6 +424,7 @@ MODULES_RUN_TASK_FP script.
         <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
         <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
         <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+        <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
         <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
         <envar><name>fhr</name><value>#fhr#</value></envar>
         <envar><name>TMMARK</name><value>tm00</value></envar>

--- a/parm/FV3LAM_wflow_nonDA.xml
+++ b/parm/FV3LAM_wflow_nonDA.xml
@@ -401,6 +401,7 @@ MODULES_RUN_TASK_FP script.
         <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
         <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
         <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+        <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
         <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
         <envar><name>fhr</name><value>#fhr#</value></envar>
         <envar><name>TMMARK</name><value>tm00</value></envar>
@@ -439,6 +440,7 @@ MODULES_RUN_TASK_FP script.
         <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
         <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
         <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+        <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
         <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
         <envar><name>fhr</name><value>#fhr#</value></envar>
         <envar><name>TMMARK</name><value>tm00</value></envar>

--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -60,6 +60,7 @@ valid_args=( \
 "fhr" \
 "tmmark" \
 "cycle_type" \
+"ensmem_indx" \
 )
 process_args valid_args "$@"
 #
@@ -373,7 +374,7 @@ net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 
 # Include member number with ensemble forecast output
 if [ ${DO_ENSFCST} = "TRUE" ]; then
-  ensmem_num=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')	  # 1,2,3,4,5 for REFS
+  ensmem_num=$(echo "${ensmem_indx}" | awk '{print $1+0}')	  # 1,2,3,4,5 for REFS
   bgdawp=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${gridname}grib2
   bgrd3d=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.natlev.f${fhr}.${gridname}grib2
   bgifi=${postprd_dir}/${net4}.t${cyc}z.m0${ensmem_num}.ififip.f${fhr}.${gridname}grib2

--- a/scripts/exrrfs_run_prdgen.sh
+++ b/scripts/exrrfs_run_prdgen.sh
@@ -59,6 +59,7 @@ valid_args=( \
 "cdate" \
 "fhr" \
 "tmmark" \
+"ensmem_indx" \
 )
 process_args valid_args "$@"
 #
@@ -191,7 +192,7 @@ net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 #
 # Include member number with ensemble forecast output
 if [ ${DO_ENSFCST} = "TRUE" ]; then
-  ensmem_num=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')   # 1,2,3,4,5 for REFS
+  ensmem_num=$(echo "${ensmem_indx}" | awk '{print $1+0}')   # 1,2,3,4,5 for REFS
   prslev=${net4}.t${cyc}z.m0${ensmem_num}.prslev.f${fhr}.${gridname}grib2
   natlev=${net4}.t${cyc}z.m0${ensmem_num}.natlev.f${fhr}.${gridname}grib2
   ififip=${net4}.t${cyc}z.m0${ensmem_num}.ififip.f${fhr}.${gridname}grib2
@@ -311,7 +312,7 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
       for task in $(seq ${tasks[count]})
       do
         mkdir -p $DATAprdgen/prdgen_${domain}_${task}
-        echo "$USHrrfs/rrfs_prdgen_subpiece.sh $fhr $cyc $task $domain ${DATAprdgen} ${COMOUT} &" >> $DATAprdgen/poescript_${fhr}
+        echo "$USHrrfs/rrfs_prdgen_subpiece.sh $fhr $cyc $task $domain $prslev ${DATAprdgen} ${COMOUT} &" >> $DATAprdgen/poescript_${fhr}
       done
       count=$count+1
     done

--- a/ush/prdgen/rrfs_prdgen_subpiece.sh
+++ b/ush/prdgen/rrfs_prdgen_subpiece.sh
@@ -19,8 +19,9 @@ fhr=$1
 cyc=$2
 subpiece=$3
 domain=$4
-DATA=$5
-comout=$6
+prslev=$5
+DATA=$6
+comout=$7
 export compress_type=c3
 
 cd $DATA/prdgen_${domain}_${subpiece}
@@ -44,7 +45,7 @@ elif [ $domain == "pr" ]; then
 fi
 
 # Use different parm file for each subpiece
-wgrib2 $comout/rrfs.t${cyc}z.prslev.f${fhr}.grib2 | grep -F -f ${parmfile} | wgrib2 -i -grib inputs.grib${domain} $comout/rrfs.t${cyc}z.prslev.f${fhr}.grib2
+wgrib2 $comout/${prslev} | grep -F -f ${parmfile} | wgrib2 -i -grib inputs.grib${domain} $comout/${prslev}
 wgrib2 inputs.grib${domain} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
 wgrib2 inputs.grib${domain}.uv -set_bitmap 1 -set_grib_type ${compress_type} \
   -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- An issue was discovered with the untested changes that were added as part of PR #312 . Those changes involved adding the ensemble member number to the ensemble grib2 output. ENSMEM_INDX was not being recognized in the run_post or run_prdgen tasks, so it is added as an environment variable in the Rocoto xmls and passed into the ex-scripts as an input argument. In addition, some logic was fixed in ush/prdgen/rrfs_prdgen_subpiece.sh. These fixes have been tested as local changes in v0.9.1 on Cactus, and they are working well.
- This PR is identical to #334 but this one is for the production/RRFS.v1 branch.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested in v0.9.1 on Cactus.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #281 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@MatthewPyle-NOAA 
