### PR TITLE
[production/RRFS.v1] Modify run directory structure for fire weather workflow

### DIFF
--- a/parm/FV3LAM_wflow_firewx.xml
+++ b/parm/FV3LAM_wflow_firewx.xml
@@ -36,6 +36,8 @@ Workflow task names.
 
 <!ENTITY TAG                  "{{ tag }}">
 <!ENTITY NET                  "{{ net }}">
+<!ENTITY RUN                  "{{ run }}">
+<!ENTITY envir                "{{ envir }}">
 
 <!--
 Flags that specify whether to run the preprocessing tasks.
@@ -63,7 +65,7 @@ Directories and files.
 <!ENTITY JOBSdir                  "{{ jobsdir }}">
 <!ENTITY LOG_BASEDIR              "{{ log_basedir }}">
 <!ENTITY LOGDIR                   "{{ log_basedir }}/rrfsfw.@Y@m@d/@H">
-<!ENTITY CYCLE_BASEDIR            "{{ cycle_basedir }}">
+<!ENTITY DATAROOT                 "{{ dataroot }}">
 <!ENTITY NWGES_BASEDIR            "{{ nwges_basedir }}">
 <!ENTITY GLOBAL_VAR_DEFNS_FP      "{{ global_var_defns_fp }}">
 <!ENTITY LOAD_MODULES_RUN_TASK_FP "{{ load_modules_run_task_fp }}">
@@ -199,6 +201,8 @@ MODULES_RUN_TASK_FP script.
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
   </task>
 {%- endif %}
@@ -219,6 +223,8 @@ MODULES_RUN_TASK_FP script.
     <join><cyclestr>&LOGDIR;/&MAKE_OROG_TN;.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <taskdep task="&MAKE_GRID_TN;"/>
@@ -243,6 +249,8 @@ MODULES_RUN_TASK_FP script.
     <join><cyclestr>&LOGDIR;/&MAKE_SFC_CLIMO_TN;.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -272,11 +280,13 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
     <envar><name>EXTRN_MDL_NAME</name><value>{{ extrn_mdl_name_ics }}</value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
     <envar><name>GEFS_INPUT_SUBDIR</name><value>#subdirGE#</value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -309,7 +319,8 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>EXTRN_MDL_NAME</name><value>{{ extrn_mdl_name_lbcs }}</value></envar>
       <envar><name>BOUNDARY_LEN</name><value>{{ boundary_len_hrs }}</value></envar>
@@ -317,6 +328,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GEFS_INPUT_SUBDIR</name><value>#subdirGE#</value></envar>
       <envar><name>bcgrp</name><value>#bcgrp#</value></envar>
       <envar><name>bcgrpnum</name><value>{{ boundary_proc_group_num }}</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
         <and>
@@ -349,11 +361,13 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
     <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>RESTART_HRS</name><value><cyclestr>0</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -383,18 +397,19 @@ MODULES_RUN_TASK_FP script.
         <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
         <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
         <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-        <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
         <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
         <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
         <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
         <envar><name>fhr</name><value>#fhr#</value></envar>
         <envar><name>TMMARK</name><value>tm00</value></envar>
+        <envar><name>KEEPDATA</name><value>YES</value></envar>
 
         <dependency>
           <or>
             <taskdep task="&RUN_FCST_TN;"/>
             <and>
-              <datadep age="05:00"><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H{{ slash_ensmem_subdir }}/fcst_fv3lam/log.atm.f#fhr#</cyclestr></datadep>
+              <datadep age="05:00"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
             </and>
           </or>
         </dependency>
@@ -422,12 +437,13 @@ MODULES_RUN_TASK_FP script.
         <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
         <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
         <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-        <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
         <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
         <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
         <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
         <envar><name>fhr</name><value>#fhr#</value></envar>
         <envar><name>TMMARK</name><value>tm00</value></envar>
+        <envar><name>KEEPDATA</name><value>YES</value></envar>
 
         <dependency>
           <taskdep task="&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr#"/>

--- a/parm/FV3LAM_wflow_nonDA.xml
+++ b/parm/FV3LAM_wflow_nonDA.xml
@@ -36,6 +36,8 @@ Workflow task names.
 
 <!ENTITY TAG                  "{{ tag }}">
 <!ENTITY NET                  "{{ net }}">
+<!ENTITY RUN                  "{{ run }}">
+<!ENTITY envir                "{{ envir }}">
 
 <!--
 Flags that specify whether to run the preprocessing tasks.
@@ -423,7 +425,7 @@ MODULES_RUN_TASK_FP script.
           <or>
             <taskdep task="&RUN_FCST_TN;"/>
             <and>
-              <datadep age="05:00"><cyclestr>&DATAROOT;/rrfs_forecast_prod_@H/log.atm.f#fhr#</cyclestr></datadep>
+              <datadep age="05:00"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
             </and>
           </or>
         </dependency>

--- a/scripts/exrrfs_run_post.sh
+++ b/scripts/exrrfs_run_post.sh
@@ -400,11 +400,6 @@ if [ -f AVIATI.GrbF${post_fhr} ]; then
   wgrib2 AVIATI.GrbF${post_fhr} -set center 7 -grib ${bgavi} >>$pgmout 2>>errfile
 fi
 
-# Keep latlons_corners.txt file for RRFS fire weather grid
-#if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
-#  cp ${postprd_dir}/${fhr}/latlons_corners.txt.f${fhr} ${postprd_dir}
-#fi
-
 #
 #-----------------------------------------------------------------------
 #   clean forecast netcdf files for saving space

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -227,6 +227,7 @@ settings="\
   'tag': ${TAG}
   'net': ${NET}
   'run': ${RUN}
+  'envir': ${envir}
 #
 # Number of nodes to use for each task.
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the run directory structure changes that were added with PR #348 have been applied to the RRFS fire weather nest workflow.  This involves changes to the xml file, and some fire weather specific logic is removed from exrrfs_run_post.sh.  In addition, $RUN and $envir are added to the workflow xml templates for firewx and non-DA.  They are needed for specifying the correct location of the new run directories as data dependencies.
- The next PR for modifying the run directory structure will be for the DA workflow tasks.  I will try and break it up into several smaller PRs instead of one huge PR.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
These changes were tested with the fire-weather workflow and the non-DA engineering test (netcdf).

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [x] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Continues to address issue #237 