### PR TITLE
[production/RRFS.v1] Modify run directory structure for DA processing tasks

### DIFF
--- a/jobs/JRRFS_PROCESS_BUFR
+++ b/jobs/JRRFS_PROCESS_BUFR
@@ -1,52 +1,40 @@
 #!/bin/bash
 
-#
 #-----------------------------------------------------------------------
-#
-# This J-JOB script runs the preprocess of BUFR files
-#
+# RRFS BUFR Preprocessing
 #-----------------------------------------------------------------------
-#
-#
+
 #-----------------------------------------------------------------------
-#
 # Source the variable definitions file and the bash utility functions.
-#
 #-----------------------------------------------------------------------
-#
+
 . ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/source_util_funcs.sh
 
 date
 export PS4='+ $SECONDS + '
-#
+
 #-----------------------------------------------------------------------
-#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { save_shell_opts; set -u -x; } > /dev/null 2>&1
-#
+
 #-----------------------------------------------------------------------
-#
 # Get the full path to the file in which this script/function is located 
 # (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
 # which the file is located (scrfunc_dir).
-#
 #-----------------------------------------------------------------------
-#
+
 scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
-#
+
 #-----------------------------------------------------------------------
-#
 # Print message indicating entry into script.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Entering script:  \"${scrfunc_fn}\"
@@ -55,75 +43,73 @@ In directory:     \"${scrfunc_dir}\"
 This is the J-job script for the task that runs a BUFR preprocess for 
 the specified cycle.
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Create the working directory under the cycle directory.
-#
+# Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
-#
+
+export pid=${pid:-$$}
+export envir=${envir:-prod}
+export RUN=${RUN:-rrfs}
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export workdir=${CYCLE_DIR}/process_bufr_spinup
+  export jobid=${RUN}_process_bufr_spinup_${envir}_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    workdir=${CYCLE_DIR}/process_bufr_spinup_enkf
+    export jobid=${RUN}_process_bufr_spinup_enkf_${envir}_${cyc}
   fi
 else
-  export workdir=${CYCLE_DIR}/process_bufr
+  export jobid=${RUN}_process_bufr_${envir}_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    workdir=${CYCLE_DIR}/process_bufr_enkf
+    export jobid=${RUN}_process_bufr_enkf_${envir}_${cyc}
   fi
 fi
-rm -fr ${workdir}
-mkdir -p ${workdir}
-cd ${workdir}
-#
+
+export DATA=${DATAROOT}/${jobid}
+mkdir -p ${DATA}
+cd ${DATA}
+
+export pgmout="${DATA}/OUTPUT.$$"
+
 #-----------------------------------------------------------------------
-#
-# create COMOUT directory
-#
+# Define COM directories
 #-----------------------------------------------------------------------
-#
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup"
 else
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}"
 fi
 mkdir -p "${COMOUT}"
-#
-#-----------------------------------------------------------------------
-#
-# Call the ex-script for this J-job.
-#
-#-----------------------------------------------------------------------
-#
-export pgmout="${workdir}/OUTPUT.$$"
 env
 
-$SCRIPTSdir/exrrfs_process_bufr.sh \
-  CYCLE_DIR="${CYCLE_DIR}"
+#-----------------------------------------------------------------------
+# Execute the script.
+#-----------------------------------------------------------------------
+
+$SCRIPTSdir/exrrfs_process_bufr.sh
 export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then
   cat $pgmout
 fi
-#
+
+if [ "${KEEPDATA}" = "NO" ]; then
+  rm -rf ${DATA}
+fi
+
 #-----------------------------------------------------------------------
-#
 # Print exit message.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Exiting script:  \"${scrfunc_fn}\"
 In directory:    \"${scrfunc_dir}\"
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
 # Restore the shell options saved at the beginning of this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { restore_shell_opts; } > /dev/null 2>&1
 

--- a/jobs/JRRFS_PROCESS_GLMFED
+++ b/jobs/JRRFS_PROCESS_GLMFED
@@ -1,80 +1,66 @@
 #!/bin/bash
 
+#-----------------------------------------------------------------------
+# RRFS GLM Gridded Lightning Data Preprocessing
+#-----------------------------------------------------------------------
 
-#
 #-----------------------------------------------------------------------
-#
-# This J-JOB script runs the GLM gridded lightning data preprocess 
-#      for the FV3-LAM model
-#
-#-----------------------------------------------------------------------
-#
-
-#
-#-----------------------------------------------------------------------
-#
 # Source the variable definitions file and the bash utility functions.
-#
 #-----------------------------------------------------------------------
-#
+
 . ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/source_util_funcs.sh
-#
+
 #-----------------------------------------------------------------------
-#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { save_shell_opts; set -u -x; } > /dev/null 2>&1
-#
+
 #-----------------------------------------------------------------------
-#
 # Get the full path to the file in which this script/function is located 
 # (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
 # which the file is located (scrfunc_dir).
-#
 #-----------------------------------------------------------------------
-#
+
 scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
-#
+
 #-----------------------------------------------------------------------
-#
 # Print message indicating entry into script.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Entering script:  \"${scrfunc_fn}\"
 In directory:     \"${scrfunc_dir}\"
 
 This is the J-job script for the task that runs a GLM FED 
-preprocess with FV3 for the specified cycle.
+preprocess with RRFS for the specified cycle.
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Create the working directory under the cycle directory.
-#
+# Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
-#
+
+export pid=${pid:-$$}
+export envir=${envir:-prod}
+export RUN=${RUN:-rrfs}
+
 if [ ${CYCLE_TYPE} == "spinup" ]; then
-  workdir=${CYCLE_DIR}/process_glmfed_spinup
+  export jobid=${RUN}_process_glmfed_spinup_${envir}_${cyc}
 else
-  workdir=${CYCLE_DIR}/process_glmfed
+  export jobid=${RUN}_process_glmfed_${envir}_${cyc}
 fi
 if [ ${DO_ENSEMBLE} = TRUE ]; then
-  workdir=${CYCLE_DIR}/process_glmfed_enkf
+  export jobid=${RUN}_process_glmfed_enkf_${envir}_${cyc}
 fi
 
-rm -fr ${workdir}
-mkdir_vrfy -p ${workdir}
-
-cd ${workdir}
+export DATA=${DATAROOT}/${jobid}
+mkdir -p ${DATA}
+cd ${DATA}
 
 export FIX_GSI=$FIX_GSI
 export OBS_EAST=$GLMFED_EAST_ROOT
@@ -83,36 +69,37 @@ export RRFSE_NWGES_BASEDIR=$NWGES
 export NUM_ENS_MEMBERS=$NUM_ENS_MEMBERS
 export DA_CYCLE_INTERV=$DA_CYCLE_INTERV
 export MODE=$GLMFED_DATA_MODE
-#
+
+export pgmout="${DATA}/OUTPUT.$$"
+env
+
 #-----------------------------------------------------------------------
-#
-# Call the ex-script for this J-job and pass to it the necessary varia-
-# bles.
-#
+# Execute the script.
 #-----------------------------------------------------------------------
-#
-python -u ${SCRIPTSdir}/exrrfs_process_glmfed.py \
-#
+
+python -u ${SCRIPTSdir}/exrrfs_process_glmfed.py
+
+if [ -e "$pgmout" ]; then
+  cat $pgmout
+fi
+
+if [ "${KEEPDATA}" = "NO" ]; then
+  rm -rf ${DATA}
+fi
+
 #-----------------------------------------------------------------------
-#
-#-----------------------------------------------------------------------
-#
 # Print exit message.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Exiting script:  \"${scrfunc_fn}\"
 In directory:    \"${scrfunc_dir}\"
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Restore the shell options saved at the beginning of this script/func-
-# tion.
-#
+# Restore the shell options saved at the beginning of this script/funcion.
 #-----------------------------------------------------------------------
-#
+
 { restore_shell_opts; } > /dev/null 2>&1
 

--- a/jobs/JRRFS_PROCESS_GLMFED
+++ b/jobs/JRRFS_PROCESS_GLMFED
@@ -78,6 +78,7 @@ env
 #-----------------------------------------------------------------------
 
 python -u ${SCRIPTSdir}/exrrfs_process_glmfed.py
+export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then
   cat $pgmout

--- a/jobs/JRRFS_PROCESS_LIGHTNING
+++ b/jobs/JRRFS_PROCESS_LIGHTNING
@@ -1,52 +1,40 @@
 #!/bin/bash
 
-#
 #-----------------------------------------------------------------------
-#
-# This J-JOB script runs the NetCDF ligthning observation preprocess 
-#
+# RRFS Lightning Observation Preprocessing
 #-----------------------------------------------------------------------
-#
-#
+
 #-----------------------------------------------------------------------
-#
 # Source the variable definitions file and the bash utility functions.
-#
 #-----------------------------------------------------------------------
-#
+
 . ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/source_util_funcs.sh
 
 date
 export PS4='+ $SECONDS + '
-#
+
 #-----------------------------------------------------------------------
-#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { save_shell_opts; set -u -x; } > /dev/null 2>&1
-#
+
 #-----------------------------------------------------------------------
-#
 # Get the full path to the file in which this script/function is located 
 # (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
 # which the file is located (scrfunc_dir).
-#
 #-----------------------------------------------------------------------
-#
+
 scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
-#
+
 #-----------------------------------------------------------------------
-#
 # Print message indicating entry into script.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Entering script:  \"${scrfunc_fn}\"
@@ -55,69 +43,67 @@ In directory:     \"${scrfunc_dir}\"
 This is the J-job script for the task that runs a lightning preprocess for 
 the specified cycle.
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Create the working directory under the cycle directory.
-#
+# Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
-#
+
+export pid=${pid:-$$}
+export envir=${envir:-prod}
+export RUN=${RUN:-rrfs}
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export workdir=${CYCLE_DIR}/process_lightning_spinup
+  export jobid=${RUN}_process_lightning_spinup_${envir}_${cyc}
 else
-  export workdir=${CYCLE_DIR}/process_lightning
+  export jobid=${RUN}_process_lightning_${envir}_${cyc}
 fi
-rm -fr ${workdir}
-mkdir -p ${workdir}
-cd ${workdir}
-#
+
+export DATA=${DATAROOT}/${jobid}
+mkdir -p ${DATA}
+cd ${DATA}
+
+export pgmout="${DATA}/OUTPUT.$$"
+
 #-----------------------------------------------------------------------
-#
-# create COMOUT directory
-#
+# Define COM directories
 #-----------------------------------------------------------------------
-#
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup${SLASH_ENSMEM_SUBDIR}"
 else
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/$cyc/ensmean"
 fi
 mkdir -p "${COMOUT}"
-#
-#-----------------------------------------------------------------------
-#
-# Call the ex-script for this J-job.
-#
-#-----------------------------------------------------------------------
-#
-export pgmout="${workdir}/OUTPUT.$$"
 env
 
-$SCRIPTSdir/exrrfs_process_lightning.sh \
-  CYCLE_DIR="${CYCLE_DIR}"
+#-----------------------------------------------------------------------
+# Execute the script.
+#-----------------------------------------------------------------------
+
+$SCRIPTSdir/exrrfs_process_lightning.sh
 export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then
   cat $pgmout
 fi
-#
+
+if [ "${KEEPDATA}" = "NO" ]; then
+  rm -rf ${DATA}
+fi
+
 #-----------------------------------------------------------------------
-#
 # Print exit message.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Exiting script:  \"${scrfunc_fn}\"
 In directory:    \"${scrfunc_dir}\"
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
 # Restore the shell options saved at the beginning of this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { restore_shell_opts; } > /dev/null 2>&1
 

--- a/jobs/JRRFS_PROCESS_PM
+++ b/jobs/JRRFS_PROCESS_PM
@@ -1,52 +1,40 @@
 #!/bin/bash
 
-#
 #-----------------------------------------------------------------------
-#
-# This J-JOB script runs the preprocess of PM observation
-#
+# RRFS PM Preprocessing
 #-----------------------------------------------------------------------
-#
-#
+
 #-----------------------------------------------------------------------
-#
 # Source the variable definitions file and the bash utility functions.
-#
 #-----------------------------------------------------------------------
-#
+
 . ${GLOBAL_VAR_DEFNS_FP}
 . $USHDIR/source_util_funcs.sh
 
 date
 export PS4='+ $SECONDS + '
-#
+
 #-----------------------------------------------------------------------
-#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { save_shell_opts; set -u -x; } > /dev/null 2>&1
-#
+
 #-----------------------------------------------------------------------
-#
 # Get the full path to the file in which this script/function is located 
 # (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
 # which the file is located (scrfunc_dir).
-#
 #-----------------------------------------------------------------------
-#
+
 scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
-#
+
 #-----------------------------------------------------------------------
-#
 # Print message indicating entry into script.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Entering script:  \"${scrfunc_fn}\"
@@ -55,76 +43,73 @@ In directory:     \"${scrfunc_dir}\"
 This is the J-job script for the task that runs a PM preprocess for 
 the specified cycle.
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Create the working directory under the cycle directory.
-#
+# Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
-#
+
+export pid=${pid:-$$}
+export envir=${envir:-prod}
+export RUN=${RUN:-rrfs}
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export workdir=${CYCLE_DIR}/process_pm_spinup
+  export jobid=${RUN}_process_pm_spinup_${envir}_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    workdir=${CYCLE_DIR}/process_pm_spinup_enkf
+    export jobid=${RUN}_process_pm_spinup_enkf_${envir}_${cyc}
   fi
 else
-  export workdir=${CYCLE_DIR}/process_pm
+  export jobid=${RUN}_process_pm_${envir}_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    workdir=${CYCLE_DIR}/process_pm_enkf
+    export jobid=${RUN}_process_pm_enkf_${envir}_${cyc}
   fi
 fi
-rm -fr ${workdir}
-mkdir -p ${workdir}
-cd ${workdir}
-#
+
+export DATA=${DATAROOT}/${jobid}
+mkdir -p ${DATA}
+cd ${DATA}
+
+export pgmout="${DATA}/OUTPUT.$$"
+
 #-----------------------------------------------------------------------
-#
-# create COMOUT directory
-#
+# Define COM directories
 #-----------------------------------------------------------------------
-#
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup"
 else
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}"
 fi
 mkdir -p "${COMOUT}"
-#
-#-----------------------------------------------------------------------
-#
-# Call the ex-script for this J-job.
-#
-#-----------------------------------------------------------------------
-#
-export pgmout="${workdir}/OUTPUT.$$"
 env
 
-$SCRIPTSDIR/exrrfs_process_pm.sh \
-  CYCLE_DIR="${CYCLE_DIR}"
+#-----------------------------------------------------------------------
+# Execute the script.
+#-----------------------------------------------------------------------
+
+$SCRIPTSDIR/exrrfs_process_pm.sh
 export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then
   cat $pgmout
 fi
-#
+
+if [ "${KEEPDATA}" = "NO" ]; then
+  rm -rf ${DATA}
+fi
+
 #-----------------------------------------------------------------------
-#
 # Print exit message.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Exiting script:  \"${scrfunc_fn}\"
 In directory:    \"${scrfunc_dir}\"
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Restore the shell options saved at the beginning of this script/func-
-# tion.
-#
+# Restore the shell options saved at the beginning of this script/function.
 #-----------------------------------------------------------------------
-#
+
 { restore_shell_opts; } > /dev/null 2>&1
 

--- a/jobs/JRRFS_PROCESS_RADARREF
+++ b/jobs/JRRFS_PROCESS_RADARREF
@@ -1,133 +1,119 @@
 #!/bin/bash
 
-#
 #-----------------------------------------------------------------------
-#
-# This J-JOB script runs the radar reflectivity preprocess 
-#
+# RRFS Radar Reflectivity Preprocessing
 #-----------------------------------------------------------------------
-#
 
-#
 #-----------------------------------------------------------------------
-#
 # Source the variable definitions file and the bash utility functions.
-#
 #-----------------------------------------------------------------------
-#
+
 . ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/source_util_funcs.sh
 
 date
 export PS4='+ $SECONDS + '
-#
+
 #-----------------------------------------------------------------------
-#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { save_shell_opts; set -u -x; } > /dev/null 2>&1
-#
+
 #-----------------------------------------------------------------------
-#
 # Get the full path to the file in which this script/function is located 
 # (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
 # which the file is located (scrfunc_dir).
-#
 #-----------------------------------------------------------------------
-#
+
 scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
-#
+
 #-----------------------------------------------------------------------
-#
 # Print message indicating entry into script.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Entering script:  \"${scrfunc_fn}\"
 In directory:     \"${scrfunc_dir}\"
 
 This is the J-job script for the task that runs a radar reflectivity 
-preprocess with FV3 for the specified cycle.
+preprocess with RRFS for the specified cycle.
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Create the working directory under the cycle directory.
-#
+# Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
-#
+
+export pid=${pid:-$$}
+export envir=${envir:-prod}
+export RUN=${RUN:-rrfs}
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export workdir=${CYCLE_DIR}/process_radarref_spinup
+  export jobid=${RUN}_process_radarref_spinup_${envir}_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    workdir=${CYCLE_DIR}/process_radarref_spinup_enkf
+    export jobid=${RUN}_process_radarref_spinup_enkf_${envir}_${cyc}
   fi
 else
-  export workdir=${CYCLE_DIR}/process_radarref
+  export jobid=${RUN}_process_radarref_${envir}_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    workdir=${CYCLE_DIR}/process_radarref_enkf
+    export jobid=${RUN}_process_radarref_enkf_${envir}_${cyc}
   fi
 fi
-rm -fr ${workdir}
-mkdir -p ${workdir}
-cd ${workdir}
-#
+
+export DATA=${DATAROOT}/${jobid}
+mkdir -p ${DATA}
+cd ${DATA}
+
 export gridspec_dir=${NWGES_BASEDIR}/grid_spec
-#
+
+export pgmout="${DATA}/OUTPUT.$$"
+
 #-----------------------------------------------------------------------
-#
-# create COMOUT directory
-#
+# Define COM directories
 #-----------------------------------------------------------------------
-#
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup"
 else
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}"
 fi
 mkdir -p "${COMOUT}"
-#
-#-----------------------------------------------------------------------
-#
-# Call the ex-script for this J-job.
-#
-#-----------------------------------------------------------------------
-#
-export pgmout="${workdir}/OUTPUT.$$"
 env
 
+#-----------------------------------------------------------------------
+# Execute the script.
+#-----------------------------------------------------------------------
+
 $SCRIPTSdir/exrrfs_process_radarref.sh \
-  CYCLE_DIR="${CYCLE_DIR}" cycle_type="${CYCLE_TYPE}" \
+  cycle_type="${CYCLE_TYPE}" \
   RADAR_REF_THINNING="${RADAR_REF_THINNING}"
 export err=$?; err_chk
 
 if [ -e "$pgmout" ]; then
   cat $pgmout
 fi
-#
+
+if [ "${KEEPDATA}" = "NO" ]; then
+  rm -rf ${DATA}
+fi
+
 #-----------------------------------------------------------------------
-#
 # Print exit message.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Exiting script:  \"${scrfunc_fn}\"
 In directory:    \"${scrfunc_dir}\"
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
 # Restore the shell options saved at the beginning of this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { restore_shell_opts; } > /dev/null 2>&1
 

--- a/jobs/JRRFS_PROCESS_SMOKE
+++ b/jobs/JRRFS_PROCESS_SMOKE
@@ -1,50 +1,40 @@
 #!/bin/bash
 #
 #-----------------------------------------------------------------------
-#
-# This J-JOB script runs the smoke preprocessing
-#
+# RRFS Smoke Preprocessing
 #-----------------------------------------------------------------------
-#
+
 #-----------------------------------------------------------------------
-#
 # Source the variable definitions file and the bash utility functions.
-#
 #-----------------------------------------------------------------------
-#
+
 . ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/source_util_funcs.sh
 
 date
 export PS4='+ $SECONDS + '
-#
+
 #-----------------------------------------------------------------------
-#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { save_shell_opts; set -u -x; } > /dev/null 2>&1
-#
+
 #-----------------------------------------------------------------------
-#
 # Get the full path to the file in which this script/function is located 
 # (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
 # which the file is located (scrfunc_dir).
-#
 #-----------------------------------------------------------------------
-#
+
 scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
-#
+
 #-----------------------------------------------------------------------
-#
 # Print message indicating entry into script.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Entering script:  \"${scrfunc_fn}\"
@@ -53,53 +43,58 @@ In directory:     \"${scrfunc_dir}\"
 This is the J-job script for the task that runs the smoke preprocessing
 for the specified cycle.
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
-# Create the working directory under the cycle directory.
-#
+# Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
-#
+
+export pid=${pid:-$$}
+export envir=${envir:-prod}
+export RUN=${RUN:-rrfs}
+
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export workdir=${CYCLE_DIR}/process_smoke_spinup
+  export jobid=${RUN}_process_smoke_spinup_${envir}_${cyc}
 else
-  export workdir=${CYCLE_DIR}/process_smoke
+  export jobid=${RUN}_process_smoke_${envir}_${cyc}
 fi
-rm -fr ${workdir}
-mkdir -p ${workdir}
-cd ${workdir}
+
+export DATA=${DATAROOT}/${jobid}
+mkdir -p ${DATA}
+cd ${DATA}
 
 export gridspec_dir=${NWGES_BASEDIR}/grid_spec
-#
-#-----------------------------------------------------------------------
-#
-# Call the ex-script for this J-job.
-#
-#-----------------------------------------------------------------------
-#
-export pgmout="${workdir}/OUTPUT.$$"
+
+export pgmout="${DATA}/OUTPUT.$$"
 env
+
+#-----------------------------------------------------------------------
+# Execute the script.
+#-----------------------------------------------------------------------
 
 $SCRIPTSdir/exrrfs_process_smoke.sh
 export err=$?; err_chk
-#
+
+if [ -e "$pgmout" ]; then
+  cat $pgmout
+fi
+
+if [ "${KEEPDATA}" = "NO" ]; then
+  rm -rf ${DATA}
+fi
+
 #-----------------------------------------------------------------------
-#
 # Print exit message.
-#
 #-----------------------------------------------------------------------
-#
+
 print_info_msg "
 ========================================================================
 Exiting script:  \"${scrfunc_fn}\"
 In directory:    \"${scrfunc_dir}\"
 ========================================================================"
-#
+
 #-----------------------------------------------------------------------
-#
 # Restore the shell options saved at the beginning of this script/function.
-#
 #-----------------------------------------------------------------------
-#
+
 { restore_shell_opts; } > /dev/null 2>&1
 

--- a/jobs/JRRFS_RUN_POST
+++ b/jobs/JRRFS_RUN_POST
@@ -66,7 +66,6 @@ mkdir -p ${DATA}
 cd ${DATA}
 
 export pgmout="${DATA}/OUTPUT.$$"
-env
 
 #-----------------------------------------------------------------------
 # Define COM directories
@@ -77,6 +76,7 @@ if [ ${CYCLE_TYPE} = "spinup" ]; then
   COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup${SLASH_ENSMEM_SUBDIR}"
 fi
 mkdir -p "${COMOUT}"
+env
 
 #-----------------------------------------------------------------------
 # Execute the script.

--- a/jobs/JRRFS_RUN_PRDGEN
+++ b/jobs/JRRFS_RUN_PRDGEN
@@ -64,7 +64,6 @@ mkdir -p ${DATA}
 cd ${DATA}
 
 export pgmout="${DATA}/OUTPUT.$$"
-env
 
 #-----------------------------------------------------------------------
 # Define COM directories
@@ -75,6 +74,7 @@ if [ "${CYCLE_TYPE}" = "spinup" ]; then
   COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup${SLASH_ENSMEM_SUBDIR}"
 fi
 mkdir -p "${COMOUT}"
+env
 
 #-----------------------------------------------------------------------
 # Execute the script.

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -72,8 +72,10 @@ Workflow task names.
 <!ENTITY RUN_SMOKE_TN         "run_proc_smoke">
 <!ENTITY RUN_PM_TN            "run_proc_pm">
 
-<!ENTITY TAG  "{{ tag }}">
-<!ENTITY NET  "{{ net }}">
+<!ENTITY TAG   "{{ tag }}">
+<!ENTITY NET   "{{ net }}">
+<!ENTITY RUN   "{{ run }}">
+<!ENTITY envir "{{ envir }}">
 
 <!--
 Flags that determine whether to run the specific tasks.
@@ -98,6 +100,7 @@ Directories and files.
 <!ENTITY LOGDIR                   "{{ log_basedir }}/{{ run }}.@Y@m@d/@H">
 <!ENTITY OBSPATH                  "{{ obspath }}">
 <!ENTITY OBSPATH_PM               "{{ obspath_pm }}">
+<!ENTITY DATAROOT                 "{{ dataroot }}">
 <!ENTITY CYCLE_BASEDIR            "{{ cycle_basedir }}">
 <!ENTITY NWGES_BASEDIR            "{{ nwges_basedir }}">
 <!ENTITY ENSCTRL_CYCLE_BASEDIR    "{{ ensctrl_cycle_basedir }}">
@@ -389,6 +392,9 @@ MODULES_RUN_TASK_FP script.
     <join><cyclestr>&LOGDIR;/&MAKE_GRID_TN;.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
   </task>
 {% endif %}
@@ -409,6 +415,8 @@ MODULES_RUN_TASK_FP script.
     <join><cyclestr>&LOGDIR;/&MAKE_OROG_TN;.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <or>
@@ -436,6 +444,8 @@ MODULES_RUN_TASK_FP script.
     <join><cyclestr>&LOGDIR;/&MAKE_SFC_CLIMO_TN;.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -489,12 +499,13 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>#type#</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>NWGES_DIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -531,12 +542,13 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>#type#</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>NWGES_DIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -570,12 +582,13 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>#type#</cyclestr></value></envar>
     <envar><name>RADAR_REF_THINNING</name><value>{{ radar_ref_thinning }}</value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
         
     <dependency>
       <and>
@@ -607,10 +620,11 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>#type#</cyclestr></value></envar>
     <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -643,10 +657,11 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>#type#</cyclestr></value></envar>
     <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>PREP_MODEL</name><value>0</value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
         <timedep><cyclestr offset="&START_TIME_PROC_GLMFED;">@Y@m@d@H@M00</cyclestr></timedep>
@@ -677,10 +692,11 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>#type#</cyclestr></value></envar>
     <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -736,7 +752,8 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
     <envar><name>FG_ROOT</name><value><cyclestr>&FG_ROOT;</cyclestr></value></envar>
     <envar><name>EXTRN_MDL_NAME</name><value>{{ extrn_mdl_name_ics }}</value></envar>
@@ -745,6 +762,7 @@ MODULES_RUN_TASK_FP script.
     <envar><name>WRF_MEM_NAME</name><value>#memNameWRF#</value></envar>
     <envar><name>GDASENKF_INPUT_SUBDIR</name><value>#subdirGDAS#</value></envar>
     <envar><name>GDAS_MEM_NAME</name><value>#memNameGDAS#</value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -911,7 +929,8 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
     <envar><name>EXTRN_MDL_NAME</name><value>{{ extrn_mdl_name_lbcs }}</value></envar>
     <envar><name>BOUNDARY_LEN</name><value>{{ boundary_len_hrs }}</value></envar>
@@ -921,6 +940,7 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GDAS_MEM_NAME</name><value>#memNameGDAS#</value></envar>
     <envar><name>bcgrp</name><value>#bcgrp#</value></envar>
     <envar><name>bcgrpnum</name><value>{{ boundary_proc_group_num }}</value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
       <and>
@@ -1151,14 +1171,16 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
     <envar><name>HH</name><value><cyclestr>@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
     <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
     <envar><name>CYCLE_SUBTYPE</name><value><cyclestr>ensinit</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>RESTART_HRS</name><value><cyclestr>0</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
         <and>   
@@ -1956,12 +1978,14 @@ MODULES_RUN_TASK_FP script.
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
     <envar><name>HH</name><value><cyclestr>@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
     <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>RESTART_HRS</name><value><cyclestr>1</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
   
     <dependency>
       {%- if do_dacycle and do_refl2tten and do_nonvar_cldanal%}
@@ -2076,7 +2100,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
       <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
@@ -2084,9 +2108,10 @@ MODULES_RUN_TASK_FP script.
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
-        <datadep age="02:30"><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H{{ slash_ensmem_subdir }}/fcst_fv3lam_spinup/log.atm.f#fhr#</cyclestr></datadep>
+        <datadep age="02:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
       </dependency>
 
     </task>
@@ -2110,13 +2135,14 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
       <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>CYCLE_TYPE</name><value><cyclestr>spinup</cyclestr></value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
         <taskdep task="&RUN_POST_TN;_spinup{{ uscore_ensmem_name }}_f#fhr#"/>
@@ -3029,12 +3055,14 @@ MODULES_RUN_TASK_FP script.
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
     <envar><name>HH</name><value><cyclestr>@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
     <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>prod</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>RESTART_HRS</name><value><cyclestr>{{ restart_hrs_prod }}</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
   
     <dependency>
       {%- if do_ensfcst %}
@@ -3112,12 +3140,14 @@ MODULES_RUN_TASK_FP script.
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
     <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
     <envar><name>HH</name><value><cyclestr>@H</cyclestr></value></envar>
-    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+    <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
     <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
     <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
     <envar><name>CYCLE_TYPE</name><value><cyclestr>prod</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value>&NWGES_BASEDIR;</value></envar>
     <envar><name>RESTART_HRS</name><value><cyclestr>{{ restart_hrs_prod_long }}</cyclestr></value></envar>
+    <envar><name>KEEPDATA</name><value>YES</value></envar>
   
     <dependency>
       {%- if do_dacycle and do_refl2tten and do_nonvar_cldanal%}
@@ -3294,16 +3324,17 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
       <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
-          <datadep age="01:30"><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H{{ slash_ensmem_subdir }}/fcst_fv3lam/log.atm.f#fhr#</cyclestr></datadep>
+          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
       </dependency>
 
     </task>
@@ -3342,16 +3373,17 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
       <envar><name>NWGES_DIR</name><value><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
       <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
-         <datadep age="01:30"><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H{{ slash_ensmem_subdir }}/fcst_fv3lam/log.atm.f#fhr#</cyclestr></datadep>
+         <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
       </dependency>
 
     </task>
@@ -3394,12 +3426,13 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value>&DATAROOT;</value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
       <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
         <taskdep task="&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr#"/>
@@ -3442,12 +3475,13 @@ MODULES_RUN_TASK_FP script.
       <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
       <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
       <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
-      <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+      <envar><name>DATAROOT</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
       <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
       <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
       <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
       <envar><name>fhr</name><value>#fhr#</value></envar>
       <envar><name>TMMARK</name><value>tm00</value></envar>
+      <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
         <taskdep task="&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr#_long"/>

--- a/scripts/exrrfs_process_bufr.sh
+++ b/scripts/exrrfs_process_bufr.sh
@@ -43,30 +43,8 @@ Entering script:  \"${scrfunc_fn}\"
 In directory:     \"${scrfunc_dir}\"
 
 This is the ex-script for the task that runs bufr (cloud, metar, lightning) preprocess
-with FV3 for the specified cycle.
+with RRFS for the specified cycle.
 ========================================================================"
-#
-#-----------------------------------------------------------------------
-#
-# Specify the set of valid argument names for this script/function.  
-# Then process the arguments provided to this script/function (which 
-# should consist of a set of name-value pairs of the form arg1="value1",
-# etc).
-#
-#-----------------------------------------------------------------------
-#
-valid_args=( "CYCLE_DIR" )
-process_args valid_args "$@"
-#
-#-----------------------------------------------------------------------
-#
-# For debugging purposes, print out values of arguments passed to this
-# script.  Note that these will be printed out only if VERBOSE is set to
-# TRUE.
-#
-#-----------------------------------------------------------------------
-#
-print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
@@ -296,7 +274,7 @@ EOF
 #
 #-----------------------------------------------------------------------
 #
-# Run the process for NASA LaRc cloud  bufr file 
+# Run the process for NASA LaRc cloud bufr file 
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exrrfs_process_lightning.sh
+++ b/scripts/exrrfs_process_lightning.sh
@@ -43,30 +43,8 @@ Entering script:  \"${scrfunc_fn}\"
 In directory:     \"${scrfunc_dir}\"
 
 This is the ex-script for the task that runs lightning preprocess
-with FV3 for the specified cycle.
+with RRFS for the specified cycle.
 ========================================================================"
-#
-#-----------------------------------------------------------------------
-#
-# Specify the set of valid argument names for this script/function.  
-# Then process the arguments provided to this script/function (which 
-# should consist of a set of name-value pairs of the form arg1="value1",
-# etc).
-#
-#-----------------------------------------------------------------------
-#
-valid_args=( "CYCLE_DIR" )
-process_args valid_args "$@"
-#
-#-----------------------------------------------------------------------
-#
-# For debugging purposes, print out values of arguments passed to this
-# script.  Note that these will be printed out only if VERBOSE is set to
-# TRUE.
-#
-#-----------------------------------------------------------------------
-#
-print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exrrfs_process_pm.sh
+++ b/scripts/exrrfs_process_pm.sh
@@ -48,28 +48,6 @@ pm) preprocess for the specified cycle.
 #
 #-----------------------------------------------------------------------
 #
-# Specify the set of valid argument names for this script/function.  
-# Then process the arguments provided to this script/function (which 
-# should consist of a set of name-value pairs of the form arg1="value1",
-# etc).
-#
-#-----------------------------------------------------------------------
-#
-valid_args=( "CYCLE_DIR" )
-process_args valid_args "$@"
-#
-#-----------------------------------------------------------------------
-#
-# For debugging purposes, print out values of arguments passed to this
-# script.  Note that these will be printed out only if VERBOSE is set to
-# TRUE.
-#
-#-----------------------------------------------------------------------
-#
-print_input_args valid_args
-#
-#-----------------------------------------------------------------------
-#
 # Set environment.
 #
 #-----------------------------------------------------------------------

--- a/scripts/exrrfs_process_radarref.sh
+++ b/scripts/exrrfs_process_radarref.sh
@@ -43,7 +43,7 @@ Entering script:  \"${scrfunc_fn}\"
 In directory:     \"${scrfunc_dir}\"
 
 This is the ex-script for the task that runs radar reflectivity preprocess
-with FV3 for the specified cycle.
+with RRFS for the specified cycle.
 ========================================================================"
 #
 #-----------------------------------------------------------------------
@@ -55,7 +55,7 @@ with FV3 for the specified cycle.
 #
 #-----------------------------------------------------------------------
 #
-valid_args=( "CYCLE_DIR" "cycle_type" "RADAR_REF_THINNING" )
+valid_args=( "cycle_type" "RADAR_REF_THINNING" )
 process_args valid_args "$@"
 #
 #-----------------------------------------------------------------------
@@ -163,8 +163,8 @@ export pgm="process_NSSL_mosaic.exe"
 
 for bigmin in ${RADARREFL_TIMELEVEL[@]}; do
   bigmin=$( printf %2.2i $bigmin )
-  mkdir ${workdir}/${bigmin}
-  cd ${workdir}/${bigmin}
+  mkdir ${DATA}/${bigmin}
+  cd ${DATA}/${bigmin}
 
   fixdir=$FIX_GSI/
   fixgriddir=$FIX_GSI/${PREDEF_GRID_NAME}

--- a/scripts/exrrfs_process_smoke.sh
+++ b/scripts/exrrfs_process_smoke.sh
@@ -87,16 +87,16 @@ do
    timestr=`date +%Y%m%d%H -d "$previous_day + $i hours"`
    intp_fname=${PREDEF_GRID_NAME}_intp_${timestr}00_${timestr}59.nc
    if  [ -f ${rave_nwges_dir}/${intp_fname} ]; then
-      ${LN} -sf ${rave_nwges_dir}/${intp_fname} ${workdir}/${intp_fname}
-      echo "${rave_nwges_dir}/${intp_fname} interoplated file available to reuse"
+      ${LN} -sf ${rave_nwges_dir}/${intp_fname} ${DATA}/${intp_fname}
+      echo "${rave_nwges_dir}/${intp_fname} interpolated file available to reuse"
    else
-      echo "${rave_nwges_dir}/${intp_fname} interoplated file non available to reuse"  
+      echo "${rave_nwges_dir}/${intp_fname} interpolated file not available to reuse"  
    fi
 done
 
 #-----------------------------------------------------------------------
 #
-#  link RAVE data to work directory  $workdir
+#  link RAVE data to work directory  $DATA
 #
 #-----------------------------------------------------------------------
 
@@ -104,7 +104,7 @@ previous_2day=`${DATE} '+%C%y%m%d' -d "$current_day-2 days"`
 YYYYMMDDm1=${previous_day:0:8}
 YYYYMMDDm2=${previous_2day:0:8}
 if [ -d ${FIRE_RAVE_DIR}/${YYYYMMDDm1}/rave ]; then
-   fire_rave_dir_work=${workdir}
+   fire_rave_dir_work=${DATA}
    ln -s ${FIRE_RAVE_DIR}/${YYYYMMDD}/rave/RAVE-HrlyEmiss-3km_* ${fire_rave_dir_work}/.
    ln -s ${FIRE_RAVE_DIR}/${YYYYMMDDm1}/rave/RAVE-HrlyEmiss-3km_* ${fire_rave_dir_work}/.
    ln -s ${FIRE_RAVE_DIR}/${YYYYMMDDm2}/rave/RAVE-HrlyEmiss-3km_* ${fire_rave_dir_work}/.
@@ -115,21 +115,21 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Call the ex-script for this J-job.
+# Call the Python script for this job.
 #
 #-----------------------------------------------------------------------
 #
 python -u  ${USHdir}/generate_fire_emissions.py \
   "${FIX_SMOKE_DUST}/${PREDEF_GRID_NAME}" \
   "${fire_rave_dir_work}" \
-  "${workdir}" \
+  "${DATA}" \
   "${PREDEF_GRID_NAME}" \
   "${EBB_DCYCLE}" 
 export err=$?; err_chk
 
 #Copy the the hourly, interpolated RAVE data to $rave_nwges_dir so it
 # is maintained there for future cycles.
-for file in ${workdir}/*; do
+for file in ${DATA}/*; do
    filename=$(basename "$file")
    if [ ! -f ${rave_nwges_dir}/${filename} ]; then
       cp ${file} ${rave_nwges_dir}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR for modifying the run directory structure is building off of PRs #348 and #356.  The process_bufr, process_smoke, process_radarref, process_lightning, process_pm, and process_glmfed tasks have been updated to use `${RUN}_${task}_${envir}_${cyc}` run directories.  After this PR, there will be one final PR to update all the remaining workflow tasks.
- The CYCLE_DIR (now DATAROOT) input argument has been removed from the process_pm, process_lightning, process_radarref, and process_bufr ex-scripts.  This input argument is not necessary because CYCLE_DIR is not referenced anywhere in these ex-scripts.
- Several miscellaneous fixes to typos/comments in the J-jobs/ex-scripts are also included (e.g. changing FV3 to RRFS).
- Note that CYCLE_DIR is still defined in FV3LAM_wflow.xml.  It hasn't been removed yet because the other tasks which need to be updated (e.g. JRRFS_RUN_ANALYSIS) still use it.
- One thing that I have not done yet and will need to do is update the NWGES directory structure, which also uses date/cycle-specific directories.  I think this change can be done separately from updating the run directory structure.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- The process_bufr, process_radarref, and process_smoke tasks were successfully tested with these changes.  The process_pm, process_lightning, and process_glmfed tasks have not been tested because they are not turned on with the DA engineering test, but they will be tested with a full RRFS system test once all the other workflow tasks have been updated.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Continues to address issue #237 