### PR TITLE
[dev-sci] Add RRFS_sas to input.nml yaml files

### DIFF
--- a/parm/FV3.input.nonDA.yml
+++ b/parm/FV3.input.nonDA.yml
@@ -139,6 +139,76 @@ FV3_HRRR_gf:
     sfclay_compute_flux: true
     thsfc_loc: false 
 
+RRFS_sas:
+  diag_manager_nml:
+    max_output_fields: 450
+  external_ic_nml:
+    levp: 66
+  fms_nml:
+    domains_stack_size: 12000000
+  fv_core_nml:
+    d_con: 0.5
+    d2_bg_k2: 0.04
+    dz_min: 2.0
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    k_split: 2
+    kord_mt: 9
+    kord_tm: -9
+    kord_tr: 9
+    kord_wz: 9
+    n_split: 5
+    nord_tr: 0
+    npz: 65
+    nrows_blend: 10
+    psm_bc: 1
+    range_warn: False
+    regional_bcs_from_gsi: false
+    rf_cutoff: 2000.0
+    sg_cutoff: !!python/none
+    vtdm4: 0.02
+    write_restart_with_bcs: false
+  gfs_physics_nml: 
+    betadcu: 1.0
+    cdmbgwd: [3.5, 1.0]
+    diag_log: true
+    do_deep: true
+    do_gsl_drag_ls_bl: true
+    do_gsl_drag_ss: true
+    do_gsl_drag_tofd: true
+    do_mynnsfclay: true
+    effr_in: true
+    gwd_opt: 3
+    iaer: 5111
+    ialb: 2 
+    icliq_sw: 2
+    iems: 2 
+    imfdeepcnv: 2
+    imfshalcnv: -1
+    iopt_alb: 2
+    iopt_btr: 1
+    iopt_crs: 1
+    iopt_dveg: 2
+    iopt_frz: 1
+    iopt_inf: 1
+    iopt_rad: 1
+    iopt_run: 1
+    iopt_sfc: 1
+    iopt_snf: 4
+    iopt_stc: 1
+    iopt_tbot: 2
+    iopt_trs: 2
+    iovr: 3
+    lrefres: !!python/none
+    mosaic_lu: 0
+    mosaic_soil: 0
+    progsigma: true
+    sfclay_compute_flux: true
+    thsfc_loc: false
+
 FV3_RAP:
   diag_manager_nml:
     max_output_fields: 450

--- a/parm/FV3.input.yml
+++ b/parm/FV3.input.yml
@@ -221,6 +221,117 @@ FV3_HRRR_gf:
   fv_diagnostics_nml:
     do_hailcast: true
 
+RRFS_sas:
+  atmos_model_nml:
+    avg_max_length: 3600.
+    ignore_rst_cksum: true
+  fv_core_nml:
+    agrid_vel_rst: true
+    d_con: 0.5
+    d2_bg_k2: 0.04
+    dz_min: 2.0
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    k_split: 2
+    kord_mt: 9
+    kord_tm: -9
+    kord_tr: 9
+    kord_wz: 9
+    n_split: 5
+    psm_bc: 1
+    nord_tr: 0
+    nrows_blend: 10
+    range_warn: False
+    regional_bcs_from_gsi: false
+    rf_cutoff: 2000.0
+    vtdm4: 0.02
+    write_restart_with_bcs: false
+  gfs_physics_nml: 
+    betadcu: 1.0
+    cdmbgwd: [3.5, 1.0]
+    diag_log: true
+    do_deep: true
+    do_gsl_drag_ls_bl: true
+    do_gsl_drag_ss: true
+    do_gsl_drag_tofd: true
+    do_mynnsfclay: true
+    do_sfcperts: !!python/none
+    do_tofd : false
+    do_ugwp : false
+    do_ugwp_v0 : false
+    do_ugwp_v0_nst_only : false
+    do_ugwp_v0_orog_only : false
+    dt_inner : 36
+    ebb_dcycle : 1
+    effr_in: true
+    gwd_opt: 3
+    fhlwr: 900.0
+    fhswr: 900.0
+    iaer: 1011
+    ialb: 2 
+    iccn: 2
+    icliq_sw: 2
+    iems: 2 
+    imfdeepcnv: 2
+    imfshalcnv: -1
+    iopt_alb: 2
+    iopt_btr: 1
+    iopt_crs: 1
+    iopt_dveg: 2
+    iopt_frz: 1
+    iopt_inf: 1
+    iopt_rad: 1
+    iopt_run: 1
+    iopt_sfc: 1
+    iopt_snf: 4
+    iopt_stc: 1
+    iopt_tbot: 2
+    iovr: 3
+    ldiag_ugwp: false
+    lgfdlmprad: false
+    lightning_threat: true
+    mosaic_lu: 1
+    mosaic_soil: 1
+    isncond_opt: 2
+    isncovr_opt: 3
+    progsigma: true
+    sfclay_compute_flux: true
+    thsfc_loc: false 
+    # Smoke/dust options
+    rrfs_sd : false
+    rrfs_smoke_debug : false
+    seas_opt : 0
+    mix_chem : true
+    dust_opt : 1
+    coarsepm_settling : 1
+    smoke_conv_wet_coef : [0.5, 0.5, 0.5]
+    hwp_method : 1
+    aero_ind_fdb : false
+    aero_dir_fdb : true
+    addsmoke_flag : 1
+    wetdep_ls_opt : 1
+    do_plumerise : true
+    do_smoke_transport : true
+    plumerisefire_frq : 30
+    plume_wind_eff : 1
+    dust_moist_correction : 2.0
+    dust_drylimit_factor : 0.5
+    dust_alpha : 10.0
+    dust_gamma : 1.3
+    drydep_opt : 1
+    enh_mix : false
+    wetdep_ls_alpha : 0.5
+    smoke_conv_wet_coef : [ 0.50, 0.50, 0.50 ]
+    do_smoke_transport : true
+    ebb_dcycle : 2
+    sc_factor : 1.0
+
+  fv_diagnostics_nml:
+    do_hailcast: true
+
 FV3_RAP:
   atmos_model_nml:
     avg_max_length: 3600.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the RRFS_sas CCPP suite is added to FV3.input.yml and FV3.input.nonDA.yml.  When generating the workflow to create the namelist, the yaml files are used to modify certain variables based on the input.nml.FV3 template.  For RRFS_sas, I used the namelist values for FV3_HRRR_gf in each yaml file, and included the changes to run with saSAS convection.
- This PR is an add on to #439 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Successfully created the namelist with SAS options by generating the workflow.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

