### PR TITLE
[production/RRFS.v1] Updates enkf config files for new layout

### DIFF
--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3
@@ -164,11 +164,11 @@ if [[ ${DO_ENSEMBLE}  == "TRUE" ]]; then
    write_diag_2=.true.
 
    START_TIME_SPINUP="00:30:00"
-   LAYOUT_X="15"
-   LAYOUT_Y="54"
+   LAYOUT_X="16"
+   LAYOUT_Y="48"
    NNODES_FORECAST="13"
    WRTCMP_write_groups="1"
-   WRTCMP_write_tasks_per_group="22"
+   WRTCMP_write_tasks_per_group="64"
 
    NUM_ENS_MEMBERS_FCST=5
    if [[ ${DO_ENSFCST} == "TRUE" ]] ; then

--- a/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3_retro
+++ b/ush/sample_configs/RRFS_A/config.sh_rrfs_a_enkf_n3_retro
@@ -165,10 +165,10 @@ if [[ ${DO_ENSEMBLE}  == "TRUE" ]]; then
    write_diag_2=.true.
 
    START_TIME_SPINUP="00:30:00"
-   LAYOUT_X="15"
-   LAYOUT_Y="54"
+   LAYOUT_X="16"
+   LAYOUT_Y="48"
    NNODES_FORECAST="13"
-   WRTCMP_write_tasks_per_group="22"
+   WRTCMP_write_tasks_per_group="64"
 
    NUM_ENS_MEMBERS_FCST=5
    if [[ ${DO_ENSFCST} == "TRUE" ]] ; then


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Makes changes made on dev-sci in https://github.com/NOAA-EMC/rrfs-workflow/pull/446 on the production branch.
- Shifts from a 15x54+22 to a 16x48+64 layout, getting all quilt tasks on a separate node.  

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- No tests run here, but same changes were tested on the dev-sci PR.  
### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

