### PR TITLE
Switch EnKF spinup cycle prep_cyc and prep_cyc_ensinit task name

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -1110,7 +1110,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&PREP_CYC_SPINUP_TN;{{ uscore_ensmem_name }}" cycledefs="spinupcyc" maxtries="{{ maxtries_run_prepstart }}">
+  <task name="&PREP_CYC_SPINUP_TN;_ensinit{{ uscore_ensmem_name }}" cycledefs="spinupcyc" maxtries="{{ maxtries_run_prepstart }}">
 
     &RSRV_DEFAULT;
     &WALL_LIMIT_PRE;
@@ -1122,8 +1122,8 @@ MODULES_RUN_TASK_FP script.
     <walltime>&WALLTIME_PREP_CYC;</walltime>
     &NODESIZE_ALL;
     &MEMO_PREP_CYC;
-    <jobname>&TAG;_&PREP_CYC_SPINUP_TN;{{ uscore_ensmem_name }}</jobname>
-    <join><cyclestr>&LOGDIR;/&PREP_CYC_SPINUP_TN;_&TAG;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
+    <jobname>&TAG;_&PREP_CYC_SPINUP_TN;_ensinit{{ uscore_ensmem_name }}</jobname>
+    <join><cyclestr>&LOGDIR;/&PREP_CYC_SPINUP_TN;_ensinit_&TAG;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
@@ -1224,7 +1224,7 @@ MODULES_RUN_TASK_FP script.
             <streq><left>{{ h }}</left><right><cyclestr>@H</cyclestr></right></streq>
            {%- endfor %}
           </or>   
-          <taskdep task="&PREP_CYC_SPINUP_TN;{{ uscore_ensmem_name }}"/>
+          <taskdep task="&PREP_CYC_SPINUP_TN;_ensinit{{ uscore_ensmem_name }}"/>
         </and>  
     </dependency>
 
@@ -1272,7 +1272,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&PREP_CYC_SPINUP_TN;_ensinit{{ uscore_ensmem_name }}" cycledefs="spinupcyc" maxtries="{{ maxtries_run_prepstart }}">
+  <task name="&PREP_CYC_SPINUP_TN;{{ uscore_ensmem_name }}" cycledefs="spinupcyc" maxtries="{{ maxtries_run_prepstart }}">
 
     &RSRV_DEFAULT;
     &WALL_LIMIT_PRE;
@@ -1283,8 +1283,8 @@ MODULES_RUN_TASK_FP script.
     <walltime>&WALLTIME_PREP_CYC;</walltime>
     &NODESIZE_ALL;
     &MEMO_PREP_CYC;
-    <jobname>&TAG;_&PREP_CYC_SPINUP_TN;_ensinit{{ uscore_ensmem_name }}</jobname>
-    <join><cyclestr>&LOGDIR;/&PREP_CYC_SPINUP_TN;_ensinit_&TAG;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
+    <jobname>&TAG;_&PREP_CYC_SPINUP_TN;{{ uscore_ensmem_name }}</jobname>
+    <join><cyclestr>&LOGDIR;/&PREP_CYC_SPINUP_TN;_&TAG;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
@@ -1345,7 +1345,7 @@ MODULES_RUN_TASK_FP script.
       <and>
         {%- for m in range(1, num_ens_members+1) %}
         {%- if do_ensinit %}
-          <taskdep task="&PREP_CYC_SPINUP_TN;_ensinit_mem{{ "%04d" % m }}"/>
+          <taskdep task="&PREP_CYC_SPINUP_TN;_mem{{ "%04d" % m }}"/>
         {%- endif %}
         {%- endfor %}
         <datadep age="00:00:00:05"><cyclestr>&ENSCTRL_COMOUT_DIR;/@H_spinup/nonvarcldanl_complete.txt</cyclestr></datadep>


### PR DESCRIPTION
Now, the EnKF DA spinup cycle will look like:
```
202202011800    prep_cyc_spinup_ensinit_mem0001                 
202202011800    run_fcst_ensinit_mem0001                   
202202011800    save_restart_ensinit_mem0001             
202202011800    prep_cyc_spinup_mem0001               
202202011800    run_fcst_spinup_mem0001               
202202011800    save_restart_spinup_mem0001_f001        
```

It works for cold start and blending cycles. This change is tested in v0.9.3 retro.