### PR TITLE
Appending the GRIB2 recod "CEIL:cloud ceiling" to the testbed files.

### DIFF
--- a/fix/upp/testbed_fields_bgdawp.txt
+++ b/fix/upp/testbed_fields_bgdawp.txt
@@ -23,6 +23,7 @@ WIND:10 m above ground:
 APCP:surface:
 CEIL:cloud base:
 HGT:cloud ceiling:
+CEIL:cloud ceiling:
 VIS:surface:
 CAPE:surface:
 CIN:surface:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Appending the GRIB2 record "CEIL:cloud ceiling" to the testbed files at the request of AWC.  This GRIB2 record provides an alternative ceiling diagnostic, supplementing the legacy ceiling diagnostic ("HGT:cloud ceiling").

## TESTS CONDUCTED: 
Using RRFS retro output on Hera (CONUS domain), the GRIB2 record successfully appears in the testbed files.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ x] DA engineering test
    - [x ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:
