### PR TITLE
[dev-sci] Update ufs-weather-model hash, default CCPP suite

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -13,7 +13,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 7813700
+hash = 0d12f68
 local_path = ufs-weather-model
 required = True
 

--- a/ush/set_rrfs_config_general.sh
+++ b/ush/set_rrfs_config_general.sh
@@ -431,7 +431,7 @@ elif [[ ${PREDEF_GRID_NAME} == "RRFS_CONUS_13km" ]] ; then
 
 elif [[ ${PREDEF_GRID_NAME} == "RRFS_NA_3km" ]] ; then 
   DT_ATMOS=36
-  CCPP_PHYS_SUITE="FV3_HRRR_gf"
+  CCPP_PHYS_SUITE="RRFS_sas"
   ADDNL_OUTPUT_GRIDS=( "hrrr" "hrrrak" )
   TILE_LABELS="NA hrrr_regions1 hrrr_regions2 hrrr_tiles1 hrrr_tiles2 hrrr_tiles3 \
     hrrr_tiles4 hrrrak_tiles"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The ufs-weather-model version is updated to #0d12f68.  This update includes a typo fix to FV3/ccpp/suites/suite_RRFS_sas_nogwd.xml that caused the model compilation to fail.
- The default CCPP suite in ush/set_rrfs_config_general.sh for the RRFS_NA_3km grid has been updated to RRFS_sas.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Successfully compiled the ufs-weather-model code on Dogwood.

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@JiliDong-NOAA 
