### PR TITLE
Updating params_grib2_tbl_new for latest UPP.

### DIFF
--- a/fix/upp/params_grib2_tbl_new
+++ b/fix/upp/params_grib2_tbl_new
@@ -5,6 +5,7 @@
    0   3    15   0 5WAVH
    0   3   193   1 5WAVH
    0  20   106   0 AACOEF
+   4  10     4   0 AATRATE
    0   2    11   0 ABSD
    4   2     5   0 ABSFRQ
    0   1    18   0 ABSH
@@ -24,8 +25,10 @@
    0   2    36   0 AFRWE
    0  20    50   0 AIA
    0  18    10   0 AIRCON
+  10   0    82   0 AIRDENOC
    2   0   208   1 AKHS
    2   0   209   1 AKMS
+  10   2    14   0 ALBDOICE
    0  19     1   0 ALBDO
    0  20   108   0 ALBGRD
    0  20   107   0 ALBSAT
@@ -37,6 +40,7 @@
    0   3    11   0 ALTS
   10   0    37   0 ALTWH
    2   0   219   1 AMIXL
+   4   5     0   0 AMPL
    3 192    11   0 AMSRE10
    3 192    12   0 AMSRE11
    3 192    13   0 AMSRE12
@@ -65,7 +69,11 @@
    0 190     0   0 ATEXT
    3   1    13   0 ATMDIV
    0  20   101   0 ATMTK
+   4  10     7   0 AURELEC
+  20   1     8   0 AVECTNUM
+  20   1     7   0 AVHRATIO
    2   3   201   1 AVSFT
+  10 191     4   0 BARDSF
    2   3   200   1 BARET
   10   4     7   0 BATHY
   10   0    44   0 BENINX
@@ -79,6 +87,7 @@
    2   0   197   1 BMIXL
    0   7   201   1 BNEGELAY
    2   3     4   0 BOTLST
+  10   4    29   0 BPEH
    0   7   202   1 BPOSELAY
    0  15     1   0 BREF
    3   1    27   0 BRFLF
@@ -87,6 +96,11 @@
    0  15     2   0 BRVEL
    0  15     0   0 BSWID
    4   3     0   0 BTOT
+   2   6     2   0 BUILDCOVER
+   2   6     3   0 BUILDHGT
+   2   4    21   0 BURNABAREA
+   2   4    20   0 BURNAREA
+   2   4    17   0 BURNIDX
    4   3     1   0 BVEC1
    4   3     2   0 BVEC2
    4   3     3   0 BVEC3
@@ -94,6 +108,7 @@
    4   8     4   0 CAIIRAD
    0   7   206   1 CANGLE
    2   1   192   1 CANL
+   2   0    63   0 CANTMP
    0   7     6   0 CAPE
    0   1    88   0 CATCP
    0  19    29   0 CATEDR
@@ -111,27 +126,48 @@
    0   6    11   0 CDCB
    0   6    22   0 CDCC
    0  17     3   0 CDCDLTFD
+   0   1   162   0 CDCIMF
    0   6    23   0 CDCIMR
+   0   1   161   0 CDCLWMF
    0   6     2   0 CDCON
    0   6    12   0 CDCTOP
    0   6     8   0 CDCT
    0  17     2   0 CDGDLTFD
+   0   3    43   0 CDGFLUX
+   0  20    80   0 CDIVMF
    0   6    14   0 CDLYR
    0   6   192   1 CDLYR
+   0   1   163   0 CDRMF
+   0   1   164   0 CDSMF
+   0   3    35   0 CDTMF
+   0   1   165   0 CDTWMF
    0   4   195   1 CDUVB
+   0   1   160   0 CDWFMF
+   0   3    42   0 CDWGFLUX
   10   0    16   0 CDWW
    0   2    29   0 CD
    0   2   196   1 CD
+   0   1   154   0 CECIMF
+   0   1   152   0 CECLWMF
+   0   1   158   0 CEFMF
+   0   3    40   0 CEGFLUX
    0   6    13   0 CEIL
+   0  20    78   0 CEMF
+   0   1   156   0 CERMF
+   0   3    36   0 CETMF
+   0   1   150   0 CEWVMF
    0   5   197   1 CFNLF
    0   4   199   1 CFNSF
    0   1    34   0 CFRZR
    0   1   193   1 CFRZR
    0  20    54   0 CGDRC
    0  20    53   0 CGPRC
+  10   0    76   0 CHNCK
+   0   1   147   0 CHPRECIP
   10   3     2   0 CH
    0  18    17   0 CIAIRC
    0  19   206   1 CICEL
+   0   1   146   0 CICEPR
    0   1    35   0 CICEP
    0   1   194   1 CICEP
   10   2    12   0 CICES
@@ -157,12 +193,23 @@
    3   2     6   0 CLDPER
    3   2     4   0 CLDPHAS
    3   1    16   0 CLDRAD
+   3   1    31   0 CLDREF
    3   2     3   0 CLDTYPE
    0   1   235   1 CLLMR
    0   1    22   0 CLMR
    3   0     7   0 CLOUDM
+   3   1    32   0 CLRREF
+   0   3    39   0 CMATMOS
+   0   1   155   0 CNCIMF
+   0   1   153   0 CNCLWMF
+   0  20    81   0 CNETS
+   0   3    41   0 CNGFLUX
    0   2   216   1 CNGWDU
    0   2   217   1 CNGWDV
+   0  20    79   0 CNMF
+   0   1   157   0 CNRMF
+   0   1   159   0 CNSMF
+   0   3    37   0 CNTMF
    0   3   209   1 CNVDEMF
    0   3   208   1 CNVDMF
    0   0   196   1 CNVHR
@@ -172,8 +219,10 @@
    0   2   213   1 CNVV
    2   0    13   0 CNWAT
    2   0   196   1 CNWAT
+   0   1   151   0 CNWVMF
    0  20    56   0 COAIA
    0  20     1   0 COLMD
+   2   4    24   0 COMBCO
    0  20    51   0 CONAIR
    0   7    19   0 CONAPES
    0   1   216   1 CONDP
@@ -210,6 +259,7 @@
    0   1    33   0 CRAIN
    0   1   192   1 CRAIN
    0  20    71   0 CRERELSP
+   2   0    48   0 CROPCOV
    0   1    76   0 CRRATE
    4   2     9   0 CRTFRQ
    1   2    13   0 CSAFC
@@ -220,6 +270,8 @@
    3   1    17   0 CSKYRAD
    0   1    36   0 CSNOW
    0   1   195   1 CSNOW
+  20   3     8   0 CSPPCAP
+  20   3     9   0 CSPPROD
    0   1    58   0 CSRATE
    0   1    55   0 CSRWE
    0   5   195   1 CSULF
@@ -231,29 +283,41 @@
    0  19    21   0 CTP
    0   6    16   0 CUEFI
    0   6   194   1 CUEFI
+   0  19   239   1 CWASP
+   0   1   149   0 CWATERMR
    0   6     6   0 CWAT
    0   7   195   1 CWDI
    0   6    15   0 CWORK
    0   6   193   1 CWORK
    0   1    48   0 CWP
    1   1   195   1 CWR
+   0   1   166   0 CWVF
+   0  19    41   0 DBHEIGHT
   10   4   195   1 DBSS
    0   7   203   1 DCAPE
+   2   4    33   0 DDLMC
    0  20    12   0 DDMFLX
    0   3    30   0 DDRATE
+   2   6     8   0 DDROAD
+   2   6     6   0 DDROOF
    0  20    15   0 DDVEL
-   2   0    30   0 DECF
+   2   4    35   0 DDWMC
+   2   0    30   0 DECFC
+   0   2    61   0 DEC
    0   3    14   0 DENALT
    0   3    10   0 DEN
    0   0     7   0 DEPR
    1   0    13   0 DEPWSS
+  20   1     6   0 DFPRATIO
   10   2     2   0 DICED
+   4  10     3   0 DIDXSG
    4   4     2   0 DIFEFLUX
    4   4     4   0 DIFIFLUX
    4   4     0   0 DIFPFLUX
    3   6     5   0 DIFSOLEX
    3   6     4   0 DIFSOLIR
    0   4    14   0 DIFSWRF
+   2   6     7   0 DIOWALL
   10   1     0   0 DIRC
    2   3    14   0 DIREC
   10   0    10   0 DIRPW
@@ -264,36 +328,82 @@
   10   0    32   0 DIRWWW
    1   0     7   0 DISRS
    0   3     6   0 DIST
+   0  21    13   0 DIVENTFLUX
+   0  21    16   0 DIVKENGFLUX
+   0  21    14   0 DIVPOTFLUX
+   0  21    17   0 DIVTOTFLUX
+   0  21    18   0 DIVWENTFLUX
+   0  21    15   0 DIVWPOTFLUX
+   2   4    29   0 DLFL
    0   5     8   0 DLWRFCS
    0   5     3   0 DLWRF
    0   5   192   1 DLWRF
    0   3    28   0 DMFLX
+   0   4    54   0 DNSWRFLX
+   0   1   123   0 DPTYPE
    0   0     6   0 DPT
+   2   0    43   0 DRAINDIR
+   2   4    13   0 DRFACT
    2   4     8   0 DRTCODE
    0  18    12   0 DRYDEP
    0  19   237   1 DRYTPROB
    4   7     2   0 DSKDAY
    4   7     1   0 DSKINT
    4   7     3   0 DSKNGT
+  10   3    20   0 DSLIBARCOR
   10   3     1   0 DSLM
   10 191     3   0 DSLOBSO
    0 191     3   0 DSLOBS
    0   4    52   0 DSWRFCS
+   0   4    61   0 DSWRFLXCS
    0   4    13   0 DSWRFLX
    0   4     7   0 DSWRF
    0   4   192   1 DSWRF
+   0   2    60   0 DTC
    0   4   204   1 DTRF
    2   4     7   0 DUFMCODE
    0   4   194   1 DUVB
+   2   4    30   0 DWFL
+  10   3     4   0 DWHFLUX
    0   4    12   0 DWUVR
    0   2     9   0 DZDT
    0   7   207   1 E3KH
+   0  21    22   0 EADYGR
    3   2    11   0 EAODR
+  10   1     5   0 EASTCUR
+   0  21     5   0 EASTENTFLUX
+   0  21    19   0 EASTHFLUX
+   0  21     9   0 EASTKINFLUX
+   0  21     7   0 EASTPOTFLUX
+   0  21    11   0 EASTTOTFLUX
+   0   2    64   0 EASTTSSOD
+   0   2    66   0 EASTTSSSR
+   0   2    62   0 EASTTSS
+  10   3     5   0 EASTWSS
+  10   4    23   0 EASTWVEL
    3   5     5   0 EBSDSSTS
    3   5     4   0 EBSSTSTD
+   2   0    61   0 ECORFLUX
+   4  10     6   0 EDISSTIX
    0  19    30   0 EDPARM
+   0   1   138   0 EFARCICE
+   0   1   140   0 EFARGRL
+   0   1   141   0 EFARHAIL
+   0   1   137   0 EFARRAIN
+   0   1   142   0 EFARSIC
+   0   1   139   0 EFARSNOW
+  20   0     5   0 EFFTEMP
    0   7   204   1 EFHL
+   0   1   129   0 EFRCCWAT
+   0   1   131   0 EFRCICE
+   0   1   133   0 EFRGRL
+   0   1   134   0 EFRHAIL
+   0   1   130   0 EFRRAIN
+   0   1   136   0 EFRSICEC
+   0   1   135   0 EFRSLC
+   0   1   132   0 EFRSNOW
    0   3   222   1 EFSH
+  10   0    89   0 EFWS
    0   7     9   0 EHLX
    2   0   237   1 EIWATER
    4   2     1   0 ELCDEN
@@ -303,9 +413,15 @@
    0   0   205   1 ELMELT
    0 191   197   1 ELONN
    0 191   193   1 ELON
+   0  20    76   0 EMISFLX
+   2   0    62   0 EMISS
+  10   0    93   0 EMIWAVE
    0   1   211   1 EMNP
+   2   4    19   0 ENRELCOM
+   0  21     3   0 ENTHALPY
    0   0     3   0 EPOT
    0  19   218   1 EPSR
+   4   2    13   0 EQSLABT
   10   3   252   1 EROSNP
    1   0     3   0 ESCT
    0   2   233   1 ESHR
@@ -313,6 +429,8 @@
    3   1     0   0 ESTP
    3   1     4   0 ESTUGRD
    3   1     5   0 ESTVGRD
+  10   3    14   0 ESURFWVEL
+  10   4    38   0 ESWVP
    0   2    32   0 ETACVV
   10   3   250   1 ETCWL
    4   3     4   0 ETOT
@@ -320,6 +438,7 @@
    0   2    38   0 ETSS
    4   6     3   0 EUVIRR
    4   8     1   0 EUVRAD
+   2   0    39   0 EVAPTRAT
    2   0     6   0 EVAPT
    0   1    79   0 EVARATE
    2   3   198   1 EVBS
@@ -327,22 +446,29 @@
    4   3     5   0 EVEC1
    4   3     6   0 EVEC2
    4   3     7   0 EVEC3
-   2   0    29   0 EVERF
+   2   0    29   0 EVGFC
    0   1     6   0 EVP
    2   0   213   1 EWATR
+   0   2    50   0 EWINDSTR
    0   2    39   0 EWTPARM
+   0   3    26   0 EXPRES
    4   6     5   0 F107
+  20   1     5   0 FALPRATE
    2   4     3   0 FBAREA
    2   4    10   0 FBUPINX
    0   6    37   0 FCONPC
+  10   0    81   0 FCVOCEAN
+   2   4    32   0 FDLMC
    3   5     3   0 FDNSSTMP
    2   4    11   0 FDSRTE
+   2   4    34   0 FDWMC
    1   0     0   0 FFLDG
    1   0     1   0 FFLDRO
    2   4     6   0 FFMCODE
    0   1   228   1 FICEAC
    0   6    21   0 FICE
    0   6   199   1 FICE
+   2   4    15   0 FIREDIDX
    3   0     9   0 FIREDI
    2   4     1   0 FIREODT
    2   4     0   0 FIREOLK
@@ -350,11 +476,15 @@
    1   0    12   0 FLDPSW
    0  19   205   1 FLGHT
    0   7    18   0 FLXRN
+  20   1     9   0 FMALVRH
+   0   6    50   0 FOG
    2   4     4   0 FOSINDX
    0   1    67   0 FPRATE
    0   6    32   0 FRACCC
+   2   4    36   0 FRADPOW
    0   1    43   0 FRAIN
    0   1   202   1 FRAIN
+   4   5     2   0 FREQ
   10   0    63   0 FREWWW
   10   0    17   0 FRICVW
    0   2    30   0 FRICV
@@ -362,12 +492,19 @@
    0   1   227   1 FROZR
    2   3    24   0 FRSTINX
   10   0    64   0 FRWWTSW
+  10   2    29   0 FRZDATE
+  10   2    27   0 FRZMLTPOT
    0   1   225   1 FRZR
   10   3   204   1 FRZSPR
    0   1   121   0 FSNOWC
    0   6    36   0 FSTRPC
+   2   4    23   0 FUELLOAD
+   2   4    25   0 FUELMC
+  10   4    31   0 FWFC
+  10   4    30   0 FWFSW
    2   4     5   0 FWINX
    0   1    95   0 FZPRATE
+   0   3    33   0 GAMSL
    0  18     3   0 GDCES
    0  18     4   0 GDIOD
    0  18     5   0 GDRADP
@@ -377,13 +514,19 @@
    0   2    44   0 GEOWS
    2   0    10   0 GFLUX
    2   0   193   1 GFLUX
+   0   3    34   0 GHARGRD
+   2   5     0   0 GLACCOV
    2   5     1   0 GLACTMP
+   0  19    47   0 GLIRRTS
+  20   0     3   0 GLOBETMP
    0   3     9   0 GPA
    0   1    75   0 GPRATE
    0   3     4   0 GP
    0   4     3   0 GRAD
+   2   0    49   0 GRASSCOV
    0   7    17   0 GRDRN
    0   1    32   0 GRLE
+   2   0    60   0 GROSSFLUX
    3   6     1   0 GSOLEXP
    3   6     0   0 GSOLIRR
    0   2    22   0 GUST
@@ -397,13 +540,16 @@
    0  19   198   1 HAILPROB
    0   1    73   0 HAILPR
    0   1    31   0 HAIL
+  10   3    10   0 HALOCSSH
    4   8     2   0 HARAD
    0  19   210   1 HAVNI
+  20   1     3   0 HBRATEAV
    0   6     5   0 HCDC
    0   6    26   0 HCONCB
    0   6    27   0 HCONCT
    0   0    12   0 HEATX
    4   8     6   0 HELCOR
+  10   3    18   0 HFLUXCOR
    2   0    24   0 HFLUX
    0  20    62   0 HGTMD
    0   3   211   1 HGTN
@@ -412,6 +558,7 @@
    0   3     5   0 HGT
    0  19    32   0 HIFREL
    2   4     2   0 HINDEX
+   2   0    54   0 HIVEGCOV
    0   7     8   0 HLCY
    0  18    16   0 HMXACON
    0   3    18   0 HPBL
@@ -422,14 +569,22 @@
    0  15    15   0 HSR
    0   3     7   0 HSTDV
   10   0     3   0 HTSGW
+  20   0     4   0 HUMIDX
+   0   3    44   0 HWBT
    0   3     3   0 ICAHT
    1   2     7   0 ICECIL
   10   2     0   0 ICEC
   10   2     7   0 ICED
+  10   2    19   0 ICEFTHCK
   10   2     6   0 ICEG
+  10   2    21   0 ICEMPD
+  10   2    20   0 ICEMPF
+  10   2    22   0 ICEMPV
   10   2     9   0 ICEPRS
+   0   1   127   0 ICEP
    0  19    27   0 ICESC
    0  19    37   0 ICESEV
+   2   3    29   0 ICETEMP
    1   2     6   0 ICETIL
   10   2     1   0 ICETK
   10   2     8   0 ICETMP
@@ -442,6 +597,7 @@
    0  19   234   1 ICSEV
    1   2     5   0 ICTKIL
    2   0   207   1 ICWAT
+   2   4    18   0 IGNCOMP
    0   1    20   0 ILIQW
   10   0    27   0 IMFTSW
   10   0    26   0 IMFWW
@@ -455,13 +611,19 @@
    4   0     3   0 IONTMP
    0   1    68   0 IPRATE
    3   1     1   0 IRRATE
+   2   0    47   0 IRRCOV
   10 191     0   0 IRTSEC
    3   5     0   0 ISSTMP
    0  19   235   1 JFWPRB
   10   3   201   1 KENG
+   0  21     1   0 KINENG
    0   7     3   0 KOX
+   4  10     5   0 KP
+   2   4    12   0 KRIDX
   10   0    43   0 KSSEDW
    0   7     2   0 KX
+   2   0    56   0 LAIHI
+   2   0    55   0 LAILO
    0   7   198   1 LAI
    2   0   234   1 LAKEFRC
    2   0   233   1 LANDFRC
@@ -477,19 +639,26 @@
    0   3   205   1 LAYTH
    0   6     3   0 LCDC
   10   3   203   1 LCH
+   1   2    15   0 LDEPTH
    2   0    28   0 LEAINX
+   2   4    31   0 LFMC
    0   7    10   0 LFTX
    0   7   192   1 LFTX
+   0   0    30   0 LHFLXE
+   0   0    31   0 LHFLXS
    0   0    10   0 LHTFL
    0   1   229   1 LICEAC
    0  13   195   1 LIPMF
    2   3    10   0 LIQVSM
+   2   4    27   0 LLFL
    0  15     4   0 LMAXBR
    4   7     0   0 LMBINT
    0   3   210   1 LMH
    0   2   218   1 LMV
+   1   2    14   0 LNDSNOWT
    0   2   203   1 LOPP
    0   2   199   1 LOUV
+   2   0    53   0 LOVEGCOV
    0   2   201   1 LOVV
    2   3     3   0 LOWLSM
    0  13   194   1 LPMTF
@@ -508,9 +677,13 @@
    0  17   192   1 LTNG
    0  17     1   0 LTPINX
    0   5     2   0 LWAVR
+   2   4    28   0 LWFL
    0   5   194   1 LWHR
    0   4     5   0 LWRAD
    2   3    23   0 LWSNWP
+  20   1     1   0 MACPRATE
+  20   1     0   0 MALACASE
+  20   1     4   0 MALAIMM
    4   8     7   0 MASK
    0   6    38   0 MASSDCD
    0   6    39   0 MASSDCI
@@ -526,6 +699,7 @@
    0   2    21   0 MAXGUST
    0  16   198   1 MAXREF
    0   1    27   0 MAXRH
+   4   2    10   0 MAXUFZ
    0   2   220   1 MAXUVV
    0   2   222   1 MAXUW
    0   1   245   1 MAXVIG
@@ -539,16 +713,22 @@
    0   1   112   0 MDLWGVA
    0   1   109   0 MDLWHVA
    0   1   115   0 MDLWSVA
+  10   0    74   0 MDTSWEL
+  10   0    75   0 MDWWAVE
    3   2    30   0 MEACST
+  20   0     1   0 MEANRTMP
+   0  19    44   0 MEANVGRTL
    0   6   200   1 MFLUX
    0   2    26   0 MFLX
    0   2   193   1 MFLX
    0   0    14   0 MINDPD
    0   1   198   1 MINRH
+   0  19    45   0 MINVGRTL
    0  19     3   0 MIXHT
    0  19   204   1 MIXLY
    0   1     2   0 MIXR
    0   7   212   1 MLFC
+  10   2    28   0 MLTDATE
    0 191   195   1 MLYNO
    0   1   114   0 MMLWGDA
    0   1   111   0 MMLWHDA
@@ -567,6 +747,7 @@
   10   0    20   0 MSSW
    2   0    11   0 MSTAV
    2   0   194   1 MSTAV
+   2   3   204   1 MSTAV
    2   0     7   0 MTERH
   10   4     1   0 MTHA
   10   4     0   0 MTHD
@@ -599,25 +780,53 @@
    0   6    30   0 NDENCD
    2   0    31   0 NDVINX
    2   0   217   1 NDVI
+   2   0    59   0 NECOFLUX
+  10   0    85   0 NEFOCEAN
+  10   0    83   0 NEFW
+   0  19    46   0 NETRADFLUX
+  10   3    13   0 NETUPWFLUX
+   0   5     9   0 NIRALBDIF
+   0   5    11   0 NIRALBDIRG
+   0   5    12   0 NIRALBDIRI
+   0   5    13   0 NIRALBDIRV
+   0   5    10   0 NIRALBDIR
    0 191   196   1 NLATN
    0 191   192   1 NLAT
    0   3   206   1 NLGSP
    0   3    25   0 NLPRES
+   0   2    54   0 NLSRLH
+   0   2    55   0 NLSRLM
    0   5     6   0 NLWRCS
    0   5     5   0 NLWRF
    0   5     0   0 NLWRS
    0   5     1   0 NLWRT
+  20   0     6   0 NOREFTMP
+  10   3     6   0 NORTHWSS
    3   1     6   0 NPIXU
+  10   1     6   0 NRTHCUR
+   0  21     6   0 NRTHENTFLUX
+   0  21    20   0 NRTHHFLUX
+   0  21    10   0 NRTHKINFLUX
+   0  21     8   0 NRTHPOTFLUX
+   0  21    12   0 NRTHTOTFLUX
+   0   2    65   0 NRTHTSSOD
+   0   2    67   0 NRTHTSSSR
+   0   2    63   0 NRTHTSS
+  10   4    24   0 NRTHWVEL
+  10   0    84   0 NSOCEAN
+  10   3    15   0 NSURFWVEL
    0   4    11   0 NSWRFCS
    0   4     9   0 NSWRF
    0   4     0   0 NSWRS
    0   4     1   0 NSWRT
+  10   4    39   0 NSWVP
    4   4     6   0 NTRNFLUX
    0   2    37   0 NTSS
    0   1   106   0 NUMDG
    0   1   107   0 NUMDH
    0   1   104   0 NUMDR
    0   1   105   0 NUMDS
+   0   2    51   0 NWINDSTR
    0   2    34   0 NWIND
    0  19   214   1 NWSALB
   10   0    19   0 NWSTR
@@ -649,19 +858,35 @@
    2   0   235   1 PAHFLX
    3   3     2   0 PBINFRC
    3   3     1   0 PBLIFRC
+   0   1   126   0 PBLIZZ
    0  19    12   0 PBLREG
    3   3     0   0 PBMVFRC
+   0   1   125   0 PBSNOW
+   0  19    49   0 PCONTB
+   0  19    48   0 PCONTT
    0   1   234   1 PCPDUR
    0  14   202   1 PDMAX1
    0  14   203   1 PDMAX24
+  10   0    72   0 PDTSWELL
+  10   0    71   0 PDWWAVE
+   4   2    12   0 PEAKDEN
+   4   2    11   0 PEAKH
+  20   0     8   0 PEQUTMP
+   0   1   143   0 PERATE
   10   0    11   0 PERPW
    1   0    16   0 PERRATE
   10   0    13   0 PERSW
+   2   0    40   0 PEVAPTRAT
    0   1    40   0 PEVAP
    0   1   199   1 PEVAP
    0   1    41   0 PEVPR
    0   1   200   1 PEVPR
+  20   1     2   0 PFEIRATE
+   4   5     1   0 PHASE
+   0   4    60   0 PHOARFCS
    0   4    10   0 PHOTAR
+   0   1   122   0 PIIDX
+   0  21    21   0 PILENERGY
    3   0     8   0 PIXST
    2   0   238   1 PLANTTR
    0   7     0   0 PLI
@@ -670,9 +895,12 @@
   10   0    23   0 PMAXWH
    0  13   192   1 PMTC
    0  13   193   1 PMTF
+  20   2     0   0 POPDEN
    1   1     2   0 POP
    2   3     9   0 POROS
    2   3   197   1 POROS
+   0  20    18   0 POTHPH
+   0  21     0   0 POTINTENG
    0   0     2   0 POT
    0  14   199   1 POZO
    0  14   198   1 POZT
@@ -682,11 +910,13 @@
    1   1   194   1 PPFFG
    0   1   231   1 PPINDX
    1   1     1   0 PPOSP
+  10   3     3   0 PRACTSAL
    0   1     7   0 PRATE
    4   0     4   0 PRATMP
    0  15     5   0 PREC
    0   3    13   0 PRESALT
    0   3     8   0 PRESA
+   0   3    46   0 PRESDHS
    0   3   212   1 PRESN
    0   3     0   0 PRES
    0   3     1   0 PRMSL
@@ -698,6 +928,7 @@
    0  19   216   1 PRSIGSVR
    0  19   215   1 PRSVR
   10   4    21   0 PRTSAL
+   0   1   124   0 PSHOW
    0  19    36   0 PSNOWS
    0   3     2   0 PTEND
    0   1    19   0 PTYPE
@@ -706,23 +937,33 @@
    0   1     3   0 PWAT
   10   0    46   0 PWAVEDIR
    0   1    30   0 PWCAT
+  10   0    68   0 PWDFSPAR
+  10   0    69   0 PWDSSPAR
+  10   0    70   0 PWDTSPAR
   10   0    34   0 PWPER
+  10   0    65   0 PWPFSPAR
+  10   0    66   0 PWPSSPAR
+  10   0    67   0 PWPTSPAR
    0   1   226   1 PWTHER
    0   1   219   1 QMAX
    0   1   220   1 QMIN
+   1   1   196   1 QPFARI
+   1   1   197   1 QPFFFG
    2   0   215   1 QREC
    0   1   218   1 QZ0
    0  16   201   1 RADARVIL
    2   3   202   1 RADT
+   2   4    14   0 RATESPRD
    3   1     8   0 RAZA
-   2   0    21   0 RCQ
+   2   0    20   0 RCQ
    2   0   204   1 RCQ
-   2   0    20   0 RCSOL
+   2   0    21   0 RCSOL
    2   0   205   1 RCSOL
    2   0    18   0 RCS
    2   0   202   1 RCS
    2   0    19   0 RCT
    2   0   203   1 RCT
+   1   2    16   0 RDEPTH
    2   0   206   1 RDRIP
    0  15     6   0 RDSP1
    0  15     7   0 RDSP2
@@ -740,6 +981,8 @@
    0  16   192   1 REFZR
    0   2    13   0 RELD
    0   2    12   0 RELV
+  20   3     0   0 RENPCAP
+  20   3     1   0 RENPPROD
    0  16     3   0 RETOP
    0  16   197   1 RETOP
    0   0   194   1 REV
@@ -747,6 +990,7 @@
    0  15    10   0 RFCI
    0  15    13   0 RFGRPL
    0  15    14   0 RFHAIL
+   3   1    30   0 RFL04
    3   1     9   0 RFL06
    3   1    10   0 RFL08
    3   1    11   0 RFL16
@@ -764,6 +1008,8 @@
    0   7   194   1 RI
    2   3     6   0 RLYRS
    2   3   193   1 RLYRS
+   2   6     1   0 ROADCOVER
+   4  10     2   0 ROTIDX
    0   1    65   0 RPRATE
    2   0    16   0 RSMIN
    2   0   200   1 RSMIN
@@ -771,11 +1017,13 @@
    0 191   194   1 RTSEC
   10   3   206   1 RUNUP
    1   0    11   0 RVERSW
+  10   0    80   0 RWAVEAFW
    0   1    24   0 RWMR
    0  18    14   0 SACON
    0  20   100   0 SADEN
    0  19    19   0 SALBD
    3   0     1   0 SALBEDO
+  10   3    21   0 SALINITY
   10   4   193   1 SALIN
    1   2    12   0 SALTIL
   10   4     3   0 SALTY
@@ -845,22 +1093,39 @@
    3 192    68   0 SBTAHI9
    3   0     2   0 SBTMP
    0   7   210   1 SCCP
-   4   2    10   0 SCINT
+   4  10     1   0 SCIDEXS4
+   4  10     0   0 SCINIDX
    0   1    84   0 SCLIWC
    0   1    83   0 SCLLWC
    3   1    29   0 SCRAD
    0  20   112   0 SCTAOTK
    3   0     5   0 SCTPRES
+   2   6     5   0 SDBUILDHGT
    0  20     6   0 SDDMFLX
    0   1    61   0 SDEN
+   0   3    38   0 SDFSO
    3   1    99   0 SDMPEMRR
    0   3    20   0 SDSGSO
    0   1    60   0 SDWE
+  10   4    48   0 SEACMMT
+  10   4    44   0 SEACMVT
+  10   4    50   0 SEACPSALT
+  10   4    51   0 SEACSALT
+  10   4    49   0 SEACZMT
+  10   4    45   0 SEACZVT
+  10   4    46   0 SEAMMT
+  10   4    42   0 SEAMVT
+  10   3    12   0 SEASFLUX
+  10   4    47   0 SEAZMT
+  10   4    43   0 SEAZVT
    0  20    11   0 SEDMFLX
    1   2     3   0 SEDTK
    1   2     4   0 SEDTMP
+   0  19    39   0 SEEINDEX
   10   3   207   1 SETUP
    0   1    62   0 SEVAP
+  10   0    86   0 SEVWAVE
+   0  20    77   0 SFCEFLX
    2   0   216   1 SFCRH
    2   0     1   0 SFCR
    2   0    34   0 SFCWRO
@@ -880,6 +1145,8 @@
    3 192    33   0 SFRA174
    3 192    34   0 SFRA175
    3 192    35   0 SFRA176
+   0   2    47   0 SFRHEAT
+   0   2    48   0 SFRMOIST
   10   4    11   0 SFSALP
    1   2     9   0 SFSAL
   10   4    12   0 SFTMPP
@@ -893,17 +1160,24 @@
    0   1   108   0 SHTPRM
    0   7    13   0 SHWINX
   10   2     3   0 SICED
+  10   2    17   0 SICEHC
+  10   2    15   0 SICEVOL
+   4   8     8   0 SICFL
+  10   2    23   0 SIFTP
    4   9     1   0 SIGHAL
    0   7   209   1 SIGH
    4   9     2   0 SIGPAR
    4   9     0   0 SIGPED
    0   7   211   1 SIGT
    0  19   217   1 SIPD
+   2   0    50   0 SKINRC
    0   0    17   0 SKINT
    3   5     1   0 SKSSTMP
+   0  19    38   0 SKYIDX
    0   1   230   1 SLACC
    0  19    23   0 SLDP
    3   0     4   0 SLFTI
+   0  17     5   0 SLNGPIDX
   10   3   202   1 SLTFL
    2   3   194   1 SLTYP
    0   6    34   0 SLWTC
@@ -912,6 +1186,7 @@
    0   1   113   0 SMLWGMA
    0   1   110   0 SMLWHMA
    0   1   116   0 SMLWSMA
+   2   0    41   0 SMRATE
    2   3     7   0 SMREF
    2   3   195   1 SMREF
    0  19    18   0 SNFALB
@@ -928,9 +1203,17 @@
    0   1   208   1 SNOT
    0   1    42   0 SNOWC
    0   1   201   1 SNOWC
+   0   1   148   0 SNOWERAT
    0   1   233   1 SNOWLR
+   0  19    40   0 SNOWLVL
    0  19   236   1 SNOWLVL
+   2   3    28   0 SNOWTMP
+  10   2    13   0 SNOWTSI
    0   1   222   1 SNOWT
+  20   3     6   0 SNPVPCAP
+  20   3     7   0 SNPVPPROD
+  10   2    18   0 SNSIHC
+  10   2    16   0 SNVOLSI
    2   3    25   0 SNWDEB
    2   3    27   0 SOILDEP
    2   3    21   0 SOILICE
@@ -948,6 +1231,7 @@
    3   1    28   0 SPBRT
   10   1     1   0 SPC
    4   6     4   0 SPECIRR
+  10   0    88   0 SPECWI
    4   1     0   0 SPEED
    0   1     0   0 SPFH
   10   0    45   0 SPFTR
@@ -956,7 +1240,10 @@
    0   1   100   0 SPNCR
    0   1   101   0 SPNCS
    0   1    66   0 SPRATE
+   2   4    16   0 SPRDCOMP
    4   2     7   0 SPRDF
+  20   3     4   0 SPVPCAP
+  20   3     5   0 SPVPPROD
    3   0     3   0 SPWAT
    3   0     0   0 SRAD
    0   1    85   0 SRAINC
@@ -967,16 +1254,20 @@
    3 192    49   0 SRFAGR4
    3 192    50   0 SRFAGR5
    3 192    51   0 SRFAGR6
+   0   1   144   0 SRWATERC
    0   1    12   0 SRWEQ
    0  20   103   0 SSALBK
    0   3    22   0 SSGSO
+  10   3    19   0 SSHGTPARM
   10   3   195   1 SSHG
    3   5     2   0 SSKSSTMP
    3 192    62   0 SSMS1715
    3 192    63   0 SSMS1716
    3 192    64   0 SSMS1717
    3 192    65   0 SSMS1718
+   0   1   145   0 SSNOWWC
    0   1    86   0 SSNOWW
+   0   1   168   0 SSPFHW
    1   0     6   0 SSRUN
    1   0   193   1 SSRUN
   10   3   200   1 SSST
@@ -984,22 +1275,31 @@
    2   0   211   1 SSTOR
   10   3   199   1 SSTT
    0   6    35   0 SSWTC
+  20   0     7   0 STDEFTMP
+  10   3    11   0 STERCSSH
+  10   0    96   0 STMCREST
+  10   0    97   0 STMWAVE
    0  19   200   1 STORPROB
    0   7   208   1 STPC
    0   2     4   0 STRM
    0   1    87   0 STRPRATE
+   2   0    52   0 SUBSRATE
+   0   6    51   0 SUNFRAC
    0   6    33   0 SUNSD
    0   6   201   1 SUNSD
    0   6    24   0 SUNS
+   2   0    51   0 SURFRATE
   10   3   192   1 SURGE
    0  19   220   1 SVRTS
   10   3   208   1 SWASH
+   0   3    32   0 SWATERVP
    0   4     2   0 SWAVR
   10   0     7   0 SWDIR
    0  20     7   0 SWDMFLX
    0   7     5   0 SWEATX
   10   0     8   0 SWELL
    1   0     4   0 SWEPON
+   2   3    30   0 SWET
   10   0    47   0 SWHFSWEL
    0   4   197   1 SWHR
   10   0    48   0 SWHSSWEL
@@ -1009,10 +1309,18 @@
    3   1   194   1 SWQI
    0   4     6   0 SWRAD
    0  19   212   1 SWSALB
+  10   4    41   0 SWSTBC
+  10   4    35   0 SWSTNR
+  10   4    37   0 SWSTP
+  10   4    40   0 SWTTBC
+  10   4    34   0 SWTTNR
+  10   4    36   0 SWTTP
    0   6     1   0 TCDC
+   0 191     4   0 TCDTRACK
    0   0   204   1 TCHP
    0   1    81   0 TCICON
    0  14     2   0 TCIOZ
+   0   1   169   0 TCISSPFHW
    0   1    64   0 TCIWV
    2   0    35   0 TCLASS
    0   1   209   1 TCLSW
@@ -1035,6 +1343,7 @@
    0   6    17   0 TCONDO
    0   1    21   0 TCOND
    0   6   195   1 TCOND
+   0   1   167   0 TCSLW
   10   3   242   1 TCSRG20
   10   3   243   1 TCSRG30
   10   3   244   1 TCSRG40
@@ -1046,7 +1355,10 @@
    0   1    51   0 TCWAT
    0   0    20   0 TDCHT
    0   2    31   0 TDCMOM
+  10   0    94   0 TDMCREST
+  10   0    95   0 TDMWAVE
    2   0    36   0 TFRCT
+  10   3     9   0 THERCSSH
    0   0   197   1 THFLX
    0   3    12   0 THICK
    0   6    10   0 THUNC
@@ -1055,10 +1367,13 @@
    0  18     7   0 TIACIP
    0  18     8   0 TIACRP
   10   3   251   1 TIDE
+   0   7    20   0 TIIDEX
    0   1   206   1 TIPD
    0  19    11   0 TKE
    0   1    90   0 TKMFLX
+   0  19    42   0 TLBHEIGHT
    0  17     4   0 TLGTFD
+   0  19    43   0 TLTHEIGH
    0   6     9   0 TMAXT
    0   0     4   0 TMAX
    0   0     5   0 TMIN
@@ -1073,12 +1388,15 @@
    0  19   197   1 TORPROB
    0   7     4   0 TOTALX
    0   1    80   0 TOTCON
+   0  21     2   0 TOTENG
    0  18    13   0 TOTLWD
    0  14     0   0 TOZNE
    0  14   197   1 TOZ
    2   0    37   0 TPERCT
    0  19   219   1 TPFI
    0   1    52   0 TPRATE
+   0   2   231   1 TPWDIR
+   0   2   232   1 TPWSPD
    0  20    13   0 TRANHH
    2   3    12   0 TRANSO
    2   0   230   1 TRANS
@@ -1087,11 +1405,13 @@
    0   2   225   1 TRWSPD
    0   0   200   1 TSD1D
    0 191     0   0 TSEC
+   0   2    58   0 TSFCSTR
    4   6     0   0 TSI
    0   3   199   1 TSLSA
    0   1    50   0 TSNOWP
    0   1   241   1 TSNOW
    2   0     2   0 TSOIL
+   0   1   128   0 TSPRATE
    0   1    57   0 TSRATE
    0   1    53   0 TSRWE
    0  19   203   1 TSTMC
@@ -1116,8 +1436,11 @@
   10   3   205   1 TWLWAV
    0  20    58   0 TYAAL
    0  20    57   0 TYABA
+   2   0    58   0 TYPHIVEG
+   2   0    57   0 TYPLOVEG
    0   3    16   0 U-GWD
    0   3   194   1 U-GWD
+   0   4    57   0 UBALBDIRG
   10   1   194   1 UBARO
    0   3    31   0 UCLSPRS
    0   1   120   0 UCSCIW
@@ -1135,8 +1458,10 @@
    0   5     4   0 ULWRF
    0   5   193   1 ULWRF
    0   3    27   0 UMFLX
+   2   4    22   0 UNBURNAREA
    0   1   118   0 UNCSH
    0   2    45   0 UNDIV
+   0   2    56   0 UNWIND
   10   1     2   0 UOGRD
    1   0    14   0 UPAPCP
    1   0    15   0 UPASM
@@ -1144,17 +1469,28 @@
    0   7   197   1 UPHL
    2   3     2   0 UPLSM
    2   3     1   0 UPLST
+   2   0    44   0 UPSAREA
+  10   4    27   0 UPWWVEL
+   2   6     0   0 URBCOVER
    3   1   192   1 USCT
+  10   0    90   0 USMFO
   10   0    21   0 USSD
    0   2    27   0 USTM
    0   2   194   1 USTM
    0   4    53   0 USWRFCS
    0   4     8   0 USWRF
    0   4   193   1 USWRF
+  20   0     0   0 UTHCIDX
    0   4   205   1 UTRF
+   0   4    15   0 UUVEARTH
+   0   4    55   0 UVALBDIF
+   0   4    58   0 UVALBDIRI
+   0   4    56   0 UVALBDIR
+   0   4    59   0 UVBDIRV
    0   4    50   0 UVIUCS
    0   4    51   0 UVI
    0   7   196   1 UVI
+   0   2    52   0 UWINDSTR
    0   3    17   0 V-GWD
    0   3   195   1 V-GWD
    0  19   232   1 VAFTD
@@ -1167,6 +1503,8 @@
    0  14   195   1 VDFOZ
    0   2   208   1 VDFUA
    0   2   209   1 VDFVA
+   0   2    59   0 VDIV
+  10   4    28   0 VEDDYDIF
    0   2   204   1 VEDH
    2   0   232   1 VEGMAX
    2   0   231   1 VEGMIN
@@ -1193,6 +1531,7 @@
    0  19     0   0 VIS
    0   1    92   0 VKMFLX
    0  20    52   0 VMXR
+   0   2    57   0 VNWIND
   10   1     3   0 VOGRD
    3   4     4   0 VOLACDEM
    3   4     7   0 VOLACDEN
@@ -1211,6 +1550,9 @@
    0   0    15   0 VPTMP
    0   2   224   1 VRATE
    3   1   193   1 VSCT
+  10   4    33   0 VSFC
+  10   4    32   0 VSFSW
+  10   0    91   0 VSMFO
    2   0    25   0 VSOILM
    2   3    16   0 VSOSM
   10   0    22   0 VSSD
@@ -1222,18 +1564,29 @@
    0   2    16   0 VVCSH
    0   2     8   0 VVEL
    2   0    27   0 VWILTM
+   0   2    53   0 VWINDSTR
    0   2    25   0 VWSH
    0   2   192   1 VWSH
+   2   6     4   0 VZAFRAC
   10   4    17   0 WATDENA
+   0  21     4   0 WATENTHALPY
   10   4    16   0 WATERDEN
    2   0   236   1 WATERSA
   10   4    20   0 WATPDENA
   10   4    19   0 WATPDEN
   10   4    18   0 WATPTEMP
    2   0     5   0 WATR
+  10   0    79   0 WAVEFDIR
+  10   0    78   0 WAVEFMAG
   10   0    62   0 WAVEFREW
+   4   5     3   0 WAVELGTH
+  10   0    87   0 WAVEMSLC
+  10   0    77   0 WAVESPSK
+  10   0    92   0 WAVETEFO
+  10   0    73   0 WCAPFRAC
    2   0   223   1 WCCONV
    0   0    13   0 WCF
+  10   4    22   0 WCHEATC
    2   0   221   1 WCINC
    2   0   226   1 WCUFLX
    2   0   227   1 WCVFLX
@@ -1247,9 +1600,15 @@
   10   0    58   0 WDWTSWEL
    0   1    13   0 WEASD
   10   0    42   0 WESP
+  20   0     2   0 WETBGTMP
+   0   0    32   0 WETBPT
    0   0    27   0 WETBT
+   2   0    45   0 WETCOV
    0  18    11   0 WETDEP
+   0   0   206   1 WETGLBT
+   2   0    46   0 WETTYPE
    0  20    75   0 WFIREFLX
+   2   4    26   0 WFIREPOT
    1   2     2   0 WFRACT
   10   0    59   0 WFWFSWEL
   10   0    60   0 WFWSSWEL
@@ -1259,13 +1618,18 @@
    2   0    26   0 WILT
    2   0   201   1 WILT
    0   2    33   0 WINDF
+  20   3     2   0 WINDPCAP
+  20   3     3   0 WINDPPROD
    0  19   199   1 WINDPROB
+   0   2    49   0 WINDSTR
    3   1    19   0 WINDS
    0   2     1   0 WIND
    0  19    25   0 WIWW
   10   0   193   1 WLENG
    0  20     9   0 WLSMFLX
    0   2    19   0 WMIXE
+   0   3    45   0 WOBT
+   2   0    42   0 WRDRATE
    2   0    33   0 WROD
   10   0   192   1 WSTP
   10   0    18   0 WSTR
@@ -1285,8 +1649,15 @@
    2   0   224   1 WVUFLX
    2   0   225   1 WVVFLX
   10   0    14   0 WWSDIR
+  10   3     7   0 XCOMPSS
+  10   4    25   0 XCOMPWV
+  10   2    24   0 XICE
    4   6     1   0 XLONG
-   0   3    26   0 XPRES
    4   8     0   0 XRAYRAD
    4   6     2   0 XSHRT
+  10   3    16   0 XSURFWVEL
+  10   3     8   0 YCOMPSS
+  10   4    26   0 YCOMPWV
+  10   2    25   0 YICE
+  10   3    17   0 YSURFVWEL
   10   2    10   0 ZVCICEP


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updating params_grib2_tbl_new for the latest UPP used in RRFS.

## TESTS CONDUCTED: 
UPP tests on Jet and Hera for the RRFS_NA_3km system have been using this new params_grib2_tbl_new for at least a month.  It needs to be updated in the realtime to enable output of some fields in RRFS-A.

### Machines/Platforms:
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

