### PR TITLE
[dev-sci] Updates the miniconda3 used for building workflow on Hera

### DIFF
--- a/modulefiles/wflow_hera.lua
+++ b/modulefiles/wflow_hera.lua
@@ -12,11 +12,11 @@ load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.5.0"))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("stack_impi_ver") or "2021.5.1"))
 load(pathJoin("crtm", os.getenv("crtm_ver") or "2.4.0"))
 
-prepend_path("MODULEPATH","/scratch1/NCEPDEV/nems/role.epic/miniconda3/modulefiles")
+prepend_path("MODULEPATH","/contrib/miniconda3/modulefiles")
 load(pathJoin("miniconda3", os.getenv("miniconda3_ver") or "4.12.0"))
 
 if mode() == "load" then
    LmodMsgRaw([===[Please do the following to activate conda:
-       > conda activate workflow_tools
+       > conda activate regional_workflow
 ]===])
 end


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
Updates wflow_hera to point at a miniconda3 that exists.  Previous noaa-epic version appears gone (and seems like SRW now does something very different - builds the conda environment(?))

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

Problem was reported by @xyzemc , and she confirmed that things worked normally for her after picking up the updated wflow_hera file.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #492 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

@xyzemc confirmed the fix.