### PR TITLE
Update modules

### DIFF
--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -16,6 +16,11 @@ load(pathJoin("wgrib2", os.getenv("wgrib2_ver") or "2.0.8"))
 prepend_path("MODULEPATH", "/scratch2/BMC/rtrr/gge/lua")
 load("prod_util/2.0.15")
 
+unload("fms/2023.02.01")
+unload("g2tmpl/1.10.2")
+setenv("g2tmpl_ROOT","/scratch1/BMC/wrfruc/mhu/rrfs/lib/g2tmpl/install")
+setenv("FMS_ROOT","/scratch1/BMC/wrfruc/mhu/rrfs/lib/fms.2024.01/build")
+
 setenv("CMAKE_C_COMPILER","mpiicc")
 setenv("CMAKE_CXX_COMPILER","mpiicpc")
 setenv("CMAKE_Fortran_COMPILER","mpiifort")

--- a/modulefiles/build_jet_intel.lua
+++ b/modulefiles/build_jet_intel.lua
@@ -18,6 +18,10 @@ prepend_path("MODULEPATH", "/lfs4/BMC/nrtrr/FIX_EXEC_MODULE/lua")
 load("prod_util/2.0.15")
 
 unload("python/3.10.8")
+unload("fms/2023.02.01")
+unload("g2tmpl/1.10.2")
+setenv("g2tmpl_ROOT","/mnt/lfs4/BMC/rtwbl/mhu/rrfs/lib/g2tmpl/install")
+setenv("FMS_ROOT","/mnt/lfs4/BMC/rtwbl/mhu/rrfs/lib/fms.2024.01/build")
 
 setenv("CMAKE_C_COMPILER","mpiicc")
 setenv("CMAKE_CXX_COMPILER","mpiicpc")


### PR DESCRIPTION
Update to use the following modules for compiling on Hera and Jet:
   fms.2024.01   : for new model code
   g2tmpl/1.12.0 : for UPP

Tested on Hera and Jet with retros.
