### PR TITLE
Add compiling option for parallel restart

### DIFF
--- a/modulefiles/build_wcoss2_intel.lua
+++ b/modulefiles/build_wcoss2_intel.lua
@@ -30,7 +30,7 @@ load(pathJoin("mapl", os.getenv("mapl_ver")))
 load(pathJoin("bacio", os.getenv("bacio_ver")))
 load(pathJoin("crtm", os.getenv("crtm_ver")))
 load(pathJoin("g2", os.getenv("g2_ver")))
-load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver")))
+--load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver")))
 load(pathJoin("ip", os.getenv("ip_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 
@@ -49,6 +49,9 @@ load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 
 prepend_path("MODULEPATH", os.getenv("modulepath_scotch"))
 load(pathJoin("scotch", os.getenv("scotch_ver")))
+
+prepend_path("MODULEPATH","/u/wen.meng/noscrub/ncep_post/g2tmpl/libs/modulefiles/compiler/intel/19.1.3.304")
+load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver")))
 
 setenv("FMS_ROOT","/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/lib/fms.2024.01/build")
 setenv("FMS_VERSION","2024.01")

--- a/modulefiles/build_wcoss2_intel.lua
+++ b/modulefiles/build_wcoss2_intel.lua
@@ -50,9 +50,11 @@ load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 prepend_path("MODULEPATH", os.getenv("modulepath_scotch"))
 load(pathJoin("scotch", os.getenv("scotch_ver")))
 
-setenv("FMS_ROOT","/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/lib/fms.ParallelStartup")
---setenv("FMS_ROOT","/u/daniel.kokron/fms.ParallelStartup")
-setenv("FMS_VERSION","2023.02")
+setenv("FMS_ROOT","/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/lib/fms.2024.01/build")
+setenv("FMS_VERSION","2024.01")
+
+--setenv("FMS_ROOT","/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/lib/fms.ParallelStartup")
+--setenv("FMS_VERSION","2023.02")
 
 setenv("CMAKE_C_COMPILER","cc")
 setenv("CMAKE_CXX_COMPILER","CC")

--- a/scripts/exrrfs_run_prdgen.sh
+++ b/scripts/exrrfs_run_prdgen.sh
@@ -300,9 +300,9 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
     sed -n -e '501,$p' $DATAprdgen/prslevf${fhr}.txt >& $DATAprdgen/hi_pr_2.txt
 
     # Create script to execute production generation tasks in parallel using CFP
-    echo "#!/bin/bash" > $DATAprdgen/poescript_${fhr}
-    echo "export DATA=${DATAprdgen}" >> $DATAprdgen/poescript_${fhr}
-    echo "export COMOUT=${COMOUT}" >> $DATAprdgen/poescript_${fhr}
+#    echo "#!/bin/bash" > $DATAprdgen/poescript_${fhr}
+#    echo "export DATA=${DATAprdgen}" >> $DATAprdgen/poescript_${fhr}
+#    echo "export COMOUT=${COMOUT}" >> $DATAprdgen/poescript_${fhr}
 
     tasks=(4 4 2 2)
     domains=(conus ak hi pr)
@@ -317,7 +317,7 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
       count=$count+1
     done
 
-    echo "wait" >> $DATAprdgen/poescript_${fhr}
+#    echo "wait" >> $DATAprdgen/poescript_${fhr}
     chmod 775 $DATAprdgen/poescript_${fhr}
 
     # Execute the script
@@ -376,7 +376,7 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
     echo "WARNING: this grid is not ready for parallel prdgen: ${PREDEF_GRID_NAME}"
   fi
 
-  rm -fr $DATAprdgen
+#  rm -fr $DATAprdgen
   rm -f $DATA/*.t${cyc}z.*.f${fhr}.*.grib2
 
 elif [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -125,6 +125,8 @@ option(BUILD_RRFS_UTILS "Build RRFS utilities" ON)
 option(BUILD_AQM_UTILS "Build AQM utilities" ON)
 option(BUILD_IFI "Build IFI in UPP" ON)
 option(BUILD_GTG "Build IFI in GTG" ON)
+option(ENABLE_PARALLELRESTART "Build PARALLEL RESTART" OFF)
+option(ENABLE_RRFS_WAR "Build PARALLEL RESTART" ON)
 
 message(STATUS "BUILD_UFS ............... ${BUILD_UFS}")
 message(STATUS "BUILD_UFS_UTILS ......... ${BUILD_UFS_UTILS}")
@@ -135,6 +137,8 @@ message(STATUS "BUILD_NEXUS ............. ${BUILD_NEXUS}")
 message(STATUS "BUILD_AQM_UTILS ......... ${BUILD_AQM_UTILS}")
 message(STATUS "BUILD_IFI ............... ${BUILD_IFI}")
 message(STATUS "BUILD_GTG ............... ${BUILD_GTG}")
+message(STATUS "ENABLE_PARALLELRESTART ............... ${ENABLE_PARALLELRESTART}")
+message(STATUS "ENABLE_RRFS_WAR ...................... ${ENABLE_RRFS_WAR}")
 
 # Set dependency of ufs weather model only for coupled model
 if (NOT APP)
@@ -179,8 +183,8 @@ if (BUILD_UFS)
     "-DNETCDF_DIR=$ENV{NETCDF}"
     "-D32BIT=ON"
     "-DCCPP_32BIT=ON"
-    "-DENABLE_PARALLELRESTART=NO"
-    "-DENABLE_RRFS_WAR=NO"
+    "-DENABLE_PARALLELRESTART=${ENABLE_PARALLELRESTART}"
+    "-DENABLE_RRFS_WAR=${ENABLE_RRFS_WAR}"
     "-DMPI=ON" 
     "-DFASTER=ON"
     "-DINLINE_POST=ON"

--- a/sorc/app_build.sh
+++ b/sorc/app_build.sh
@@ -29,6 +29,8 @@ OPTIONS
       build without GTG (default is true, this option turns it off)
   --noifi
       build without IFI (default is true, this option turns it off)
+  --paralstart
+      build module with enabled parallel start (default is off)
   --extrn
       check out external components
   --continue
@@ -85,6 +87,7 @@ Settings:
   EXTRN=${EXTRN}
   NOGTG=${NOGTG}
   NOIFI=${NOIFI}
+  PARALSTART=${PARALSTART}
   REMOVE=${REMOVE}
   CONTINUE=${CONTINUE}
   BUILD_TYPE=${BUILD_TYPE}
@@ -125,6 +128,7 @@ BUILD_JOBS=4
 EXTRN=false
 NOGTG=false
 NOIFI=false
+PARALSTART=false
 REMOVE=false
 CONTINUE=false
 VERBOSE=false
@@ -171,6 +175,7 @@ while :; do
     --extrn=?*|--extrn=) usage_error "$1 argument ignored." ;;
     --nogtg) NOGTG=true ;;
     --noifi) NOIFI=true ;;
+    --paralstart) PARALSTART=true ;;
     --remove) REMOVE=true ;;
     --remove=?*|--remove=) usage_error "$1 argument ignored." ;;
     --continue) CONTINUE=true ;;
@@ -251,6 +256,12 @@ if [ "${NOGTG}" = true ]; then
 fi
 if [ "${NOIFI}" = true ]; then
   BUILD_IFI="off"
+fi
+ENABLE_PARALLELRESTART="off"
+ENABLE_RRFS_WAR="on"
+if [ "${PARALSTART}" = true ]; then
+  ENABLE_PARALLELRESTART="on"
+  ENABLE_RRFS_WAR="off"
 fi
 
 # check out external components specified in External.cfg
@@ -412,7 +423,9 @@ CMAKE_SETTINGS="\
  -DBUILD_NEXUS=${BUILD_NEXUS}\
  -DBUILD_AQM_UTILS=${BUILD_AQM_UTILS}\
  -DBUILD_IFI=${BUILD_IFI}\
- -DBUILD_GTG=${BUILD_GTG}"
+ -DBUILD_GTG=${BUILD_GTG}\
+ -DENABLE_PARALLELRESTART=${ENABLE_PARALLELRESTART}\
+ -DENABLE_RRFS_WAR=${ENABLE_RRFS_WAR}"
 
 if [ ! -z "${APPLICATION}" ]; then
   CMAKE_SETTINGS="${CMAKE_SETTINGS} -DAPP=${APPLICATION}"


### PR DESCRIPTION
1) Add option in compiling process to turn on/off parallel restart.
    The defaulte is to turn off the parallel restart function in model.
2) Use model g2tmpl/1.2.0 from UPP modulefiles (set up by Meng Wen) for WCOSS2.
3) Update prdgen based on the current RRFS_A v0.9.1


## TESTS CONDUCTED: 
### Machines/Platforms:
- WCOSS2
  - [ x] Cactus/Dogwood
### Test cases: 
- [x] RRFS_A:
