### PR TITLE
Set smoke_forecast=1 for all RRFS physics suite.

### DIFF
--- a/parm/FV3.input.yml
+++ b/parm/FV3.input.yml
@@ -196,7 +196,7 @@ FV3_HRRR_gf:
     dust_opt : 1
     coarsepm_settling : 1
     smoke_conv_wet_coef : [0.5, 0.5, 0.5]
-    smoke_forecast : 0
+    smoke_forecast : 1
     aero_ind_fdb : false
     aero_dir_fdb : true
     addsmoke_flag : 1
@@ -304,7 +304,7 @@ FV3_RAP:
     dust_opt : 1
     coarsepm_settling : 1
     smoke_conv_wet_coef : [0.5, 0.5, 0.5]
-    smoke_forecast : 0
+    smoke_forecast : 1
     aero_ind_fdb : false
     aero_dir_fdb : false
     addsmoke_flag : 1

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -519,6 +519,9 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <timedep><cyclestr offset="&START_TIME_PROCSMOKE;">@Y@m@d@H@M00</cyclestr></timedep>
+        {%- if do_retro %}
+        <datadep age="00:00:01:00"><cyclestr offset="-1:00:00">&FG_ROOT;/@Y@m@d@H/fcst_fv3lam/RESTART/</cyclestr><cyclestr>@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+        {%- endif %}
       </and>
     </dependency>
 


### PR DESCRIPTION
Need to set smoke_forecast=1 for all RRFS physics suites.
Also add forecast check in smoke preprocess for retros only.