### PR TITLE
Turn off FAA grib2 output for ensemble forecasts

### DIFF
--- a/scripts/exrrfs_run_prdgen.sh
+++ b/scripts/exrrfs_run_prdgen.sh
@@ -364,10 +364,13 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
     fi
 
     #-- Upscale & subset FAA requested information
+    #-- FAA grib2 output is not generated for ensemble forecasts
     
      # echo "$USHrrfs/rrfs_prdgen_faa_subpiece.sh $fhr $cyc $prslev $natlev $ififip $aviati ${COMOUT} &" >> $DATAprdgen/poescript_faa_${fhr}
 
-    ${USHrrfs}/rrfs_prdgen_faa_subpiece.sh $fhr $cyc $prslev $natlev $ififip $aviati ${COMOUT} ${USHrrfs}
+    if [ ${DO_ENSFCST} = "FALSE" ]; then
+      ${USHrrfs}/rrfs_prdgen_faa_subpiece.sh $fhr $cyc $prslev $natlev $ififip $aviati ${COMOUT} ${USHrrfs}
+    fi
 
   else
     echo "WARNING: this grid is not ready for parallel prdgen: ${PREDEF_GRID_NAME}"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- @MatthewPyle-NOAA confirmed that the special FAA grib2 output does not need to be generated for ensemble forecasts and should be turned off.  In this PR, logic is added to the run_prdgen ex-script such that the FAA product generation is only called when DO_ENSFCST is set to false.
- These changes have not been tested, but I just added them as local changes to the real-time RRFS_A parallel on Dogwood.  So let's make sure they are working before merging this PR.
- We will also want to add these changes to the production/RRFS.v1 branch.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
None yet but will be tested in the real-time system.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #333 
