### PR TITLE
Updating the UPP hash

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 8bc3fc9
+hash = 14d6613
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This updates the hash for UPP code.  With this hash, the latest refinements to the GSL "exp1" ceiling diagnostic are used.  

Note that this PR simply changes the "exp1" ceiling formulation.  It does not affect the formulation or the availability of the other ceiling-related fields in RRFS (i.e., the legacy field and the "exp2" field).

## TESTS CONDUCTED: 
This change has been tested in a RRFS retro (1–3 Feb 2022; CONUS domain) on Hera. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
The associated PR for UPP can be viewed at https://github.com/NOAA-EMC/UPP/pull/947