### PR TITLE
[dev-sci] Update model hash to latest version

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -13,7 +13,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 6431581
+hash = 8c126a7
 local_path = ufs-weather-model
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the hash of ufs-weather-model is updated to #8c126a7.  This version allows the code to build successfully on Hera.  These changes were just added to the production/RRFS.v1 branch as part of PR #422 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
No tests conducted - built code successfully using this hash with the production/RRFS.v1 branch (build process is the same).

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Does this fix the compiling issues mentioned in either #373 or #380 ?

## CONTRIBUTORS (optional): 
@MatthewPyle-NOAA 

