### PR TITLE
Modifies the job resources for RRFS EnKF forecast 

### DIFF
--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3
@@ -172,11 +172,11 @@ if [[ ${DO_ENSEMBLE}  == "TRUE" ]]; then
    write_diag_2=.true.
 
    START_TIME_SPINUP="00:30:00"
-   LAYOUT_X="15"
-   LAYOUT_Y="54"
+   LAYOUT_X="16"
+   LAYOUT_Y="48"
    NNODES_RUN_FCST="13"
    WRTCMP_write_groups="1"
-   WRTCMP_write_tasks_per_group="22"
+   WRTCMP_write_tasks_per_group="64"
 
    NUM_ENS_MEMBERS_FCST=5
    if [[ ${DO_ENSFCST} == "TRUE" ]] ; then

--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3_retro
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3_retro
@@ -173,10 +173,10 @@ if [[ ${DO_ENSEMBLE}  == "TRUE" ]]; then
    write_diag_2=.true.
 
    START_TIME_SPINUP="00:30:00"
-   LAYOUT_X="15"
-   LAYOUT_Y="54"
+   LAYOUT_X="16"
+   LAYOUT_Y="48"
    NNODES_RUN_FCST="13"
-   WRTCMP_write_tasks_per_group="22"
+   WRTCMP_write_tasks_per_group="64"
 
    NUM_ENS_MEMBERS_FCST=5
    if [[ ${DO_ENSFCST} == "TRUE" ]] ; then


### PR DESCRIPTION


<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Modifies the resources for 1 h enkf forecast job to get the quilting tasks on a separate node.  Keeps it on 13 nodes for now, but now is laid out 16x48+64 (had been 15x54+22).  Hopefully this change will prevent intermittent failures seen with this job.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A: Just built the workflow, confirming that the desired changes reached the input.nml file and config.sh files in an rrfs_na_enkf directory.
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

