### PR TITLE
adding RTMA-specific conditions for BUFRSND workflow component.

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -3620,7 +3620,7 @@ MODULES_RUN_TASK_FP script.
 
   </task>
 
-  {%- if do_ensfcst %}
+  {%- if do_ensfcst or is_rtma %}
   <task name="&RUN_BUFRSND_TN;{{ uscore_ensmem_name }}" cycledefs="prodcyc" maxtries="1">
 
         &RSRV_POST;

--- a/scripts/exrrfs_bufrsnd.sh
+++ b/scripts/exrrfs_bufrsnd.sh
@@ -162,7 +162,15 @@ OUTTYP=netcdf
 model=FV3S
 
 INCR=01
+
+#FHRLIM set to 00 for hourly RTMA cycles
+
+if [[ "${NET}" = "RTMA"* ]]; then
+FHRLIM=00
+else
 FHRLIM=60
+fi   
+
 
 let NFILE=1
 


### PR DESCRIPTION
The BUFRSND workflow component will not be included in FV3LAM_wflow.xml without a conditional check in /parm/FV3LAM_wflow.xml. Furthermore, the time increment setting is adjusted for RTMA in scripts/exrrfs_bufrsnd.sh.