### PR TITLE
[production/RRFS.v1] Remove references to envir variable from J-jobs and ex-scripts

### DIFF
--- a/jobs/JRRFS_ANALYSIS_ENKF
+++ b/jobs/JRRFS_ANALYSIS_ENKF
@@ -49,15 +49,14 @@ specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export jobid=${RUN}_enkfupdt_${OB_TYPE}_spinup_${envir}_${cyc}
+  export jobid=${RUN}_enkfupdt_${OB_TYPE}_spinup_${cyc}
   export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}_spinup)}
 else
-  export jobid=${RUN}_enkfupdt_${OB_TYPE}_${envir}_${cyc}
+  export jobid=${RUN}_enkfupdt_${OB_TYPE}_${cyc}
   export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
 fi
 

--- a/jobs/JRRFS_ANALYSIS_GSI
+++ b/jobs/JRRFS_ANALYSIS_GSI
@@ -49,7 +49,6 @@ for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -68,16 +67,16 @@ if [[ ! -v OB_TYPE ]]; then
 fi
 if [ "${GSI_TYPE}" = "OBSERVER" ]; then
   if [ "${MEM_TYPE}" = "MEAN" ]; then
-    export jobid=${RUN}_observer_${workname}_ensmean_${envir}_${cyc}
+    export jobid=${RUN}_observer_${workname}_ensmean_${cyc}
     observer_nwges_dir="${GESROOT}/ensmean/observer_${workname}"
   else
 # GSI_TYPE = OBSERVER is only for EnKF (ensemble forecasts do not have ANALYSIS tasks)
-    export jobid=${RUN}_observer_${workname}_${mem_num}_${envir}_${cyc}
+    export jobid=${RUN}_observer_${workname}_${mem_num}_${cyc}
     observer_nwges_dir="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/observer_${workname}"
   fi
   mkdir -p ${observer_nwges_dir}
 else	# For control member, GSI_TYPE is always ANALYSIS
-  export jobid=${RUN}_analysis_${OB_TYPE}_${workname}_${envir}_${cyc}
+  export jobid=${RUN}_analysis_${OB_TYPE}_${workname}_${cyc}
 fi
 
 export DATA=${DATAROOT}/${jobid}

--- a/jobs/JRRFS_ANALYSIS_GSIDIAG
+++ b/jobs/JRRFS_ANALYSIS_GSIDIAG
@@ -49,7 +49,6 @@ the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
@@ -60,7 +59,7 @@ else
   workname="gsi"
 fi
 
-export jobid=${RUN}_analysis_conv_dbz_${workname}_${envir}_${cyc}
+export jobid=${RUN}_analysis_conv_dbz_${workname}_${cyc}
 export DATA="${DATAROOT}/${jobid}"
 rm -rf ${DATA}
 mkdir -p ${DATA}

--- a/jobs/JRRFS_ANALYSIS_NONVARCLD
+++ b/jobs/JRRFS_ANALYSIS_NONVARCLD
@@ -49,7 +49,6 @@ analysis with RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -60,12 +59,12 @@ else
   export workname="nonvar_cldanl"
 fi
 if [ ${MEM_TYPE} = "MEAN" ]; then
-  export jobid=${RUN}_${workname}_ensmean_${envir}_${cyc}
+  export jobid=${RUN}_${workname}_ensmean_${cyc}
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export jobid=${RUN}_${workname}_${mem_num}_${envir}_${cyc}
+    export jobid=${RUN}_${workname}_${mem_num}_${cyc}
   else
-    export jobid=${RUN}_${workname}_${envir}_${cyc}
+    export jobid=${RUN}_${workname}_${cyc}
   fi
 fi
 

--- a/jobs/JRRFS_BLEND_ICS
+++ b/jobs/JRRFS_BLEND_ICS
@@ -49,11 +49,10 @@ on the RRFS initial conditions.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
-export jobid=${RUN}_make_ics_${mem_num}_${envir}_${cyc}
+export jobid=${RUN}_make_ics_${mem_num}_${cyc}
 export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/ics"
 
 export DATA=${DATAROOT}/${jobid}

--- a/jobs/JRRFS_BUFRSND
+++ b/jobs/JRRFS_BUFRSND
@@ -49,7 +49,6 @@ on the output files corresponding to a specified forecast hour.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export fhr=01
@@ -59,13 +58,13 @@ export mem_num=m$(echo "${ENSMEM_INDX}")
 
 CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}"
+  export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}"
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast"
-  export jobid=${RUN}_bufrsnd_${mem_num}_${envir}_${cyc}
+  export jobid=${RUN}_bufrsnd_${mem_num}_${cyc}
 else
-  export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${envir}_${cyc}"
+  export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${cyc}"
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/forecast"
-  export jobid=${RUN}_bufrsnd_${envir}_${cyc}
+  export jobid=${RUN}_bufrsnd_${cyc}
 fi
 
 mkdir -p "${NWGES_DIR}/RESTART"

--- a/jobs/JRRFS_CALC_ENSMEAN
+++ b/jobs/JRRFS_CALC_ENSMEAN
@@ -49,16 +49,15 @@ RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
 
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export jobid=${RUN}_calc_ensmean_spinup_${envir}_${cyc}
+  export jobid=${RUN}_calc_ensmean_spinup_${cyc}
 else
-  export jobid=${RUN}_calc_ensmean_${envir}_${cyc}
+  export jobid=${RUN}_calc_ensmean_${cyc}
 fi
 
 export DATA=${DATAROOT}/${jobid}

--- a/jobs/JRRFS_FORECAST
+++ b/jobs/JRRFS_FORECAST
@@ -50,7 +50,6 @@ the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -60,18 +59,18 @@ export CYCLE_SUBTYPE=${CYCLE_SUBTYPE:-empty}
 
 if [ ${CYCLE_TYPE} == "spinup" ]; then
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then	# EnKF has spinup forecasts
-    export jobid=${RUN}_forecast_spinup_${mem_num}_${envir}_${cyc}
+    export jobid=${RUN}_forecast_spinup_${mem_num}_${cyc}
     if  [ ${CYCLE_SUBTYPE} == "ensinit" ]; then
-      export jobid=${RUN}_forecast_ensinit_${mem_num}_${envir}_${cyc}
+      export jobid=${RUN}_forecast_ensinit_${mem_num}_${cyc}
     fi
   else
-    export jobid=${RUN}_forecast_spinup_${envir}_${cyc}
+    export jobid=${RUN}_forecast_spinup_${cyc}
   fi
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export jobid=${RUN}_forecast_${mem_num}_${envir}_${cyc}
+    export jobid=${RUN}_forecast_${mem_num}_${cyc}
   else
-    export jobid=${RUN}_forecast_${envir}_${cyc}
+    export jobid=${RUN}_forecast_${cyc}
   fi
 fi
 

--- a/jobs/JRRFS_MAKE_GRID
+++ b/jobs/JRRFS_MAKE_GRID
@@ -48,9 +48,8 @@ This is the J-job script for the task that generates grid files.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
-export jobid=${RUN}_make_grid_${envir}_${cyc}
+export jobid=${RUN}_make_grid_${cyc}
 
 export DATA=${DATAROOT}/${jobid}
 mkdir -p ${DATA}

--- a/jobs/JRRFS_MAKE_ICS
+++ b/jobs/JRRFS_MAKE_ICS
@@ -120,15 +120,14 @@ extrn_mdl_fns_on_disk_str="( "$( printf "\"%s\" " "${fns_on_disk[@]}" )")"
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  export jobid=${RUN}_make_ics_${mem_num}_${envir}_${cyc}
+  export jobid=${RUN}_make_ics_${mem_num}_${cyc}
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/ics"
 else
-  export jobid=${RUN}_make_ics_${envir}_${cyc}
+  export jobid=${RUN}_make_ics_${cyc}
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/ics"
 fi
 

--- a/jobs/JRRFS_MAKE_LBCS
+++ b/jobs/JRRFS_MAKE_LBCS
@@ -160,15 +160,14 @@ extrn_mdl_fns_on_disk_str2="( "$( printf "\"%s\" " "${fns_on_disk2[@]}" )")"
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  export jobid=${RUN}_make_lbcs_${mem_num}_${envir}_${cyc}
+  export jobid=${RUN}_make_lbcs_${mem_num}_${cyc}
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/lbcs"
 else
-  export jobid=${RUN}_make_lbcs_${envir}_${cyc}
+  export jobid=${RUN}_make_lbcs_${cyc}
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/lbcs"
 fi
 

--- a/jobs/JRRFS_MAKE_OROG
+++ b/jobs/JRRFS_MAKE_OROG
@@ -48,9 +48,8 @@ This is the J-job script for the task that generates orography files.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
-export jobid=${RUN}_make_orog_${envir}_${cyc}
+export jobid=${RUN}_make_orog_${cyc}
 
 export DATA=${DATAROOT}/${jobid}
 mkdir -p ${DATA}

--- a/jobs/JRRFS_MAKE_SFC_CLIMO
+++ b/jobs/JRRFS_MAKE_SFC_CLIMO
@@ -49,9 +49,8 @@ climatology.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
-export jobid=${RUN}_make_sfc_climo_${envir}_${cyc}
+export jobid=${RUN}_make_sfc_climo_${cyc}
 
 export DATA=${DATAROOT}/${jobid}
 mkdir -p ${DATA}

--- a/jobs/JRRFS_POST
+++ b/jobs/JRRFS_POST
@@ -49,22 +49,21 @@ on the output files corresponding to a specified forecast hour.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
 
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ ${CYCLE_TYPE} == "spinup" ]; then
-  export INPUT_DATA="${DATAROOT}/${RUN}_forecast_spinup_${envir}_${cyc}"
-  jobid=${RUN}_post_spinup_${envir}_${cyc}_f${fhr}
+  export INPUT_DATA="${DATAROOT}/${RUN}_forecast_spinup_${cyc}"
+  jobid=${RUN}_post_spinup_${cyc}_f${fhr}
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}"
-    jobid=${RUN}_post_${mem_num}_${envir}_${cyc}_f${fhr}
+    export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}"
+    jobid=${RUN}_post_${mem_num}_${cyc}_f${fhr}
   else
-    export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${envir}_${cyc}"
-    jobid=${RUN}_post_${envir}_${cyc}_f${fhr}
+    export INPUT_DATA="${DATAROOT}/${RUN}_forecast_${cyc}"
+    jobid=${RUN}_post_${cyc}_f${fhr}
   fi
 fi
 

--- a/jobs/JRRFS_PRDGEN
+++ b/jobs/JRRFS_PRDGEN
@@ -49,19 +49,18 @@ files corresponding to a specified forecast hour.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
 
 CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  jobid=${RUN}_post_spinup_${envir}_${cyc}_f${fhr}
+  jobid=${RUN}_post_spinup_${cyc}_f${fhr}
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    jobid=${RUN}_post_${mem_num}_${envir}_${cyc}_f${fhr}
+    jobid=${RUN}_post_${mem_num}_${cyc}_f${fhr}
   else
-    jobid=${RUN}_post_${envir}_${cyc}_f${fhr}
+    jobid=${RUN}_post_${cyc}_f${fhr}
   fi
 fi
 

--- a/jobs/JRRFS_PREP_CYC
+++ b/jobs/JRRFS_PREP_CYC
@@ -48,7 +48,6 @@ This is the J-job script for the prep_cyc tasks for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -57,18 +56,18 @@ export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export CYCLE_SUBTYPE=${CYCLE_SUBTYPE:-empty}
 export ctrlpath=""
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export INPUT_DATA=${DATAROOT}/${RUN}_forecast_spinup_${envir}_${cyc}/INPUT
+  export INPUT_DATA=${DATAROOT}/${RUN}_forecast_spinup_${cyc}/INPUT
   if [ "${DO_ENSINIT}" = "TRUE" ] && [ "${CYCLE_SUBTYPE}" = "ensinit" ]; then
-    export INPUT_DATA=${DATAROOT}/${RUN}_forecast_ensinit_${envir}_${cyc}/INPUT
+    export INPUT_DATA=${DATAROOT}/${RUN}_forecast_ensinit_${cyc}/INPUT
   fi
   if [ "${DO_ENSINIT}" = "TRUE" ] && [ "${CYCLE_SUBTYPE}" = "spinup" ]; then
     ctrlpath=${ENSCTRL_DATAROOT}
   fi
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export INPUT_DATA=${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}/INPUT
+    export INPUT_DATA=${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}/INPUT
   else
-    export INPUT_DATA=${DATAROOT}/${RUN}_forecast_${envir}_${cyc}/INPUT
+    export INPUT_DATA=${DATAROOT}/${RUN}_forecast_${cyc}/INPUT
   fi
 fi
 

--- a/jobs/JRRFS_PROCESS_BUFR
+++ b/jobs/JRRFS_PROCESS_BUFR
@@ -49,18 +49,17 @@ the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export jobid=${RUN}_process_bufr_spinup_${envir}_${cyc}
+  export jobid=${RUN}_process_bufr_spinup_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export jobid=${RUN}_process_bufr_spinup_enkf_${envir}_${cyc}
+    export jobid=${RUN}_process_bufr_spinup_enkf_${cyc}
   fi
 else
-  export jobid=${RUN}_process_bufr_${envir}_${cyc}
+  export jobid=${RUN}_process_bufr_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export jobid=${RUN}_process_bufr_enkf_${envir}_${cyc}
+    export jobid=${RUN}_process_bufr_enkf_${cyc}
   fi
 fi
 

--- a/jobs/JRRFS_PROCESS_LIGHTNING
+++ b/jobs/JRRFS_PROCESS_LIGHTNING
@@ -46,20 +46,19 @@ preprocess with RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 if [ ${CYCLE_TYPE} == "spinup" ]; then
   if [ ${DO_ENSEMBLE} = TRUE ]; then
-    export jobid=${RUN}_process_lightning_enkf_spinup_${envir}_${cyc}
+    export jobid=${RUN}_process_lightning_enkf_spinup_${cyc}
   else
-    export jobid=${RUN}_process_lightning_spinup_${envir}_${cyc}
+    export jobid=${RUN}_process_lightning_spinup_${cyc}
   fi
 else
   if [ ${DO_ENSEMBLE} = TRUE ]; then
-    export jobid=${RUN}_process_lightning_enkf_${envir}_${cyc}
+    export jobid=${RUN}_process_lightning_enkf_${cyc}
   else
-    export jobid=${RUN}_process_lightning_${envir}_${cyc}
+    export jobid=${RUN}_process_lightning_${cyc}
   fi
 fi
 

--- a/jobs/JRRFS_PROCESS_RADAR
+++ b/jobs/JRRFS_PROCESS_RADAR
@@ -49,18 +49,17 @@ preprocessing with RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export jobid=${RUN}_process_radar_spinup_${envir}_${cyc}
+  export jobid=${RUN}_process_radar_spinup_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export jobid=${RUN}_process_radar_spinup_enkf_${envir}_${cyc}
+    export jobid=${RUN}_process_radar_spinup_enkf_${cyc}
   fi
 else
-  export jobid=${RUN}_process_radar_${envir}_${cyc}
+  export jobid=${RUN}_process_radar_${cyc}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export jobid=${RUN}_process_radar_enkf_${envir}_${cyc}
+    export jobid=${RUN}_process_radar_enkf_${cyc}
   fi
 fi
 

--- a/jobs/JRRFS_PROCESS_SMOKE
+++ b/jobs/JRRFS_PROCESS_SMOKE
@@ -49,13 +49,12 @@ for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export jobid=${RUN}_process_smoke_spinup_${envir}_${cyc}
+  export jobid=${RUN}_process_smoke_spinup_${cyc}
 else
-  export jobid=${RUN}_process_smoke_${envir}_${cyc}
+  export jobid=${RUN}_process_smoke_${cyc}
 fi
 
 export DATA=${DATAROOT}/${jobid}

--- a/jobs/JRRFS_RECENTER
+++ b/jobs/JRRFS_RECENTER
@@ -49,16 +49,15 @@ with RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
 
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export jobid=${RUN}_recenter_spinup_${mem_num}_${envir}_${cyc}
+  export jobid=${RUN}_recenter_spinup_${mem_num}_${cyc}
 else
-  export jobid=${RUN}_recenter_${mem_num}_${envir}_${cyc}
+  export jobid=${RUN}_recenter_${mem_num}_${cyc}
 fi
 
 export DATA=${DATAROOT}/${jobid}

--- a/jobs/JRRFS_SAVE_DA_OUTPUT
+++ b/jobs/JRRFS_SAVE_DA_OUTPUT
@@ -48,7 +48,6 @@ This is the J-job script for the task that saves DA analysis files to nwges.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -58,15 +57,15 @@ export mem_num=m$(echo "${ENSMEM_INDX}")
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "prod" ]; then
   if [ ${DO_ENSEMBLE} = "TRUE" ]; then
-    export DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}"
+    export DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}"
     export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast"
   else
-    export DATA="${DATAROOT}/${RUN}_forecast_${envir}_${cyc}"
+    export DATA="${DATAROOT}/${RUN}_forecast_${cyc}"
     export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/forecast"
   fi
 fi
 if [ ${CYCLE_TYPE} == "enfcst" ]; then
-  export DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}"
+  export DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}"
   export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast_enfcst"
 fi
 

--- a/jobs/JRRFS_SAVE_RESTART
+++ b/jobs/JRRFS_SAVE_RESTART
@@ -48,7 +48,6 @@ This is the J-job script for the task that saves restart files to nwges.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -58,22 +57,22 @@ export CYCLE_SUBTYPE=${CYCLE_SUBTYPE:-empty}
 export SURFACE_DIR=${SURFACE_DIR:-empty}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then	# EnKF has spinup forecasts
-    export DATA="${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${envir}_${cyc}"
+    export DATA="${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${cyc}"
     export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast_spinup"
     if [ "${CYCLE_SUBTYPE}" = "ensinit" ]; then
-      export DATA="${DATAROOT}/${RUN}_forecast_ensinit_${mem_num}_${envir}_${cyc}"
+      export DATA="${DATAROOT}/${RUN}_forecast_ensinit_${mem_num}_${cyc}"
       export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast_ensinit"
     fi
   else
-    export DATA="${DATAROOT}/${RUN}_forecast_spinup_${envir}_${cyc}"
+    export DATA="${DATAROOT}/${RUN}_forecast_spinup_${cyc}"
     export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/forecast_spinup"
   fi
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}"
+    export DATA="${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}"
     export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast"
   else
-    export DATA="${DATAROOT}/${RUN}_forecast_${envir}_${cyc}"
+    export DATA="${DATAROOT}/${RUN}_forecast_${cyc}"
     export NWGES_DIR="${GESROOT}/${RUN}.${PDY}/${cyc}/forecast"
   fi
 fi

--- a/jobs/JRRFS_UPDATE_LBC_SOIL
+++ b/jobs/JRRFS_UPDATE_LBC_SOIL
@@ -49,7 +49,6 @@ analysis with RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 
 export pid=${pid:-$$}
-export envir=${envir:-prod}
 export RUN=${RUN:-rrfs}
 
 export mem_num=m$(echo "${ENSMEM_INDX}")
@@ -66,12 +65,12 @@ if [[ ! -v OB_TYPE ]]; then
 fi
 if [ "${GSI_TYPE}" = "OBSERVER" ]; then
   if [ "${MEM_TYPE}" = "MEAN" ]; then
-    export jobid=${RUN}_observer_${workname}_ensmean_${envir}_${cyc}
+    export jobid=${RUN}_observer_${workname}_ensmean_${cyc}
   else
-    export jobid=${RUN}_observer_${workname}_${mem_num}_${envir}_${cyc}
+    export jobid=${RUN}_observer_${workname}_${mem_num}_${cyc}
   fi
 else
-  export jobid=${RUN}_analysis_${OB_TYPE}_${workname}_${envir}_${cyc}
+  export jobid=${RUN}_analysis_${OB_TYPE}_${workname}_${cyc}
 fi
 
 export DATA=${DATAROOT}/${jobid}

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -66,7 +66,6 @@ Workflow task names.
 <!ENTITY TAG   "{{ tag }}">
 <!ENTITY NET   "{{ net }}">
 <!ENTITY RUN   "{{ run }}">
-<!ENTITY envir "{{ envir }}">
 
 <!--
 Flags that determine whether to run the specific tasks.
@@ -1185,7 +1184,7 @@ MODULES_RUN_TASK_FP script.
         <and>
           <timedep><cyclestr offset="&START_TIME_CONVENTIONAL;">@Y@m@d@H@M00</cyclestr></timedep>
           <or>
-            <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_ensinit_m#mem#_&envir;_@H/RESTART/</cyclestr><cyclestr offset="{{ dt_atmos }}">@Y@m@d.@H@M@S.coupler.res</cyclestr></datadep>
+            <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_ensinit_m#mem#_@H/RESTART/</cyclestr><cyclestr offset="{{ dt_atmos }}">@Y@m@d.@H@M@S.coupler.res</cyclestr></datadep>
             <datadep age="00:00:00:05"><cyclestr>&FG_ROOT;/&RUN;.@Y@m@d/@H/m#mem#/run_blending</cyclestr> </datadep>
           </or>
         </and>
@@ -1746,7 +1745,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>&WALLTIME_ANALYSIS_GSIDIAG;</walltime>
     &NODESIZE_ALL;
     <jobname>&TAG;_&ANALYSIS_GSIDIAG_TN;_spinup</jobname>
-    <join><cyclestr>&LOGDIR;/&ANALYSIS_GSIDIAG_TN;_spinup_&TAG;@Y@m@d@H.log</cyclestr></join>
+    <join><cyclestr>&LOGDIR;/&ANALYSIS_GSIDIAG_TN;_spinup_&TAG;_@Y@m@d@H.log</cyclestr></join>
 
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
@@ -1949,11 +1948,11 @@ MODULES_RUN_TASK_FP script.
           <timedep><cyclestr offset="&START_TIME_CONVENTIONAL;">@Y@m@d@H@M00</cyclestr></timedep>
           <or>
             {%- if do_ensemble %}
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_m#mem#_&envir;_@H/RESTART/coupler.res</cyclestr></datadep>
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_m#mem#_&envir;_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_m#mem#_@H/RESTART/coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_m#mem#_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
             {%- else %}
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_&envir;_@H/RESTART/coupler.res</cyclestr></datadep>
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_&envir;_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_@H/RESTART/coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
             {%- endif %}
           </or>
         </and>
@@ -1998,9 +1997,9 @@ MODULES_RUN_TASK_FP script.
 
       <dependency>
         {%- if do_ensemble %}
-          <datadep age="02:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_m#mem#_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+          <datadep age="02:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_m#mem#_@H/log.atm.f#fhr#</cyclestr></datadep>
         {%- else %}
-          <datadep age="02:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+          <datadep age="02:30"><cyclestr>&DATAROOT;/&RUN;_forecast_spinup_@H/log.atm.f#fhr#</cyclestr></datadep>
         {%- endif %}
       </dependency>
 
@@ -3038,11 +3037,11 @@ MODULES_RUN_TASK_FP script.
           <timedep><cyclestr offset="&START_TIME_CONVENTIONAL;">@Y@m@d@H@M00</cyclestr></timedep>
           <or>
             {%- if do_ensemble %}
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_&envir;_@H/RESTART/coupler.res</cyclestr></datadep>
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_&envir;_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_@H/RESTART/coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
             {%- else %}
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/RESTART/coupler.res</cyclestr></datadep>
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/RESTART/coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
             {%- endif %}
           </or>
         </and>
@@ -3084,11 +3083,11 @@ MODULES_RUN_TASK_FP script.
           <timedep><cyclestr offset="&START_TIME_CONVENTIONAL;">@Y@m@d@H@M00</cyclestr></timedep>
           <or>
             {%- if do_ensemble %}
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_&envir;_@H/RESTART/coupler.res</cyclestr></datadep>
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_&envir;_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_@H/RESTART/coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
             {%- else %}
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/RESTART/coupler.res</cyclestr></datadep>
-              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/RESTART/coupler.res</cyclestr></datadep>
+              <datadep age="00:30"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/RESTART/</cyclestr><cyclestr offset="#fhr#:00:00">@Y@m@d.@H0000.coupler.res</cyclestr></datadep>
             {%- endif %}
           </or>
         </and>
@@ -3148,9 +3147,9 @@ MODULES_RUN_TASK_FP script.
 
       <dependency>
         {%- if do_ensemble %}
-          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_@H/log.atm.f#fhr#</cyclestr></datadep>
         {%- else %}
-          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/log.atm.f#fhr#</cyclestr></datadep>
         {%- endif %}
       </dependency>
 
@@ -3199,7 +3198,7 @@ MODULES_RUN_TASK_FP script.
       <envar><name>KEEPDATA</name><value>YES</value></envar>
 
       <dependency>
-          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+          <datadep age="01:30"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/log.atm.f#fhr#</cyclestr></datadep>
       </dependency>
 
     </task>
@@ -3335,8 +3334,8 @@ MODULES_RUN_TASK_FP script.
     <dependency>
 {%- if postproc_nsout_min > 0 %}
       <and>
-        <datadep age="00:02"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f000-00-36</cyclestr></datadep>
-        <datadep age="00:02"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f000</cyclestr></datadep>
+        <datadep age="00:02"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/log.atm.f000-00-36</cyclestr></datadep>
+        <datadep age="00:02"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/log.atm.f000</cyclestr></datadep>
       </and>
 {%- endif %}
     </dependency>
@@ -3367,7 +3366,7 @@ MODULES_RUN_TASK_FP script.
     <envar><name>KEEPDATA</name><value>YES</value></envar>
 
     <dependency>
-      <datadep age="00:02"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_&envir;_@H/log.atm.f000</cyclestr></datadep>
+      <datadep age="00:02"><cyclestr>&DATAROOT;/&RUN;_forecast_m#mem#_@H/log.atm.f000</cyclestr></datadep>
     </dependency>
 
   </task>

--- a/parm/FV3LAM_wflow_firewx.xml
+++ b/parm/FV3LAM_wflow_firewx.xml
@@ -37,7 +37,6 @@ Workflow task names.
 <!ENTITY TAG                  "{{ tag }}">
 <!ENTITY NET                  "{{ net }}">
 <!ENTITY RUN                  "{{ run }}">
-<!ENTITY envir                "{{ envir }}">
 
 <!--
 Flags that specify whether to run the preprocessing tasks.
@@ -408,7 +407,7 @@ MODULES_RUN_TASK_FP script.
           <or>
             <taskdep task="&FORECAST_TN;"/>
             <and>
-              <datadep age="05:00"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+              <datadep age="05:00"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/log.atm.f#fhr#</cyclestr></datadep>
             </and>
           </or>
         </dependency>

--- a/parm/FV3LAM_wflow_nonDA.xml
+++ b/parm/FV3LAM_wflow_nonDA.xml
@@ -37,7 +37,6 @@ Workflow task names.
 <!ENTITY TAG                  "{{ tag }}">
 <!ENTITY NET                  "{{ net }}">
 <!ENTITY RUN                  "{{ run }}">
-<!ENTITY envir                "{{ envir }}">
 
 <!--
 Flags that specify whether to run the preprocessing tasks.
@@ -424,7 +423,7 @@ MODULES_RUN_TASK_FP script.
           <or>
             <taskdep task="&FORECAST_TN;"/>
             <and>
-              <datadep age="05:00"><cyclestr>&DATAROOT;/&RUN;_forecast_&envir;_@H/log.atm.f#fhr#</cyclestr></datadep>
+              <datadep age="05:00"><cyclestr>&DATAROOT;/&RUN;_forecast_@H/log.atm.f#fhr#</cyclestr></datadep>
             </and>
           </or>
         </dependency>

--- a/scripts/exrrfs_analysis_enkf.sh
+++ b/scripts/exrrfs_analysis_enkf.sh
@@ -139,10 +139,10 @@ for imem in  $(seq 1 $nens) ensmean; do
     memchar="m"$(printf %03i $imem)
   fi
   if [ "${CYCLE_TYPE}" = "spinup" ]; then
-    bkpath=${DATAROOT}/${RUN}_forecast_spinup_${memchar}_${envir}_${cyc}/INPUT
+    bkpath=${DATAROOT}/${RUN}_forecast_spinup_${memchar}_${cyc}/INPUT
     observer_nwges_dir="${GESROOT}/${RUN}.${PDY}/${cyc}_spinup/${memchar}/observer_gsi_spinup"
   else
-    bkpath=${DATAROOT}/${RUN}_forecast_${memchar}_${envir}_${cyc}/INPUT
+    bkpath=${DATAROOT}/${RUN}_forecast_${memchar}_${cyc}/INPUT
     observer_nwges_dir="${GESROOT}/${RUN}.${PDY}/${cyc}/${memchar}/observer_gsi"
   fi
 

--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -125,22 +125,22 @@ AIR_REJECT_FN=$(date +%Y%m%d -d "${START_DATE} -1 day")_rejects.txt
 fixgriddir=$FIX_GSI/${PREDEF_GRID_NAME}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   if [ "${MEM_TYPE}" = "MEAN" ]; then
-    bkpath=${DATAROOT}/${RUN}_calc_ensmean_spinup_${envir}_${cyc}
+    bkpath=${DATAROOT}/${RUN}_calc_ensmean_spinup_${cyc}
   else
     if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-      bkpath=${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${envir}_${cyc}/INPUT
+      bkpath=${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${cyc}/INPUT
     else
-      bkpath=${DATAROOT}/${RUN}_forecast_spinup_${envir}_${cyc}/INPUT
+      bkpath=${DATAROOT}/${RUN}_forecast_spinup_${cyc}/INPUT
     fi
   fi
 else
   if [ "${MEM_TYPE}" = "MEAN" ]; then
-    bkpath=${DATAROOT}/${RUN}_calc_ensmean_${envir}_${cyc}
+    bkpath=${DATAROOT}/${RUN}_calc_ensmean_${cyc}
   else
     if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-      bkpath=${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}/INPUT
+      bkpath=${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}/INPUT
     else
-      bkpath=${DATAROOT}/${RUN}_forecast_${envir}_${cyc}/INPUT
+      bkpath=${DATAROOT}/${RUN}_forecast_${cyc}/INPUT
     fi
   fi
 fi
@@ -476,17 +476,17 @@ if [[ ${GSI_TYPE} == "OBSERVER" || ${anav_type} == "conv" || ${anav_type} == "co
   if [ "${anav_type}" = "conv_dbz" ]; then
     obs_number=${#obs_files_source[@]}
     if [ "${CYCLE_TYPE}" = "spinup" ]; then
-      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_spinup_${envir}_${cyc}/Gridded_ref.nc
+      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_spinup_${cyc}/Gridded_ref.nc
     else
-      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_${envir}_${cyc}/Gridded_ref.nc
+      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_${cyc}/Gridded_ref.nc
     fi
     obs_files_target[${obs_number}]=dbzobs.nc
     if [ "${DO_GLM_FED_DA}" = "TRUE" ]; then
       obs_number=${#obs_files_source[@]}
       if [ "${CYCLE_TYPE}" = "spinup" ]; then
-        obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_lightning_spinup_${envir}_${cyc}/fedobs.nc
+        obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_lightning_spinup_${cyc}/fedobs.nc
       else
-        obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_lightning_${envir}_${cyc}/fedobs.nc
+        obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_lightning_${cyc}/fedobs.nc
       fi
       obs_files_target[${obs_number}]=fedobs.nc
     fi
@@ -495,14 +495,14 @@ if [[ ${GSI_TYPE} == "OBSERVER" || ${anav_type} == "conv" || ${anav_type} == "co
   if [ "${DO_ENKF_RADAR_REF}" = "TRUE" ]; then
     obs_number=${#obs_files_source[@]}
     if [ "${CYCLE_TYPE}" = "spinup" ]; then
-      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_spinup_enkf_${envir}_${cyc}/Gridded_ref.nc
+      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_spinup_enkf_${cyc}/Gridded_ref.nc
     else
-      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_enkf_${envir}_${cyc}/Gridded_ref.nc
+      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_radar_enkf_${cyc}/Gridded_ref.nc
     fi
     obs_files_target[${obs_number}]=dbzobs.nc
     if [ "${DO_GLM_FED_DA}" = "TRUE" ]; then
       obs_number=${#obs_files_source[@]}
-      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_lightning_enkf_${envir}_${cyc}/fedobs.nc
+      obs_files_source[${obs_number}]=${DATAROOT}/${RUN}_process_lightning_enkf_${cyc}/fedobs.nc
       obs_files_target[${obs_number}]=fedobs.nc
     fi
   fi
@@ -511,16 +511,16 @@ else
 
   if [ "${anav_type}" = "radardbz" ]; then
     if [ "${CYCLE_TYPE}" = "spinup" ]; then
-      obs_files_source[0]=${DATAROOT}/${RUN}_process_radar_spinup_${envir}_${cyc}/Gridded_ref.nc
+      obs_files_source[0]=${DATAROOT}/${RUN}_process_radar_spinup_${cyc}/Gridded_ref.nc
     else
-      obs_files_source[0]=${DATAROOT}/${RUN}_process_radar_${envir}_${cyc}/Gridded_ref.nc
+      obs_files_source[0]=${DATAROOT}/${RUN}_process_radar_${cyc}/Gridded_ref.nc
     fi
     obs_files_target[0]=dbzobs.nc
     if [ "${DO_GLM_FED_DA}" = "TRUE" ]; then
       if [ "${CYCLE_TYPE}" = "spinup" ]; then
-        obs_files_source[1]=${DATAROOT}/${RUN}_process_lightning_spinup_${envir}_${cyc}/fedobs.nc
+        obs_files_source[1]=${DATAROOT}/${RUN}_process_lightning_spinup_${cyc}/fedobs.nc
       else
-        obs_files_source[1]=${DATAROOT}/${RUN}_process_lightning_${envir}_${cyc}/fedobs.nc
+        obs_files_source[1]=${DATAROOT}/${RUN}_process_lightning_${cyc}/fedobs.nc
       fi
       obs_files_target[1]=fedobs.nc
     fi

--- a/scripts/exrrfs_analysis_gsidiag.sh
+++ b/scripts/exrrfs_analysis_gsidiag.sh
@@ -294,7 +294,6 @@ if [ "${DO_RADMON}" = "TRUE" ]; then
    else
      echo "Run EMC Radmon package to generate daily monitoring data for satellite"
 
-     envir=${envir:-prod}
      REGIONAL_RR=${REGIONAL_RR:-1}
 
      export TANKverf=${TANKverf:-$GESROOT/radmon}

--- a/scripts/exrrfs_analysis_nonvarcld.sh
+++ b/scripts/exrrfs_analysis_nonvarcld.sh
@@ -118,12 +118,12 @@ else
   cycle_tag=""
 fi
 if [ "${MEM_TYPE}" = "MEAN" ]; then
-  bkpath=${DATAROOT}/${RUN}_calc_ensmean${cycle_tag}_${envir}_${cyc}/INPUT
+  bkpath=${DATAROOT}/${RUN}_calc_ensmean${cycle_tag}_${cyc}/INPUT
 else
   if [ ${DO_ENSEMBLE} = "TRUE" ]; then
-    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${mem_num}_${envir}_${cyc}/INPUT
+    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${mem_num}_${cyc}/INPUT
   else
-    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${envir}_${cyc}/INPUT
+    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${cyc}/INPUT
   fi
 fi
 
@@ -202,7 +202,7 @@ do
 done
 
 # radar reflectivity on esg grid over each subdomain.
-process_radarref_path=${DATAROOT}/${RUN}_process_radar${cycle_tag}_${envir}_${cyc}
+process_radarref_path=${DATAROOT}/${RUN}_process_radar${cycle_tag}_${cyc}
 ss=0
 for bigmin in 0; do
   bigmin=$( printf %2.2i $bigmin )

--- a/scripts/exrrfs_calc_ensmean.sh
+++ b/scripts/exrrfs_calc_ensmean.sh
@@ -121,9 +121,9 @@ for imem in  $(seq 1 $nens)
   memberstring=$( printf "%03d" $imem )
 
   if [ "${CYCLE_TYPE}" = "spinup" ]; then
-    bkpath=${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${envir}_${cyc}/INPUT  # cycling, use background from RESTART
+    bkpath=${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${cyc}/INPUT  # cycling, use background from RESTART
   else
-    bkpath=${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}/INPUT  # cycling, use background from RESTART
+    bkpath=${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}/INPUT  # cycling, use background from RESTART
   fi
 
   dynvarfile=${bkpath}/fv_core.res.tile1.nc

--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -278,7 +278,7 @@ n_iolayouty=$(($IO_LAYOUT_Y-1))
 list_iolayout=$(seq 0 $n_iolayouty)
 
 if [ "${DO_NON_DA_RUN}" = "TRUE" ]; then
-  target="${DATAROOT}/${RUN}_make_ics_${envir}_${cyc}/gfs_data.tile${TILE_RGNL}.halo${NH0}.nc"
+  target="${DATAROOT}/${RUN}_make_ics_${cyc}/gfs_data.tile${TILE_RGNL}.halo${NH0}.nc"
 else
   if [ ${BKTYPE} -eq 1 ]; then
     target="gfs_data.tile${TILE_RGNL}.halo${NH0}.nc"
@@ -310,20 +310,20 @@ else
 fi
 
 if [ "${DO_NON_DA_RUN}" = "TRUE" ]; then
-  target="${DATAROOT}/${RUN}_make_ics_${envir}_${cyc}/sfc_data.tile${TILE_RGNL}.halo${NH0}.nc"
+  target="${DATAROOT}/${RUN}_make_ics_${cyc}/sfc_data.tile${TILE_RGNL}.halo${NH0}.nc"
   symlink="sfc_data.nc"
   ln -sf ${relative_or_null} $target $symlink
 
-  target="${DATAROOT}/${RUN}_make_ics_${envir}_${cyc}/gfs_ctrl.nc"
+  target="${DATAROOT}/${RUN}_make_ics_${cyc}/gfs_ctrl.nc"
   symlink="gfs_ctrl.nc"
   ln -sf ${relative_or_null} $target $symlink
 
-  target="${DATAROOT}/${RUN}_make_ics_${envir}_${cyc}/gfs_bndy.tile${TILE_RGNL}.000.nc"
+  target="${DATAROOT}/${RUN}_make_ics_${cyc}/gfs_bndy.tile${TILE_RGNL}.000.nc"
   symlink="gfs_bndy.tile${TILE_RGNL}.000.nc"
   ln -sf ${relative_or_null} $target $symlink
 
   for fhr in $(seq -f "%03g" ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} ${FCST_LEN_HRS}); do
-    target="${DATAROOT}/${RUN}_make_lbcs_${envir}_${cyc}/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
+    target="${DATAROOT}/${RUN}_make_lbcs_${cyc}/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
     symlink="gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
     ln -sf ${relative_or_null} $target $symlink
   done

--- a/scripts/exrrfs_recenter.sh
+++ b/scripts/exrrfs_recenter.sh
@@ -117,9 +117,9 @@ for imem in  $(seq 1 $nens)
   memberstring=$( printf "%03d" $imem )
 
   if [ "${CYCLE_TYPE}" = "spinup" ]; then
-    bkpath=${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${envir}_${cyc}/INPUT  # cycling, use background from RESTART
+    bkpath=${DATAROOT}/${RUN}_forecast_spinup_${mem_num}_${cyc}/INPUT  # cycling, use background from RESTART
   else
-    bkpath=${DATAROOT}/${RUN}_forecast_${mem_num}_${envir}_${cyc}/INPUT  # cycling, use background from RESTART
+    bkpath=${DATAROOT}/${RUN}_forecast_${mem_num}_${cyc}/INPUT  # cycling, use background from RESTART
   fi
 
   dynvarfile=${bkpath}/fv_core.res.tile1.nc

--- a/scripts/exrrfs_update_lbc_soil.sh
+++ b/scripts/exrrfs_update_lbc_soil.sh
@@ -122,12 +122,12 @@ else
   cycle_tag=""
 fi
 if [ "${MEM_TYPE}" = "MEAN" ]; then
-  bkpath=${DATAROOT}/${RUN}_calc_ensmean${cycle_tag}_${envir}_${cyc}/INPUT
+  bkpath=${DATAROOT}/${RUN}_calc_ensmean${cycle_tag}_${cyc}/INPUT
 else
   if [ ${DO_ENSEMBLE} = "TRUE" ]; then
-    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${mem_num}_${envir}_${cyc}/INPUT
+    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${mem_num}_${cyc}/INPUT
   else
-    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${envir}_${cyc}/INPUT
+    bkpath=${DATAROOT}/${RUN}_forecast${cycle_tag}_${cyc}/INPUT
   fi
 fi
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the usage of envir is removed from the various J-jobs and ex-scripts in the workflow.  $envir is used in the operational HRRR run directory names so I added it to the RRFS run directory names when I updated the run directory structure a couple of months ago, but according to issue #398 it needs to be removed.
- There are a few remaining instances of envir in the ush directory that I did not remove.  One instance is for setting the correct job queues depending on the value of envir (para vs prod).  If envir should also be removed here let me know.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Completed successful tests with these changes using the fire weather workflow and a spinup cycle of the DA engineering test.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [x] Parallel
- [x] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #398 