### PR TITLE
[production/RRFS.v1] Fix issue of modules being loaded twice

### DIFF
--- a/modulefiles/tasks/wcoss2/analysis_gsi.local.lua
+++ b/modulefiles/tasks/wcoss2/analysis_gsi.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/blend_ics.local.lua
+++ b/modulefiles/tasks/wcoss2/blend_ics.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/bufrsnd.local.lua
+++ b/modulefiles/tasks/wcoss2/bufrsnd.local.lua
@@ -1,11 +1,11 @@
-load("python_srw")
-
 unload("PrgEnv-intel")
 unload("netcdf")
 
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/enkf_radarref.local.lua
+++ b/modulefiles/tasks/wcoss2/enkf_radarref.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/enkfupdt.local.lua
+++ b/modulefiles/tasks/wcoss2/enkfupdt.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/forecast.local.lua
+++ b/modulefiles/tasks/wcoss2/forecast.local.lua
@@ -1,11 +1,11 @@
-load("python_srw")
-
 unload("cray_mpich")
 unload("netcdf")
 
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/hybrid_radar_ref.local.lua
+++ b/modulefiles/tasks/wcoss2/hybrid_radar_ref.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/make_grid.local.lua
+++ b/modulefiles/tasks/wcoss2/make_grid.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/make_ics.local.lua
+++ b/modulefiles/tasks/wcoss2/make_ics.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/make_lbcs.local.lua
+++ b/modulefiles/tasks/wcoss2/make_lbcs.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/make_orog.local.lua
+++ b/modulefiles/tasks/wcoss2/make_orog.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/make_sfc_climo.local.lua
+++ b/modulefiles/tasks/wcoss2/make_sfc_climo.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/post.local.lua
+++ b/modulefiles/tasks/wcoss2/post.local.lua
@@ -1,11 +1,11 @@
-load("python_srw")
-
 unload("PrgEnv-intel")
 unload("netcdf")
 
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/prdgen.local.lua
+++ b/modulefiles/tasks/wcoss2/prdgen.local.lua
@@ -1,9 +1,10 @@
-load("python_srw")
 load(pathJoin("cfp", os.getenv("cfp_ver")))
 
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/prep_cyc.local.lua
+++ b/modulefiles/tasks/wcoss2/prep_cyc.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/process_smoke.local.lua
+++ b/modulefiles/tasks/wcoss2/process_smoke.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/python_srw.lua
+++ b/modulefiles/tasks/wcoss2/python_srw.lua
@@ -1,5 +1,0 @@
-load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
-load(pathJoin("craype", os.getenv("craype_ver")))
-load(pathJoin("intel", os.getenv("intel_ver")))
-load(pathJoin("python", os.getenv("python_ver")))
-load(pathJoin("prod_util", os.getenv("prod_util_ver")))

--- a/modulefiles/tasks/wcoss2/recenter.local.lua
+++ b/modulefiles/tasks/wcoss2/recenter.local.lua
@@ -1,11 +1,11 @@
-load("python_srw")
-
 unload("PrgEnv-intel")
 unload("netcdf")
 
 load(pathJoin("PrgEnv-intel", os.getenv("PrgEnv_intel_ver")))
 load(pathJoin("intel", os.getenv("intel_ver")))
 load(pathJoin("craype", os.getenv("craype_ver")))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver")))
 load(pathJoin("cray-pals", os.getenv("cray_pals_ver")))
 

--- a/modulefiles/tasks/wcoss2/save_restart.local.lua
+++ b/modulefiles/tasks/wcoss2/save_restart.local.lua
@@ -1,8 +1,8 @@
-load("python_srw")
-
 load(pathJoin("PrgEnv-intel", "8.1.0"))
 load(pathJoin("intel", "19.1.3.304"))
 load(pathJoin("craype", "2.7.13"))
+load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("cray-mpich", "8.1.7"))
 
 setenv("HPC_OPT", "/apps/ops/para/libs")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- On WCOSS2, the python_srw module is loaded for every task.  Because of this, some modules are loaded twice, including PrgEnv-intel, craype, and intel.  With this PR, python_srw is removed, and the python module is loaded in each individual task's modulefile instead.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Completed a successful non-DA engineering test on Dogwood.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #136  