### PR TITLE
Updates UPP hash to get 15 minute product changes

### DIFF
--- a/fix/upp/postxconfig-NT-rrfs_subh.txt
+++ b/fix/upp/postxconfig-NT-rrfs_subh.txt
@@ -1,5 +1,5 @@
 1
-40
+41
 PRSLEV
 32769
 ncep_nco
@@ -9,7 +9,7 @@ fcst
 oper
 fcst
 fcst
-hour
+minute
 nws_ncep
 rrfs
 complex_packing_spatial_diff
@@ -312,9 +312,9 @@ surface
 ?
 ?
 ?
-725
-GSD_ACM_SNOD_ON_SURFACE
-?
+525
+BUCKET1_ASNOW_ON_SURFACE
+bucket Var density snowfall on surface
 1
 tmpl4_8
 ASNOW
@@ -349,9 +349,9 @@ surface
 ?
 ?
 ?
-417
-CACM_APCP_ON_SURFACE
-?
+526
+BUCKET1_APCP_ON_SURFACE
+bucket Total precipitation on surface
 1
 tmpl4_8
 APCP
@@ -386,9 +386,9 @@ surface
 ?
 ?
 ?
-1004
-ACM_SNOWFALL_ON_SURFACE
-?
+528
+BUCKET1_TSNOWP_ON_SURFACE
+bucket snow on surface
 1
 tmpl4_8
 TSNOWP
@@ -423,12 +423,49 @@ surface
 ?
 ?
 ?
-782
-ACM_FRAIN_ON_SURFACE
-?
+527
+BUCKET1_FRZR_ON_SURFACE
+bucket Freezing rain on surface
 1
 tmpl4_8
 FRZR
+NCEP
+ACM
+surface
+0
+?
+0
+?
+?
+0
+?
+0
+?
+?
+?
+0
+0.0
+0
+0.0
+?
+0
+0.0
+0
+0.0
+1
+6.0
+0
+0
+0
+?
+?
+?
+530
+BUCKET1_GRAUPEL_ON_SURFACE
+bucket graupel precipitation on surface
+1
+tmpl4_8
+FROZR
 NCEP
 ACM
 surface

--- a/fix/upp/rrfs_post_avblflds.xml
+++ b/fix/upp/rrfs_post_avblflds.xml
@@ -4509,6 +4509,17 @@
     </param>
 
     <param>
+       <post_avblfldidx>525</post_avblfldidx>
+       <shortname>BUCKET1_ASNOW_ON_SURFACE</shortname>
+       <longname>bucket Var density snowfall on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ASNOW</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
        <post_avblfldidx>526</post_avblfldidx>
        <shortname>BUCKET1_APCP_ON_SURFACE</shortname>
        <longname>bucket Total precipitation on surface</longname>
@@ -4521,10 +4532,11 @@
 
     <param>
        <post_avblfldidx>527</post_avblfldidx>
-       <shortname>BUCKET1_ACPCP_ON_SURFACE</shortname>
-       <longname>bucket Convective precipitation on surface</longname>
+       <shortname>BUCKET1_FRZR_ON_SURFACE</shortname>
+       <longname>bucket Freezing rain on surface</longname>
        <pdstmpl>tmpl4_8</pdstmpl>
-       <pname>ACPCP</pname>
+       <pname>FRZR</pname>
+       <table_info>NCEP</table_info>
        <stats_proc>ACM</stats_proc>
        <fixed_sfc1_type>surface</fixed_sfc1_type>
        <scale>4.0</scale>
@@ -4532,10 +4544,10 @@
 
     <param>
        <post_avblfldidx>528</post_avblfldidx>
-       <shortname>BUCKET1_NCPCP_ON_SURFACE</shortname>
-       <longname>bucket Large scale precipitation on surface</longname>
+       <shortname>BUCKET1_TSNOWP_ON_SURFACE</shortname>
+       <longname>bucket snow on surface</longname>
        <pdstmpl>tmpl4_8</pdstmpl>
-       <pname>NCPCP</pname>
+       <pname>TSNOWP</pname>
        <stats_proc>ACM</stats_proc>
        <fixed_sfc1_type>surface</fixed_sfc1_type>
        <scale>4.0</scale>

--- a/fix/upp/rrfs_postcntrl_subh.xml
+++ b/fix/upp/rrfs_postcntrl_subh.xml
@@ -11,7 +11,7 @@
     <prod_status>oper</prod_status>
     <data_type>fcst</data_type>
     <gen_proc_type>fcst</gen_proc_type>
-    <time_range_unit>hour</time_range_unit>
+    <time_range_unit>minute</time_range_unit>
     <orig_center>nws_ncep</orig_center>
     <gen_proc>rrfs</gen_proc>
     <packing_method>complex_packing_spatial_diff</packing_method>
@@ -71,25 +71,29 @@
        </param>
 
        <param>
-       <shortname>GSD_ACM_SNOD_ON_SURFACE</shortname>
+       <shortname>BUCKET1_ASNOW_ON_SURFACE</shortname>
        <scale>9.0</scale>
        </param>
 
        <param>
-       <shortname>CACM_APCP_ON_SURFACE</shortname>
-       <pname>APCP</pname>
+       <shortname>BUCKET1_APCP_ON_SURFACE</shortname>
        <scale>-4.0</scale>
        </param>
 
        <param>
-       <shortname>ACM_SNOWFALL_ON_SURFACE</shortname>
+       <shortname>BUCKET1_TSNOWP_ON_SURFACE</shortname>
        <scale>6.0</scale>
        </param>
 
-        <param>
-        <shortname>ACM_FRAIN_ON_SURFACE</shortname>
-        <scale>6.0</scale>
-        </param>
+       <param>
+       <shortname>BUCKET1_FRZR_ON_SURFACE</shortname>
+       <scale>6.0</scale>
+       </param>
+
+       <param>
+       <shortname>BUCKET1_GRAUPEL_ON_SURFACE</shortname>
+       <scale>6.0</scale>
+       </param>
 
        <param>
        <shortname>GSD_INST_CRAIN_ON_SURFACE</shortname>

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 14d6613
+hash = b0e574b
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Simple change to update the UPP hash

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- Confirmed that this update checked out the proper hash from UPP, and also confirmed (after updating the config files) that the time labeling problems and zero QPF in first hour or so seen previously is fixed with these changes.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test - but tweaked to generate 15 minute output and use the special RRFS control files
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Hopefully fixes the issue(s) mentioned in #304

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
Bringing in UPP changes courtesy of @EricJames-NOAA 
