### PR TITLE
Add FED cutoff to tile preprocessing

### DIFF
--- a/scripts/exrrfs_process_glmfed.py
+++ b/scripts/exrrfs_process_glmfed.py
@@ -203,6 +203,7 @@ def process_prod_tiles():
   obs_west = os.environ.get("OBS_WEST")
   obs_east = os.environ.get("OBS_EAST")
   fixdir   = os.environ.get("FIX_GSI")
+  fedcutoff = 8
 
   # format datetime obj
   myDate = dt.datetime(int(inDate[:4]),int(inDate[4:6]),int(inDate[6:8]),int(inDate[8:10]))
@@ -248,7 +249,7 @@ def process_prod_tiles():
         lon = lon[np.where(this_glm>0)]
         this_glm = this_glm[np.where(this_glm>0)]
         this_glm = this_glm/5. # average
-        out_fed = out_fed + [z for z in this_glm]
+        out_fed = out_fed + [min(fedcutoff,z) for z in this_glm]
         out_lats = out_lats + [z for z in lat]
         out_lons = out_lons + [z for z in lon]
   # write output to NetCDF
@@ -284,6 +285,7 @@ def process_gsl_tiles():
   obs_west = os.environ.get("OBS_WEST")
   obs_east = os.environ.get("OBS_EAST")
   fixdir   = os.environ.get("FIX_GSI")
+  fedcutoff = 8
 
   # format datetime obj
   myDate = dt.datetime(int(inDate[:4]),int(inDate[4:6]),int(inDate[6:8]),int(inDate[8:10]))
@@ -328,7 +330,7 @@ def process_gsl_tiles():
         lon = lon[np.where(this_glm>0)]
         this_glm = this_glm[np.where(this_glm>0)]
         this_glm = this_glm/5. # average
-        out_fed = out_fed + [z for z in this_glm]
+        out_fed = out_fed + [min(fedcutoff,z) for z in this_glm]
         out_lats = out_lats + [z for z in lat]
         out_lons = out_lons + [z for z in lon]
   # write output to NetCDF


### PR DESCRIPTION


## DESCRIPTION OF CHANGES: 
Changed a few lines of flash extent density preprocessing script to apply a high-flash-rate-cutoff to tiled data, as is done for full-disk data

## TESTS CONDUCTED: 
Tested on Jet for several hours of retro

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [X ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [X ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
Fixes issue 344


