### PR TITLE
[production/RRFS.v1] Add SAS option to real-time parallel

### DIFF
--- a/parm/FV3.input.nonDA.yml
+++ b/parm/FV3.input.nonDA.yml
@@ -139,6 +139,76 @@ FV3_HRRR_gf:
     sfclay_compute_flux: true
     thsfc_loc: false 
 
+RRFS_sas:
+  diag_manager_nml:
+    max_output_fields: 450
+  external_ic_nml:
+    levp: 66
+  fms_nml:
+    domains_stack_size: 12000000
+  fv_core_nml:
+    d_con: 0.5
+    d2_bg_k2: 0.04
+    dz_min: 2.0
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    k_split: 2
+    kord_mt: 9
+    kord_tm: -9
+    kord_tr: 9
+    kord_wz: 9
+    n_split: 5
+    nord_tr: 0
+    npz: 65
+    nrows_blend: 10
+    psm_bc: 1
+    range_warn: False
+    regional_bcs_from_gsi: false
+    rf_cutoff: 2000.0
+    sg_cutoff: !!python/none
+    vtdm4: 0.02
+    write_restart_with_bcs: false
+  gfs_physics_nml: 
+    betadcu: 1.0
+    cdmbgwd: [3.5, 1.0]
+    diag_log: true
+    do_deep: true
+    do_gsl_drag_ls_bl: true
+    do_gsl_drag_ss: true
+    do_gsl_drag_tofd: true
+    do_mynnsfclay: true
+    effr_in: true
+    gwd_opt: 3
+    iaer: 5111
+    ialb: 2 
+    icliq_sw: 2
+    iems: 2 
+    imfdeepcnv: 2
+    imfshalcnv: -1
+    iopt_alb: 2
+    iopt_btr: 1
+    iopt_crs: 1
+    iopt_dveg: 2
+    iopt_frz: 1
+    iopt_inf: 1
+    iopt_rad: 1
+    iopt_run: 1
+    iopt_sfc: 1
+    iopt_snf: 4
+    iopt_stc: 1
+    iopt_tbot: 2
+    iopt_trs: 2
+    iovr: 3
+    lrefres: !!python/none
+    mosaic_lu: 0
+    mosaic_soil: 0
+    progsigma: true
+    sfclay_compute_flux: true
+    thsfc_loc: false
+
 FV3_RAP:
   diag_manager_nml:
     max_output_fields: 450

--- a/parm/FV3.input.yml
+++ b/parm/FV3.input.yml
@@ -221,6 +221,117 @@ FV3_HRRR_gf:
   fv_diagnostics_nml:
     do_hailcast: true
 
+RRFS_sas:
+  atmos_model_nml:
+    avg_max_length: 3600.
+    ignore_rst_cksum: true
+  fv_core_nml:
+    agrid_vel_rst: true
+    d_con: 0.5
+    d2_bg_k2: 0.04
+    dz_min: 2.0
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    k_split: 2
+    kord_mt: 9
+    kord_tm: -9
+    kord_tr: 9
+    kord_wz: 9
+    n_split: 5
+    psm_bc: 1
+    nord_tr: 0
+    nrows_blend: 10
+    range_warn: False
+    regional_bcs_from_gsi: false
+    rf_cutoff: 2000.0
+    vtdm4: 0.02
+    write_restart_with_bcs: false
+  gfs_physics_nml: 
+    betadcu: 1.0
+    cdmbgwd: [3.5, 1.0]
+    diag_log: true
+    do_deep: true
+    do_gsl_drag_ls_bl: true
+    do_gsl_drag_ss: true
+    do_gsl_drag_tofd: true
+    do_mynnsfclay: true
+    do_sfcperts: !!python/none
+    do_tofd : false
+    do_ugwp : false
+    do_ugwp_v0 : false
+    do_ugwp_v0_nst_only : false
+    do_ugwp_v0_orog_only : false
+    dt_inner : 36
+    ebb_dcycle : 1
+    effr_in: true
+    gwd_opt: 3
+    fhlwr: 900.0
+    fhswr: 900.0
+    iaer: 1011
+    ialb: 2 
+    iccn: 2
+    icliq_sw: 2
+    iems: 2 
+    imfdeepcnv: 2
+    imfshalcnv: -1
+    iopt_alb: 2
+    iopt_btr: 1
+    iopt_crs: 1
+    iopt_dveg: 2
+    iopt_frz: 1
+    iopt_inf: 1
+    iopt_rad: 1
+    iopt_run: 1
+    iopt_sfc: 1
+    iopt_snf: 4
+    iopt_stc: 1
+    iopt_tbot: 2
+    iovr: 3
+    ldiag_ugwp: false
+    lgfdlmprad: false
+    lightning_threat: true
+    mosaic_lu: 1
+    mosaic_soil: 1
+    isncond_opt: 2
+    isncovr_opt: 3
+    progsigma: true
+    sfclay_compute_flux: true
+    thsfc_loc: false 
+    # Smoke/dust options
+    rrfs_sd : false
+    rrfs_smoke_debug : false
+    seas_opt : 0
+    mix_chem : true
+    dust_opt : 1
+    coarsepm_settling : 1
+    smoke_conv_wet_coef : [0.5, 0.5, 0.5]
+    hwp_method : 1
+    aero_ind_fdb : false
+    aero_dir_fdb : true
+    addsmoke_flag : 1
+    wetdep_ls_opt : 1
+    do_plumerise : true
+    do_smoke_transport : true
+    plumerisefire_frq : 30
+    plume_wind_eff : 1
+    dust_moist_correction : 2.0
+    dust_drylimit_factor : 0.5
+    dust_alpha : 10.0
+    dust_gamma : 1.3
+    drydep_opt : 1
+    enh_mix : false
+    wetdep_ls_alpha : 0.5
+    smoke_conv_wet_coef : [ 0.50, 0.50, 0.50 ]
+    do_smoke_transport : true
+    ebb_dcycle : 2
+    sc_factor : 1.0
+
+  fv_diagnostics_nml:
+    do_hailcast: true
+
 FV3_RAP:
   atmos_model_nml:
     avg_max_length: 3600.

--- a/parm/FV3.input.yml_ensphy
+++ b/parm/FV3.input.yml_ensphy
@@ -18,6 +18,7 @@ rrfsens_phy1:
     n_var_spp: 4
     satmedmf: true
     shal_cnv: true
+    gf_coldstart: true
     conv_cf_opt: 1
     rrfs_sd :  
     rrfs_smoke_debug : 
@@ -136,6 +137,7 @@ rrfsens_phy4:
     nssl_invertccn: true
     satmedmf: true
     shal_cnv: true
+    gf_coldstart: true
     conv_cf_opt: 1
     rrfs_sd :
     rrfs_smoke_debug :

--- a/parm/diag_table.RRFS_sas
+++ b/parm/diag_table.RRFS_sas
@@ -1,0 +1,523 @@
+{{ starttime.strftime("%Y%m%d.%H") }}Z.{{ cres }}.32bit.non-hydro.regional
+{{ starttime.strftime("%Y %m %d %H %M %S") }}
+
+"grid_spec",              -1,  "months",  1, "days",  "time"
+"atmos_static",           -1,  "hours",   1, "hours", "time"
+#"atmos_4xdaily",          1,  "hours",   1, "days",  "time"
+"fv3_history",             0,  "hours",   1, "hours", "time"
+"fv3_history2d",           0,  "hours",   1, "hours", "time"
+
+#
+#=======================
+# ATMOSPHERE DIAGNOSTICS
+#=======================
+###
+# grid_spec
+###
+ "dynamics", "grid_lon", "grid_lon", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lat", "grid_lat", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lont", "grid_lont", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_latt", "grid_latt", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "area",     "area",     "grid_spec", "all", .false.,  "none", 2,
+###
+# 4x daily output
+###
+# "dynamics",  "slp",         "slp",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort850",     "vort850",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort200",     "vort200",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "us",          "us",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u1000",       "u1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u850",        "u850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u700",        "u700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u500",        "u500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u200",        "u200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u100",        "u100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u50",         "u50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u10",         "u10",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vs",          "vs",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v1000",       "v1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v850",        "v850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v700",        "v700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v500",        "v500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v200",        "v200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v100",        "v100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v50",         "v50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v10",         "v10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "tm",          "tm",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t1000",       "t1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t850",        "t850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t700",        "t700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t500",        "t500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t200",        "t200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t100",        "t100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t50",         "t50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t10",         "t10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "z1000",       "z1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z850",        "z850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z700",        "z700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z500",        "z500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z200",        "z200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z100",        "z100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z50",         "z50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z10",         "z10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "w1000",       "w1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w850",        "w850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w700",        "w700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w500",        "w500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w200",        "w200",       "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "q1000",       "q1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q850",        "q850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q700",        "q700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q500",        "q500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q200",        "q200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q100",        "q100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q50",         "q50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q10",         "q10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "rh1000",      "rh1000",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh850",       "rh850",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh700",       "rh700",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh500",       "rh500",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh200",       "rh200",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg1000",     "omg1000",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg850",      "omg850",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg700",      "omg700",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg500",      "omg500",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg200",      "omg200",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg100",      "omg100",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg50",       "omg50",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg10",       "omg10",      "atmos_4xdaily", "all", .false.,  "none", 2
+###
+# gfs static data
+###
+ "dynamics",      "pk",          "pk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "bk",          "bk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hyam",        "hyam",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hybm",        "hybm",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "zsurf",       "zsurf",        "atmos_static",      "all", .false.,  "none", 2
+###
+# FV3 variabls needed for NGGPS evaluation
+###
+"gfs_dyn",     "ucomp",       "ugrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "vcomp",       "vgrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sphum",       "spfh",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "temp",        "tmp",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "liq_wat",     "clwmr",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "o3mr",        "o3mr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delp",        "dpres",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delz",        "delz",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "w",           "dzdt",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_wat",     "icmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rainwat",     "rwmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snowwat",     "snmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel",     "grle",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "refl_10cm"    "refl_10cm"  "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "rain_nc",     "rain_nc",    "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "water_nc",    "water_nc",   "fv3_history",  "all",  .false.,  "none",  2
+
+"gfs_dyn",   "wmaxup",        "upvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "wmaxdn",        "dnvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax03",       "uhmax03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax25",       "uhmax25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin03",       "uhmin03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin25",       "uhmin25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort01",     "maxvort01",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort02",     "maxvort02",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvorthy1",    "maxvorthy1",  "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "hailcast_dhail_max", "hailcast_dhail", "fv3_history2d", "all",  .false.,  "none", 2
+
+"gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRFI",        "dlwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRF",         "ulwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFI",        "ulwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRF",         "dswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFI",        "dswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFCI",       "dswrf_clr",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRF",         "uswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFI",        "uswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFItoa",     "ulwrf_toa",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "shtfl_ave",     "shtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "pwat",          "pwatclm",     "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "soilm",         "soilm",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_aveclm",   "tcdc_aveclm", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avebndcl", "tcdc_avebndcl",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avehcl",   "tcdc_avehcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avelcl",   "tcdc_avelcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avemcl",   "tcdc_avemcl", "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "TCDCcnvcl",     "tcdccnvcl",   "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "PREScnvclt",    "prescnvclt",  "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "PREScnvclb",    "prescnvclb",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehct",   "pres_avehct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehcb",   "pres_avehcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avehct",   "tmp_avehct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemct",   "pres_avemct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemcb",   "pres_avemcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avemct",   "tmp_avemct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelct",   "pres_avelct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelcb",   "pres_avelcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avelct",   "tmp_avelct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "u-gwd_ave",     "u-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "v-gwd_ave",     "v-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dusfc",         "uflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dvsfc",         "vflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvw",          "cnvcldwat",   "fv3_history2d",         "all",  .false.,  "none",  2
+
+"gfs_phys",    "u10max",     "u10max",     "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "v10max",     "v10max",     "fv3_history2d",  "all", .false.,  "none",  2
+"gfs_phys",    "spd10max",   "spd10max",   "fv3_history2d", "all", .false.,  "none",  2
+"gfs_dyn",     "ustm",        "ustm",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "vstm",        "vstm",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "srh01",        "srh01",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "srh03",        "srh03",       "fv3_history", "all", .false.,  "none",  2
+"gfs_phys",    "pratemax",    "pratemax",   "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "refdmax",    "refdmax",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "refdmax263k","refdmax263k","fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "t02max",     "t02max",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "t02min",     "t02min",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "rh02max",    "rh02max",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "rh02min",    "rh02min",    "fv3_history2d", "all", .false.,  "none",  2
+
+"gfs_phys",    "psurf",       "pressfc",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "u10m",        "ugrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "v10m",        "vgrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "crain",       "crain",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tprcp",       "tprcp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hgtsfc",      "orog",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "weasd",       "weasd",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "f10m",        "f10m",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "q2m",         "spfh2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "t2m",         "tmp2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "dpt2m",       "dpt2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tsfc",        "tmpsfc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vtype",       "vtype",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "stype",       "sotyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slmsksfc",    "land",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vfracsfc",    "veg",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "wetness",     "wetness",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zorlsfc",     "sfcr",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "uustar",      "fricv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt1",      "soilt1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt2",      "soilt2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt3",      "soilt3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt4",      "soilt4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt5",      "soilt5"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt6",      "soilt6"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt7",      "soilt7"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt8",      "soilt8"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt9",      "soilt9"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw1",      "soilw1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw2",      "soilw2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw3",      "soilw3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw4",      "soilw4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw5",      "soilw5"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw6",      "soilw6"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw7",      "soilw7"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw8",      "soilw8"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw9",      "soilw9"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_1",       "soill1",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_2",       "soill2",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_3",       "soill3",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_4",       "soill4",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_5",       "soill5",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_6",       "soill6",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_7",       "soill7",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_8",       "soill8",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_9",       "soill9",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slope",       "sltyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnsf",       "alnsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnwf",       "alnwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvsf",       "alvsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvwf",       "alvwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "canopy",      "cnwat",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facsf",       "facsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facwf",       "facwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffhh",        "ffhh",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffmm",        "ffmm",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "fice",        "icec",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hice",        "icetk",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snoalb",      "snoalb",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmax",      "shdmax",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmin",      "shdmin",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowd",       "snod",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tg3",         "tg3",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tisfc",       "tisfc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tref",        "tref",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "z_c",         "zc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_0",         "c0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_d",         "cd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_0",         "w0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_d",         "wd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xt",          "xt",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xz",          "xz",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "dt_cool",     "dtcool",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xs",          "xs",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xu",          "xu",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xv",          "xv",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xtts",        "xtts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xzts",        "xzts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "d_conv",      "dconv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "qrain",       "qrain",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "acond",        "acond",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cduvb_ave",    "cduvb_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cpofp",        "cpofp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "duvb_ave",     "duvb_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdlf_ave",    "csdlf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_ave",    "csusf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_avetoa", "csusftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdsf_ave",    "csdsf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_ave",    "csulf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_avetoa", "csulftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_phys",    "cwork_ave",    "cwork_aveclm",  "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_phys",    "fldcp",        "fldcp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "hgt_hyblev1",  "hgt_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfh_hyblev1", "spfh_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ugrd_hyblev1", "ugrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vgrd_hyblev1", "vgrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmp_hyblev1",  "tmp_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "gfluxi",       "gflux",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "lhtfl",        "lhtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "shtfl",        "shtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr",        "pevpr",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr_ave",    "pevpr_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno_ave",    "sbsno_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sfexc",        "sfexc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snohf",        "snohf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowc",        "snowc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmax2m",    "spfhmax_max2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmin2m",    "spfhmin_min2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmax2m",     "tmax_max2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmin2m",     "tmin_min2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ssrun_acc",    "ssrun_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+# "gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirbmdi",      "nirbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirdfdi",      "nirdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visbmdi",      "visbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visdfdi",      "visdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nddsf_ave",    "nddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans_ave",    "transp_ave",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs_ave",     "direvap_ave",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw_ave",     "canevap_ave",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno",        "sublim",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs",         "direvap",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw",         "canevap",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans",        "transp",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowmt_land",  "snom_land",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowmt_ice",   "snom_ice",      "fv3_history2d",  "all",  .false.,  "none",  2
+# Aerosols (CCN, IN) from Thompson microphysics
+"gfs_phys",    "nwfa",         "nwfa",          "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "nifa",         "nifa",          "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "nwfa2d",       "nwfa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "nifa2d",       "nifa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+# Cloud effective radii from Thompson and WSM6 microphysics
+"gfs_phys",    "cleffr",       "cleffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cieffr",       "cieffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cseffr",       "cseffr",        "fv3_history",    "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from MYNN
+"gfs_phys",    "QC_BL",        "qc_bl",         "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "CLDFRA",    "cldfra",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "EL_PBL",       "el_pbl",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "QKE",          "qke",           "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "maxmf",        "maxmf",         "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "nupdraft",     "nupdrafts",     "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "ktop_shallow", "ktop_shallow",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zol",          "zol",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flhc",         "flhc",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flqc",         "flqc",          "fv3_history2d",  "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from RUC LSM
+"gfs_sfc",     "rhofr",             "rhofr",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowfall_acc_land", "snacc_land",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "acsnow_land",       "accswe_land",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowfall_acc_ice",  "snacc_ice",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "acsnow_ice",        "accswe_ice",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xlaixy",            "xlaixy",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "sfalb",             "sfalb",        "fv3_history2d",  "all",  .false.,  "none",  2
+# Stochastic physics
+#"gfs_phys",    "sppt_wts",      "sppt_wts",      "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "skebu_wts",     "skebu_wts",     "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "skebv_wts",     "skebv_wts",     "fv3_history",  "all", .false., "none", 2
+#"dynamics",    "diss_est",      "diss_est",      "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "shum_wts",      "shum_wts",      "fv3_history",  "all", .false., "none", 2
+#
+"gfs_phys",    "frzr",      "frzr",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frzrb",     "frzrb",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frozr",     "frozr",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frozrb",    "frozrb",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tsnowp",    "tsnowp",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tsnowpb",   "tsnowpb",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snow",      "snow",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "graupel",   "graupel",     "fv3_history2d",  "all",  .false.,  "none",  2
+# lightning threat indices
+"gfs_sfc",     "ltg1_max",  "ltg1_max",    "fv3_history2d",   "all", .false.,   "none", 2
+"gfs_sfc",     "ltg2_max",  "ltg2_max",    "fv3_history2d",   "all", .false.,   "none", 2
+"gfs_sfc",     "ltg3_max",  "ltg3_max",    "fv3_history2d",   "all", .false.,   "none", 2
+# CLM lake model
+"gfs_sfc",     "lakefrac",         "lakefrac",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lakedepth",        "lakedepth",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t2m",         "lake_t2m",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_q2m",         "lake_q2m",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_albedo",      "lake_albedo",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_h2osno2d",    "lake_h2osno2d",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_sndpth2d",    "lake_sndpth2d",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_snl2d",       "lake_snl2d",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_grnd2d",    "lake_t_grnd2d",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_savedtke12d", "lake_savedtke12d", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_1",  "lake_t_h2osoi_vol3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_2",  "lake_t_h2osoi_vol3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_3",  "lake_t_h2osoi_vol3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_4",  "lake_t_h2osoi_vol3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_5",  "lake_t_h2osoi_vol3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_6",  "lake_t_h2osoi_vol3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_7",  "lake_t_h2osoi_vol3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_8",  "lake_t_h2osoi_vol3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_9",  "lake_t_h2osoi_vol3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_10",  "lake_t_h2osoi_vol3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_11",  "lake_t_h2osoi_vol3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_12",  "lake_t_h2osoi_vol3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_13",  "lake_t_h2osoi_vol3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_14",  "lake_t_h2osoi_vol3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_15",  "lake_t_h2osoi_vol3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_1",  "lake_t_h2osoi_liq3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_2",  "lake_t_h2osoi_liq3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_3",  "lake_t_h2osoi_liq3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_4",  "lake_t_h2osoi_liq3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_5",  "lake_t_h2osoi_liq3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_6",  "lake_t_h2osoi_liq3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_7",  "lake_t_h2osoi_liq3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_8",  "lake_t_h2osoi_liq3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_9",  "lake_t_h2osoi_liq3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_10",  "lake_t_h2osoi_liq3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_11",  "lake_t_h2osoi_liq3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_12",  "lake_t_h2osoi_liq3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_13",  "lake_t_h2osoi_liq3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_14",  "lake_t_h2osoi_liq3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_15",  "lake_t_h2osoi_liq3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_1",  "lake_t_h2osoi_ice3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_2",  "lake_t_h2osoi_ice3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_3",  "lake_t_h2osoi_ice3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_4",  "lake_t_h2osoi_ice3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_5",  "lake_t_h2osoi_ice3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_6",  "lake_t_h2osoi_ice3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_7",  "lake_t_h2osoi_ice3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_8",  "lake_t_h2osoi_ice3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_9",  "lake_t_h2osoi_ice3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_10",  "lake_t_h2osoi_ice3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_11",  "lake_t_h2osoi_ice3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_12",  "lake_t_h2osoi_ice3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_13",  "lake_t_h2osoi_ice3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_14",  "lake_t_h2osoi_ice3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_15",  "lake_t_h2osoi_ice3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_1",  "lake_t_soisno3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_2",  "lake_t_soisno3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_3",  "lake_t_soisno3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_4",  "lake_t_soisno3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_5",  "lake_t_soisno3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_6",  "lake_t_soisno3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_7",  "lake_t_soisno3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_8",  "lake_t_soisno3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_9",  "lake_t_soisno3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_10",  "lake_t_soisno3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_11",  "lake_t_soisno3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_12",  "lake_t_soisno3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_13",  "lake_t_soisno3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_14",  "lake_t_soisno3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_15",  "lake_t_soisno3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_1",  "lake_t_lake3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_2",  "lake_t_lake3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_3",  "lake_t_lake3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_4",  "lake_t_lake3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_5",  "lake_t_lake3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_6",  "lake_t_lake3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_7",  "lake_t_lake3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_8",  "lake_t_lake3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_9",  "lake_t_lake3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_10",  "lake_t_lake3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_1",  "lake_icefrac3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_2",  "lake_icefrac3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_3",  "lake_icefrac3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_4",  "lake_icefrac3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_5",  "lake_icefrac3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_6",  "lake_icefrac3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_7",  "lake_icefrac3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_8",  "lake_icefrac3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_9",  "lake_icefrac3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_10",  "lake_icefrac3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+
+"gfs_sfc",     "use_lake_model",    "use_lake_model",    "fv3_history2d","all",  .false.,  "none",  2
+#=============================================================================================
+#
+#====> This file can be used with diag_manager/v2.0a (or higher) <====
+#
+#
+#  FORMATS FOR FILE ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"file_name", output_freq, "output_units", format, "time_units", "long_name",
+#
+#
+#output_freq:  > 0  output frequency in "output_units"
+#              = 0  output frequency every time step
+#              =-1  output frequency at end of run
+#
+#output_units = units used for output frequency
+#               (years, months, days, minutes, hours, seconds)
+#
+#time_units   = units used to label the time axis
+#               (days, minutes, hours, seconds)
+#
+#
+#  FORMAT FOR FIELD ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+#
+#time_avg = .true. or .false.
+#
+#packing  = 1  double precision
+#         = 2  float
+#         = 4  packed 16-bit integers
+#         = 8  packed 1-byte (not tested?)
+# This file contains diag_table entries for the RRFS-SD.
+# It should be appended to the end of the diag_table before execution of the test.
+
+# Tracers
+"gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
+
+# Aerosols emission for smoke
+"gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "coef_bb_dc",   "coef_bb_dc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "min_fplume",   "min_fplume",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "max_fplume",   "max_fplume",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hwp",          "hwp",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hwp_ave",      "hwp_ave",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "frp_output",   "frp_output",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ebu_smoke",    "ebu_smoke",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "ext550",       "ext550",        "fv3_history",    "all",  .false.,  "none",  2

--- a/parm/diag_table.RRFS_sas_nogwd
+++ b/parm/diag_table.RRFS_sas_nogwd
@@ -1,0 +1,428 @@
+{{ starttime.strftime("%Y%m%d.%H") }}Z.{{ cres }}.32bit.non-hydro.regional
+{{ starttime.strftime("%Y %m %d %H %M %S") }}
+
+"grid_spec",              -1,  "months",  1, "days",  "time"
+"atmos_static",           -1,  "hours",   1, "hours", "time"
+#"atmos_4xdaily",          1,  "hours",   1, "days",  "time"
+"fv3_history",             1,  "years",   1, "hours", "time"
+"fv3_history2d",           1,  "years",   1, "hours", "time"
+
+#
+#=======================
+# ATMOSPHERE DIAGNOSTICS
+#=======================
+###
+# grid_spec
+###
+ "dynamics", "grid_lon", "grid_lon", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lat", "grid_lat", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lont", "grid_lont", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_latt", "grid_latt", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "area",     "area",     "grid_spec", "all", .false.,  "none", 2,
+###
+# 4x daily output
+###
+# "dynamics",  "slp",         "slp",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort850",     "vort850",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort200",     "vort200",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "us",          "us",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u1000",       "u1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u850",        "u850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u700",        "u700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u500",        "u500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u200",        "u200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u100",        "u100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u50",         "u50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u10",         "u10",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vs",          "vs",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v1000",       "v1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v850",        "v850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v700",        "v700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v500",        "v500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v200",        "v200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v100",        "v100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v50",         "v50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v10",         "v10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "tm",          "tm",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t1000",       "t1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t850",        "t850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t700",        "t700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t500",        "t500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t200",        "t200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t100",        "t100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t50",         "t50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t10",         "t10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "z1000",       "z1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z850",        "z850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z700",        "z700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z500",        "z500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z200",        "z200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z100",        "z100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z50",         "z50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z10",         "z10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "w1000",       "w1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w850",        "w850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w700",        "w700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w500",        "w500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w200",        "w200",       "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "q1000",       "q1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q850",        "q850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q700",        "q700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q500",        "q500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q200",        "q200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q100",        "q100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q50",         "q50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q10",         "q10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "rh1000",      "rh1000",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh850",       "rh850",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh700",       "rh700",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh500",       "rh500",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh200",       "rh200",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg1000",     "omg1000",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg850",      "omg850",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg700",      "omg700",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg500",      "omg500",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg200",      "omg200",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg100",      "omg100",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg50",       "omg50",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg10",       "omg10",      "atmos_4xdaily", "all", .false.,  "none", 2
+###
+# gfs static data
+###
+ "dynamics",      "pk",          "pk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "bk",          "bk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hyam",        "hyam",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hybm",        "hybm",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "zsurf",       "zsurf",        "atmos_static",      "all", .false.,  "none", 2
+###
+# FV3 variabls needed for NGGPS evaluation
+###
+"gfs_dyn",     "ucomp",       "ugrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "vcomp",       "vgrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sphum",       "spfh",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "temp",        "tmp",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "liq_wat",     "clwmr",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "o3mr",        "o3mr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delp",        "dpres",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delz",        "delz",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "w",           "dzdt",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_wat",     "icmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rainwat",     "rwmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snowwat",     "snmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel",     "grle",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "refl_10cm"    "refl_10cm"  "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "rain_nc",     "rain_nc",    "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "water_nc",    "water_nc",   "fv3_history",  "all",  .false.,  "none",  2
+
+"gfs_dyn",   "wmaxup",        "upvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "wmaxdn",        "dnvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax03",       "uhmax03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax25",       "uhmax25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin03",       "uhmin03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin25",       "uhmin25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort01",     "maxvort01",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort02",     "maxvort02",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvorthy1",    "maxvorthy1",  "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "hailcast_dhail_max", "hailcast_dhail", "fv3_history2d", "all",  .false.,  "none", 2
+
+"gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRFI",        "dlwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRF",         "ulwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFI",        "ulwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRF",         "dswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFI",        "dswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFCI",       "dswrf_clr",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRF",         "uswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFI",        "uswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "shtfl_ave",     "shtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "pwat",          "pwatclm",     "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "soilm",         "soilm",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_aveclm",   "tcdc_aveclm", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avebndcl", "tcdc_avebndcl",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avehcl",   "tcdc_avehcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avelcl",   "tcdc_avelcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avemcl",   "tcdc_avemcl", "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "TCDCcnvcl",     "tcdccnvcl",   "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "PREScnvclt",    "prescnvclt",  "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "PREScnvclb",    "prescnvclb",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehct",   "pres_avehct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehcb",   "pres_avehcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avehct",   "tmp_avehct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemct",   "pres_avemct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemcb",   "pres_avemcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avemct",   "tmp_avemct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelct",   "pres_avelct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelcb",   "pres_avelcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avelct",   "tmp_avelct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "u-gwd_ave",     "u-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "v-gwd_ave",     "v-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dusfc",         "uflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dvsfc",         "vflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvw",          "cnvcldwat",   "fv3_history2d",         "all",  .false.,  "none",  2
+
+"gfs_phys",    "u10max",     "u10max",     "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "v10max",     "v10max",     "fv3_history2d",  "all", .false.,  "none",  2
+"gfs_phys",    "spd10max",   "spd10max",   "fv3_history2d", "all", .false.,  "none",  2
+"gfs_dyn",     "ustm",        "ustm",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "vstm",        "vstm",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "srh01",        "srh01",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "srh03",        "srh03",       "fv3_history", "all", .false.,  "none",  2
+"gfs_phys",    "pratemax",    "pratemax",   "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "refdmax",    "refdmax",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "refdmax263k","refdmax263k","fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "t02max",     "t02max",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "t02min",     "t02min",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "rh02max",    "rh02max",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "rh02min",    "rh02min",    "fv3_history2d", "all", .false.,  "none",  2
+
+"gfs_phys",    "psurf",       "pressfc",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "u10m",        "ugrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "v10m",        "vgrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "crain",       "crain",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tprcp",       "tprcp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hgtsfc",      "orog",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "weasd",       "weasd",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "f10m",        "f10m",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "q2m",         "spfh2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "t2m",         "tmp2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "dpt2m",       "dpt2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tsfc",        "tmpsfc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vtype",       "vtype",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "stype",       "sotyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slmsksfc",    "land",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vfracsfc",    "veg",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "wetness",     "wetness",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zorlsfc",     "sfcr",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "uustar",      "fricv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt1",      "soilt1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt2",      "soilt2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt3",      "soilt3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt4",      "soilt4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt5",      "soilt5"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt6",      "soilt6"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt7",      "soilt7"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt8",      "soilt8"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt9",      "soilt9"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw1",      "soilw1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw2",      "soilw2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw3",      "soilw3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw4",      "soilw4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw5",      "soilw5"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw6",      "soilw6"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw7",      "soilw7"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw8",      "soilw8"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw9",      "soilw9"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_1",       "soill1",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_2",       "soill2",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_3",       "soill3",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_4",       "soill4",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_5",       "soill5",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_6",       "soill6",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_7",       "soill7",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_8",       "soill8",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_9",       "soill9",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slope",       "sltyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnsf",       "alnsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnwf",       "alnwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvsf",       "alvsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvwf",       "alvwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "canopy",      "cnwat",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facsf",       "facsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facwf",       "facwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffhh",        "ffhh",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffmm",        "ffmm",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "fice",        "icec",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hice",        "icetk",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snoalb",      "snoalb",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmax",      "shdmax",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmin",      "shdmin",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowd",       "snod",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tg3",         "tg3",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tisfc",       "tisfc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tref",        "tref",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "z_c",         "zc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_0",         "c0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_d",         "cd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_0",         "w0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_d",         "wd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xt",          "xt",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xz",          "xz",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "dt_cool",     "dtcool",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xs",          "xs",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xu",          "xu",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xv",          "xv",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xtts",        "xtts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xzts",        "xzts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "d_conv",      "dconv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "qrain",       "qrain",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "acond",        "acond",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cduvb_ave",    "cduvb_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cpofp",        "cpofp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "duvb_ave",     "duvb_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdlf_ave",    "csdlf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_ave",    "csusf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_avetoa", "csusftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdsf_ave",    "csdsf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_ave",    "csulf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_avetoa", "csulftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_phys",    "cwork_ave",    "cwork_aveclm",  "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_phys",    "fldcp",        "fldcp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "hgt_hyblev1",  "hgt_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfh_hyblev1", "spfh_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ugrd_hyblev1", "ugrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vgrd_hyblev1", "vgrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmp_hyblev1",  "tmp_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "gfluxi",       "gflux",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "lhtfl",        "lhtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "shtfl",        "shtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr",        "pevpr",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr_ave",    "pevpr_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno_ave",    "sbsno_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sfexc",        "sfexc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snohf",        "snohf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowc",        "snowc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmax2m",    "spfhmax_max2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmin2m",    "spfhmin_min2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmax2m",     "tmax_max2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmin2m",     "tmin_min2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ssrun_acc",    "ssrun_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+# "gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirbmdi",      "nirbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirdfdi",      "nirdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visbmdi",      "visbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visdfdi",      "visdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nddsf_ave",    "nddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans_ave",    "transp_ave",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs_ave",     "direvap_ave",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw_ave",     "canevap_ave",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno",        "sublim",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs",         "direvap",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw",         "canevap",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans",        "transp",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowmt_land",  "snom_land",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowmt_ice",   "snom_ice",      "fv3_history2d",  "all",  .false.,  "none",  2
+# Aerosols (CCN, IN) from Thompson microphysics
+"gfs_phys",    "nwfa",         "nwfa",          "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "nifa",         "nifa",          "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "nwfa2d",       "nwfa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "nifa2d",       "nifa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+# Cloud effective radii from Thompson and WSM6 microphysics
+"gfs_phys",    "cleffr",       "cleffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cieffr",       "cieffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cseffr",       "cseffr",        "fv3_history",    "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from MYNN
+"gfs_phys",    "QC_BL",        "qc_bl",         "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "CLDFRA",    "cldfra",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "EL_PBL",       "el_pbl",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "QKE",          "qke",           "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "maxmf",        "maxmf",         "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "nupdraft",     "nupdrafts",     "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "ktop_shallow", "ktop_shallow",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zol",          "zol",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flhc",         "flhc",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flqc",         "flqc",          "fv3_history2d",  "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from RUC LSM
+"gfs_sfc",     "rhofr",             "rhofr",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowfall_acc_land", "snacc_land",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "acsnow_land",       "accswe_land",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowfall_acc_ice",  "snacc_ice",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "acsnow_ice",        "accswe_ice",   "fv3_history2d",  "all",  .false.,  "none",  2
+# Stochastic physics
+#"gfs_phys",    "sppt_wts",      "sppt_wts",      "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "skebu_wts",     "skebu_wts",     "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "skebv_wts",     "skebv_wts",     "fv3_history",  "all", .false., "none", 2
+#"dynamics",    "diss_est",      "diss_est",      "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "shum_wts",      "shum_wts",      "fv3_history",  "all", .false., "none", 2
+#
+"gfs_phys",    "frzr",      "frzr",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frzrb",     "frzrb",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frozr",     "frozr",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frozrb",    "frozrb",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tsnowp",    "tsnowp",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tsnowpb",   "tsnowpb",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "rhonewsn",  "rhonewsn",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snow",      "snow",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "graupel",   "graupel",     "fv3_history2d",  "all",  .false.,  "none",  2
+# lightning threat indices
+"gfs_sfc",     "ltg1_max",  "ltg1_max",    "fv3_history2d",   "all", .false.,   "none", 2
+"gfs_sfc",     "ltg2_max",  "ltg2_max",    "fv3_history2d",   "all", .false.,   "none", 2
+"gfs_sfc",     "ltg3_max",  "ltg3_max",    "fv3_history2d",   "all", .false.,   "none", 2
+#=============================================================================================
+#
+#====> This file can be used with diag_manager/v2.0a (or higher) <====
+#
+#
+#  FORMATS FOR FILE ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"file_name", output_freq, "output_units", format, "time_units", "long_name",
+#
+#
+#output_freq:  > 0  output frequency in "output_units"
+#              = 0  output frequency every time step
+#              =-1  output frequency at end of run
+#
+#output_units = units used for output frequency
+#               (years, months, days, minutes, hours, seconds)
+#
+#time_units   = units used to label the time axis
+#               (days, minutes, hours, seconds)
+#
+#
+#  FORMAT FOR FIELD ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+#
+#time_avg = .true. or .false.
+#
+#packing  = 1  double precision
+#         = 2  float
+#         = 4  packed 16-bit integers
+#         = 8  packed 1-byte (not tested?)
+# This file contains diag_table entries for the RRFS-SD.
+# It should be appended to the end of the diag_table before execution of the test.
+
+# Tracers
+"gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
+
+# Aerosols emission for smoke
+"gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "coef_bb_dc",   "coef_bb_dc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "min_fplume",   "min_fplume",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "max_fplume",   "max_fplume",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hwp",          "hwp",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hwp_ave",      "hwp_ave",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "frp_output",   "frp_output",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ebu_smoke",    "ebu_smoke",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "ext550",       "ext550",        "fv3_history",    "all",  .false.,  "none",  2

--- a/parm/field_table.RRFS_sas
+++ b/parm/field_table.RRFS_sas
@@ -1,0 +1,85 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e-6" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ice water mixing ratio
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic rain water mixing ratio
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic snow water mixing ratio
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic graupel mixing ratio
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water number concentration
+ "TRACER", "atmos_mod", "water_nc"
+           "longname",     "cloud  liquid water  number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic cloud ice number concentration
+ "TRACER", "atmos_mod", "ice_nc"
+           "longname",     "cloud ice water number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic rain number concentration
+ "TRACER", "atmos_mod", "rain_nc"
+           "longname",     "rain number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# water- and ice-friendly aerosols (Thompson)
+ "TRACER", "atmos_mod", "liq_aero"
+           "longname",     "water-friendly aerosol number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+ "TRACER", "atmos_mod", "ice_aero"
+           "longname",     "ice-friendly aerosol number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic subgrid scale turbulent kinetic energy
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",     "subgrid scale turbulent kinetic energy"
+           "units",        "m2/s2"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognotsitc sigmab tracer
+ "TRACER", "atmos_mod", "sigmab"
+           "longname",     "sigma fraction"
+           "units",        "fraction"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic smoke mixing ratio tracer
+  "TRACER", "atmos_mod", "smoke"
+            "longname",     "smoke mixing ratio"
+            "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-12" /
+# prognostic dust mixing ratio tracer
+            "TRACER", "atmos_mod", "dust"
+            "longname",     "dust mixing ratio"
+            "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-12" /
+# prognostic coarsepm mixing ratio tracer
+  "TRACER", "atmos_mod", "coarsepm"
+            "longname",     "coarsepm mixing ratio"
+            "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-12" /

--- a/parm/field_table.RRFS_sas_nogwd
+++ b/parm/field_table.RRFS_sas_nogwd
@@ -1,0 +1,85 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e-6" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ice water mixing ratio
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic rain water mixing ratio
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic snow water mixing ratio
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic graupel mixing ratio
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water number concentration
+ "TRACER", "atmos_mod", "water_nc"
+           "longname",     "cloud  liquid water  number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic cloud ice number concentration
+ "TRACER", "atmos_mod", "ice_nc"
+           "longname",     "cloud ice water number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic rain number concentration
+ "TRACER", "atmos_mod", "rain_nc"
+           "longname",     "rain number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# water- and ice-friendly aerosols (Thompson)
+ "TRACER", "atmos_mod", "liq_aero"
+           "longname",     "water-friendly aerosol number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+ "TRACER", "atmos_mod", "ice_aero"
+           "longname",     "ice-friendly aerosol number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic subgrid scale turbulent kinetic energy
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",     "subgrid scale turbulent kinetic energy"
+           "units",        "m2/s2"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognotsitc sigmab tracer
+ "TRACER", "atmos_mod", "sigmab"
+           "longname",     "sigma fraction"
+           "units",        "fraction"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic smoke mixing ratio tracer
+  "TRACER", "atmos_mod", "smoke"
+            "longname",     "smoke mixing ratio"
+            "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-12" /
+# prognostic dust mixing ratio tracer
+            "TRACER", "atmos_mod", "dust"
+            "longname",     "dust mixing ratio"
+            "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-12" /
+# prognostic coarsepm mixing ratio tracer
+  "TRACER", "atmos_mod", "coarsepm"
+            "longname",     "coarsepm mixing ratio"
+            "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-12" /

--- a/parm/input.nml.RRFSFW
+++ b/parm/input.nml.RRFSFW
@@ -136,6 +136,7 @@
 /
 
 &gfs_physics_nml
+    betadcu = 1.0
     bl_mynn_edmf = 1
     bl_mynn_edmf_mom = 1
     bl_mynn_tkeadvect = .true.
@@ -177,7 +178,7 @@
     icloud_bl = 1
     ico2 = 2
     iems = 2
-    imfdeepcnv = 3
+    imfdeepcnv = 2
     imfshalcnv = -1
     imp_physics = 8
     iopt_alb = 2
@@ -221,6 +222,7 @@
     pdfcld = .false.
     pre_rad = .false.
     print_diff_pgr = .true.
+    progsigma = .true.
     prslrd0 = 0.0
     random_clds = .false.
     redrag = .true.

--- a/scripts/exrrfs_make_ics.sh
+++ b/scripts/exrrfs_make_ics.sh
@@ -258,7 +258,9 @@ case "${CCPP_PHYS_SUITE}" in
   "FV3_HRRR" | \
   "FV3_HRRR_gf" | \
   "FV3_HRRR_gf_nogwd" | \
-  "FV3_RAP" )
+  "FV3_RAP" | \
+  "RRFS_sas" | \
+  "RRFS_sas_nogwd" )
     if [ "${EXTRN_MDL_NAME_ICS}" = "RRFS" ] || \
        [ "${EXTRN_MDL_NAME_ICS}" = "GFS" ] || \
        [ "${EXTRN_MDL_NAME_ICS}" = "GDASENKF" ]; then

--- a/scripts/exrrfs_make_lbcs.sh
+++ b/scripts/exrrfs_make_lbcs.sh
@@ -352,7 +352,9 @@ case "${CCPP_PHYS_SUITE}" in
   "FV3_HRRR" | \
   "FV3_HRRR_gf" | \
   "FV3_HRRR_gf_nogwd" | \
-  "FV3_RAP" )
+  "FV3_RAP" | \
+  "RRFS_sas" | \
+  "RRFS_sas_nogwd" )
     if [ "${EXTRN_MDL_NAME_LBCS}" = "RRFS" ] || \
        [ "${EXTRN_MDL_NAME_LBCS}" = "GFS" ] || \
        [ "${EXTRN_MDL_NAME_LBCS}" = "GEFS" ]; then

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -159,7 +159,7 @@ if (BUILD_UFS)
     if(CPL_AQM)
       set(CCPP_SUITES "FV3_GFS_v16")
     else()
-      set(CCPP_SUITES "FV3_HRRR,FV3_HRRR_gf,FV3_HRRR_gf_nogwd,FV3_RAP,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RRFS_v1beta,FV3_GFS_v16,RRFSens_phy1,RRFSens_phy2,RRFSens_phy3,RRFSens_phy4,RRFSens_phy5")
+      set(CCPP_SUITES "FV3_HRRR,FV3_HRRR_gf,FV3_HRRR_gf_nogwd,FV3_RAP,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RRFS_v1beta,FV3_GFS_v16,RRFSens_phy1,RRFSens_phy2,RRFSens_phy3,RRFSens_phy4,RRFSens_phy5,RRFS_sas,RRFS_sas_nogwd")
 
     endif()
   endif()

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -13,7 +13,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = ce43a6f
+hash = 7813700
 local_path = ufs-weather-model
 required = True
 

--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -32,6 +32,8 @@ valid_vals_CCPP_PHYS_SUITE=( \
 "FV3_HRRR_gf_nogwd" \
 "FV3_RAP" \
 "FV3_GFS_v15_thompson_mynn_lam3km" \
+"RRFS_sas" \
+"RRFS_sas_nogwd" \
 ) 
 valid_vals_GFDLgrid_RES=("48" "96" "192" "384" "768" "1152" "3072")
 valid_vals_EXTRN_MDL_NAME_ICS=("GFS" "GDASENKF" "RRFS")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR to the production/RRFS.v1 branch combines the changes included in PR #439 and PR #457 for adding the saSAS convection option to the real-time parallel.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
No tests conducted.  Tests were run on the dev-sci branch with these changes.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@JiliDong-NOAA 
