### PR TITLE
[dev-sci] Fix issues with real-time parallel related to SAS

### DIFF
--- a/parm/FV3.input.yml_ensphy
+++ b/parm/FV3.input.yml_ensphy
@@ -7,15 +7,18 @@ rrfsens_phy1:
   atmos_model_nml:
     ccpp_suite: 'RRFSens_phy1'
   gfs_physics_nml: 
+    betadcu:
     bl_mynn_edmf: 
     bl_mynn_edmf_mom: 
     bl_mynn_tkeadvect: 
     do_mynnedmf: false
     do_mynnsfclay: false
+    imfdeepcnv: 3
     imfshalcnv: 3
     isatmedmf: 1
     lkm: 1
     n_var_spp: 4
+    progsigma:
     satmedmf: true
     shal_cnv: true
     gf_coldstart: true
@@ -79,6 +82,8 @@ rrfsens_phy3:
   fv_core_nml:
     nwat: 7
   gfs_physics_nml:
+    betadcu:
+    imfdeepcnv: 3
     imp_physics: 17
     lkm: 1
     nssl_alphah: 2.32
@@ -89,6 +94,7 @@ rrfsens_phy3:
     nssl_ehw0: 0.79
     nssl_hail_on: true
     nssl_invertccn: true
+    progsigma:
     rrfs_sd :
     rrfs_smoke_debug :
     seas_opt :
@@ -117,11 +123,13 @@ rrfsens_phy4:
   fv_core_nml:
     nwat: 7
   gfs_physics_nml:
+    betadcu:
     bl_mynn_edmf:
     bl_mynn_edmf_mom:
     bl_mynn_tkeadvect:
     do_mynnedmf: false
     do_mynnsfclay: false
+    imfdeepcnv: 3
     imfshalcnv: 3
     imp_physics: 17
     isatmedmf: 1
@@ -135,6 +143,7 @@ rrfsens_phy4:
     nssl_ehw0: 0.62
     nssl_hail_on: true
     nssl_invertccn: true
+    progsigma:
     satmedmf: true
     shal_cnv: true
     gf_coldstart: true

--- a/parm/diag_table.RRFS_sas_clm
+++ b/parm/diag_table.RRFS_sas_clm
@@ -1,0 +1,523 @@
+{{ starttime.strftime("%Y%m%d.%H") }}Z.{{ cres }}.32bit.non-hydro.regional
+{{ starttime.strftime("%Y %m %d %H %M %S") }}
+
+"grid_spec",              -1,  "months",  1, "days",  "time"
+"atmos_static",           -1,  "hours",   1, "hours", "time"
+#"atmos_4xdaily",          1,  "hours",   1, "days",  "time"
+"fv3_history",             0,  "hours",   1, "hours", "time"
+"fv3_history2d",           0,  "hours",   1, "hours", "time"
+
+#
+#=======================
+# ATMOSPHERE DIAGNOSTICS
+#=======================
+###
+# grid_spec
+###
+ "dynamics", "grid_lon", "grid_lon", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lat", "grid_lat", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lont", "grid_lont", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_latt", "grid_latt", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "area",     "area",     "grid_spec", "all", .false.,  "none", 2,
+###
+# 4x daily output
+###
+# "dynamics",  "slp",         "slp",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort850",     "vort850",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort200",     "vort200",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "us",          "us",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u1000",       "u1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u850",        "u850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u700",        "u700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u500",        "u500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u200",        "u200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u100",        "u100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u50",         "u50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u10",         "u10",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vs",          "vs",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v1000",       "v1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v850",        "v850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v700",        "v700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v500",        "v500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v200",        "v200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v100",        "v100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v50",         "v50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v10",         "v10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "tm",          "tm",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t1000",       "t1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t850",        "t850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t700",        "t700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t500",        "t500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t200",        "t200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t100",        "t100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t50",         "t50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t10",         "t10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "z1000",       "z1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z850",        "z850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z700",        "z700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z500",        "z500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z200",        "z200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z100",        "z100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z50",         "z50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z10",         "z10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "w1000",       "w1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w850",        "w850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w700",        "w700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w500",        "w500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w200",        "w200",       "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "q1000",       "q1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q850",        "q850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q700",        "q700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q500",        "q500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q200",        "q200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q100",        "q100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q50",         "q50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q10",         "q10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "rh1000",      "rh1000",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh850",       "rh850",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh700",       "rh700",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh500",       "rh500",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh200",       "rh200",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg1000",     "omg1000",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg850",      "omg850",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg700",      "omg700",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg500",      "omg500",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg200",      "omg200",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg100",      "omg100",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg50",       "omg50",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg10",       "omg10",      "atmos_4xdaily", "all", .false.,  "none", 2
+###
+# gfs static data
+###
+ "dynamics",      "pk",          "pk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "bk",          "bk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hyam",        "hyam",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hybm",        "hybm",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "zsurf",       "zsurf",        "atmos_static",      "all", .false.,  "none", 2
+###
+# FV3 variabls needed for NGGPS evaluation
+###
+"gfs_dyn",     "ucomp",       "ugrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "vcomp",       "vgrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sphum",       "spfh",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "temp",        "tmp",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "liq_wat",     "clwmr",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "o3mr",        "o3mr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delp",        "dpres",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delz",        "delz",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "w",           "dzdt",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_wat",     "icmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rainwat",     "rwmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snowwat",     "snmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel",     "grle",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "refl_10cm"    "refl_10cm"  "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "rain_nc",     "rain_nc",    "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "water_nc",    "water_nc",   "fv3_history",  "all",  .false.,  "none",  2
+
+"gfs_dyn",   "wmaxup",        "upvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "wmaxdn",        "dnvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax03",       "uhmax03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax25",       "uhmax25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin03",       "uhmin03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin25",       "uhmin25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort01",     "maxvort01",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort02",     "maxvort02",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvorthy1",    "maxvorthy1",  "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "hailcast_dhail_max", "hailcast_dhail", "fv3_history2d", "all",  .false.,  "none", 2
+
+"gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRFI",        "dlwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRF",         "ulwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFI",        "ulwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRF",         "dswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFI",        "dswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFCI",       "dswrf_clr",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRF",         "uswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFI",        "uswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFItoa",     "ulwrf_toa",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "shtfl_ave",     "shtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "pwat",          "pwatclm",     "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "soilm",         "soilm",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_aveclm",   "tcdc_aveclm", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avebndcl", "tcdc_avebndcl",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avehcl",   "tcdc_avehcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avelcl",   "tcdc_avelcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avemcl",   "tcdc_avemcl", "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "TCDCcnvcl",     "tcdccnvcl",   "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "PREScnvclt",    "prescnvclt",  "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "PREScnvclb",    "prescnvclb",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehct",   "pres_avehct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehcb",   "pres_avehcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avehct",   "tmp_avehct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemct",   "pres_avemct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemcb",   "pres_avemcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avemct",   "tmp_avemct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelct",   "pres_avelct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelcb",   "pres_avelcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avelct",   "tmp_avelct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "u-gwd_ave",     "u-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "v-gwd_ave",     "v-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dusfc",         "uflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dvsfc",         "vflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvw",          "cnvcldwat",   "fv3_history2d",         "all",  .false.,  "none",  2
+
+"gfs_phys",    "u10max",     "u10max",     "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "v10max",     "v10max",     "fv3_history2d",  "all", .false.,  "none",  2
+"gfs_phys",    "spd10max",   "spd10max",   "fv3_history2d", "all", .false.,  "none",  2
+"gfs_dyn",     "ustm",        "ustm",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "vstm",        "vstm",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "srh01",        "srh01",       "fv3_history", "all", .false.,  "none",  2
+"gfs_dyn",     "srh03",        "srh03",       "fv3_history", "all", .false.,  "none",  2
+"gfs_phys",    "pratemax",    "pratemax",   "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "refdmax",    "refdmax",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "refdmax263k","refdmax263k","fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "t02max",     "t02max",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "t02min",     "t02min",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "rh02max",    "rh02max",    "fv3_history2d", "all", .false.,  "none",  2
+"gfs_phys",    "rh02min",    "rh02min",    "fv3_history2d", "all", .false.,  "none",  2
+
+"gfs_phys",    "psurf",       "pressfc",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "u10m",        "ugrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "v10m",        "vgrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "crain",       "crain",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tprcp",       "tprcp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hgtsfc",      "orog",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "weasd",       "weasd",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "f10m",        "f10m",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "q2m",         "spfh2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "t2m",         "tmp2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "dpt2m",       "dpt2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tsfc",        "tmpsfc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vtype",       "vtype",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "stype",       "sotyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slmsksfc",    "land",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vfracsfc",    "veg",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "wetness",     "wetness",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zorlsfc",     "sfcr",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "uustar",      "fricv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt1",      "soilt1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt2",      "soilt2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt3",      "soilt3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt4",      "soilt4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt5",      "soilt5"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt6",      "soilt6"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt7",      "soilt7"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt8",      "soilt8"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt9",      "soilt9"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw1",      "soilw1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw2",      "soilw2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw3",      "soilw3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw4",      "soilw4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw5",      "soilw5"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw6",      "soilw6"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw7",      "soilw7"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw8",      "soilw8"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw9",      "soilw9"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_1",       "soill1",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_2",       "soill2",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_3",       "soill3",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_4",       "soill4",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_5",       "soill5",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_6",       "soill6",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_7",       "soill7",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_8",       "soill8",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_9",       "soill9",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slope",       "sltyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnsf",       "alnsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnwf",       "alnwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvsf",       "alvsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvwf",       "alvwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "canopy",      "cnwat",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facsf",       "facsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facwf",       "facwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffhh",        "ffhh",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffmm",        "ffmm",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "fice",        "icec",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hice",        "icetk",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snoalb",      "snoalb",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmax",      "shdmax",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmin",      "shdmin",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowd",       "snod",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tg3",         "tg3",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tisfc",       "tisfc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tref",        "tref",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "z_c",         "zc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_0",         "c0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_d",         "cd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_0",         "w0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_d",         "wd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xt",          "xt",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xz",          "xz",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "dt_cool",     "dtcool",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xs",          "xs",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xu",          "xu",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xv",          "xv",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xtts",        "xtts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xzts",        "xzts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "d_conv",      "dconv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "qrain",       "qrain",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "acond",        "acond",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cduvb_ave",    "cduvb_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cpofp",        "cpofp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "duvb_ave",     "duvb_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdlf_ave",    "csdlf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_ave",    "csusf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_avetoa", "csusftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdsf_ave",    "csdsf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_ave",    "csulf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_avetoa", "csulftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_phys",    "cwork_ave",    "cwork_aveclm",  "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_phys",    "fldcp",        "fldcp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "hgt_hyblev1",  "hgt_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfh_hyblev1", "spfh_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ugrd_hyblev1", "ugrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vgrd_hyblev1", "vgrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmp_hyblev1",  "tmp_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "gfluxi",       "gflux",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "lhtfl",        "lhtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "shtfl",        "shtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr",        "pevpr",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr_ave",    "pevpr_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno_ave",    "sbsno_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sfexc",        "sfexc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snohf",        "snohf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowc",        "snowc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmax2m",    "spfhmax_max2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmin2m",    "spfhmin_min2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmax2m",     "tmax_max2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmin2m",     "tmin_min2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ssrun_acc",    "ssrun_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+# "gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirbmdi",      "nirbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nirdfdi",      "nirdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visbmdi",      "visbmdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "visdfdi",      "visdfdi",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nddsf_ave",    "nddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans_ave",    "transp_ave",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs_ave",     "direvap_ave",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw_ave",     "canevap_ave",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno",        "sublim",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs",         "direvap",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw",         "canevap",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans",        "transp",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowmt_land",  "snom_land",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowmt_ice",   "snom_ice",      "fv3_history2d",  "all",  .false.,  "none",  2
+# Aerosols (CCN, IN) from Thompson microphysics
+"gfs_phys",    "nwfa",         "nwfa",          "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "nifa",         "nifa",          "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "nwfa2d",       "nwfa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "nifa2d",       "nifa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+# Cloud effective radii from Thompson and WSM6 microphysics
+"gfs_phys",    "cleffr",       "cleffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cieffr",       "cieffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cseffr",       "cseffr",        "fv3_history",    "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from MYNN
+"gfs_phys",    "QC_BL",        "qc_bl",         "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "CLDFRA",    "cldfra",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "EL_PBL",       "el_pbl",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "QKE",          "qke",           "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "maxmf",        "maxmf",         "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "nupdraft",     "nupdrafts",     "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "ktop_shallow", "ktop_shallow",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zol",          "zol",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flhc",         "flhc",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flqc",         "flqc",          "fv3_history2d",  "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from RUC LSM
+"gfs_sfc",     "rhofr",             "rhofr",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowfall_acc_land", "snacc_land",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "acsnow_land",       "accswe_land",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowfall_acc_ice",  "snacc_ice",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "acsnow_ice",        "accswe_ice",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xlaixy",            "xlaixy",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "sfalb",             "sfalb",        "fv3_history2d",  "all",  .false.,  "none",  2
+# Stochastic physics
+#"gfs_phys",    "sppt_wts",      "sppt_wts",      "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "skebu_wts",     "skebu_wts",     "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "skebv_wts",     "skebv_wts",     "fv3_history",  "all", .false., "none", 2
+#"dynamics",    "diss_est",      "diss_est",      "fv3_history",  "all", .false., "none", 2
+#"gfs_phys",    "shum_wts",      "shum_wts",      "fv3_history",  "all", .false., "none", 2
+#
+"gfs_phys",    "frzr",      "frzr",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frzrb",     "frzrb",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frozr",     "frozr",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "frozrb",    "frozrb",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tsnowp",    "tsnowp",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tsnowpb",   "tsnowpb",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snow",      "snow",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "graupel",   "graupel",     "fv3_history2d",  "all",  .false.,  "none",  2
+# lightning threat indices
+"gfs_sfc",     "ltg1_max",  "ltg1_max",    "fv3_history2d",   "all", .false.,   "none", 2
+"gfs_sfc",     "ltg2_max",  "ltg2_max",    "fv3_history2d",   "all", .false.,   "none", 2
+"gfs_sfc",     "ltg3_max",  "ltg3_max",    "fv3_history2d",   "all", .false.,   "none", 2
+# CLM lake model
+"gfs_sfc",     "lakefrac",         "lakefrac",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lakedepth",        "lakedepth",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t2m",         "lake_t2m",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_q2m",         "lake_q2m",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_albedo",      "lake_albedo",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_h2osno2d",    "lake_h2osno2d",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_sndpth2d",    "lake_sndpth2d",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_snl2d",       "lake_snl2d",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_grnd2d",    "lake_t_grnd2d",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_savedtke12d", "lake_savedtke12d", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_1",  "lake_t_h2osoi_vol3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_2",  "lake_t_h2osoi_vol3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_3",  "lake_t_h2osoi_vol3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_4",  "lake_t_h2osoi_vol3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_5",  "lake_t_h2osoi_vol3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_6",  "lake_t_h2osoi_vol3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_7",  "lake_t_h2osoi_vol3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_8",  "lake_t_h2osoi_vol3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_9",  "lake_t_h2osoi_vol3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_10",  "lake_t_h2osoi_vol3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_11",  "lake_t_h2osoi_vol3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_12",  "lake_t_h2osoi_vol3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_13",  "lake_t_h2osoi_vol3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_14",  "lake_t_h2osoi_vol3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_vol3d_15",  "lake_t_h2osoi_vol3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_1",  "lake_t_h2osoi_liq3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_2",  "lake_t_h2osoi_liq3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_3",  "lake_t_h2osoi_liq3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_4",  "lake_t_h2osoi_liq3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_5",  "lake_t_h2osoi_liq3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_6",  "lake_t_h2osoi_liq3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_7",  "lake_t_h2osoi_liq3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_8",  "lake_t_h2osoi_liq3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_9",  "lake_t_h2osoi_liq3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_10",  "lake_t_h2osoi_liq3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_11",  "lake_t_h2osoi_liq3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_12",  "lake_t_h2osoi_liq3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_13",  "lake_t_h2osoi_liq3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_14",  "lake_t_h2osoi_liq3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_liq3d_15",  "lake_t_h2osoi_liq3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_1",  "lake_t_h2osoi_ice3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_2",  "lake_t_h2osoi_ice3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_3",  "lake_t_h2osoi_ice3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_4",  "lake_t_h2osoi_ice3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_5",  "lake_t_h2osoi_ice3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_6",  "lake_t_h2osoi_ice3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_7",  "lake_t_h2osoi_ice3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_8",  "lake_t_h2osoi_ice3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_9",  "lake_t_h2osoi_ice3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_10",  "lake_t_h2osoi_ice3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_11",  "lake_t_h2osoi_ice3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_12",  "lake_t_h2osoi_ice3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_13",  "lake_t_h2osoi_ice3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_14",  "lake_t_h2osoi_ice3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_h2osoi_ice3d_15",  "lake_t_h2osoi_ice3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_1",  "lake_t_soisno3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_2",  "lake_t_soisno3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_3",  "lake_t_soisno3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_4",  "lake_t_soisno3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_5",  "lake_t_soisno3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_6",  "lake_t_soisno3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_7",  "lake_t_soisno3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_8",  "lake_t_soisno3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_9",  "lake_t_soisno3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_10",  "lake_t_soisno3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_11",  "lake_t_soisno3d_11",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_12",  "lake_t_soisno3d_12",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_13",  "lake_t_soisno3d_13",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_14",  "lake_t_soisno3d_14",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_soisno3d_15",  "lake_t_soisno3d_15",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_1",  "lake_t_lake3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_2",  "lake_t_lake3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_3",  "lake_t_lake3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_4",  "lake_t_lake3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_5",  "lake_t_lake3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_6",  "lake_t_lake3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_7",  "lake_t_lake3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_8",  "lake_t_lake3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_9",  "lake_t_lake3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_t_lake3d_10",  "lake_t_lake3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_1",  "lake_icefrac3d_1",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_2",  "lake_icefrac3d_2",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_3",  "lake_icefrac3d_3",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_4",  "lake_icefrac3d_4",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_5",  "lake_icefrac3d_5",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_6",  "lake_icefrac3d_6",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_7",  "lake_icefrac3d_7",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_8",  "lake_icefrac3d_8",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_9",  "lake_icefrac3d_9",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_sfc",     "lake_icefrac3d_10",  "lake_icefrac3d_10",  "fv3_history",  "all",  .false.,  "none",  2
+
+"gfs_sfc",     "use_lake_model",    "use_lake_model",    "fv3_history2d","all",  .false.,  "none",  2
+#=============================================================================================
+#
+#====> This file can be used with diag_manager/v2.0a (or higher) <====
+#
+#
+#  FORMATS FOR FILE ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"file_name", output_freq, "output_units", format, "time_units", "long_name",
+#
+#
+#output_freq:  > 0  output frequency in "output_units"
+#              = 0  output frequency every time step
+#              =-1  output frequency at end of run
+#
+#output_units = units used for output frequency
+#               (years, months, days, minutes, hours, seconds)
+#
+#time_units   = units used to label the time axis
+#               (days, minutes, hours, seconds)
+#
+#
+#  FORMAT FOR FIELD ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+#
+#time_avg = .true. or .false.
+#
+#packing  = 1  double precision
+#         = 2  float
+#         = 4  packed 16-bit integers
+#         = 8  packed 1-byte (not tested?)
+# This file contains diag_table entries for the RRFS-SD.
+# It should be appended to the end of the diag_table before execution of the test.
+
+# Tracers
+"gfs_dyn",     "smoke",       "smoke",     "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust",        "dust",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm",    "coarsepm",  "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "smoke_ave",       "smoke_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "dust_ave",        "dust_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_dyn",     "coarsepm_ave",    "coarsepm_ave",  "fv3_history2d",  "all",  .false.,  "none",  2
+
+# Aerosols emission for smoke
+"gfs_sfc",     "emdust",       "emdust",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "coef_bb_dc",   "coef_bb_dc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "min_fplume",   "min_fplume",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "max_fplume",   "max_fplume",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hwp",          "hwp",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hwp_ave",      "hwp_ave",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "frp_output",   "frp_output",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ebu_smoke",    "ebu_smoke",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "ext550",       "ext550",        "fv3_history",    "all",  .false.,  "none",  2

--- a/scripts/exrrfs_run_fcst.sh
+++ b/scripts/exrrfs_run_fcst.sh
@@ -256,7 +256,7 @@ fi
 # wave drag parameterization in that suite.  Below, create symlinks to these 
 # files in the run directory.
 #
-suites=( "FV3_RAP" "FV3_HRRR" "FV3_HRRR_gf" "FV3_GFS_v15_thompson_mynn_lam3km" "FV3_GFS_v17_p8" )
+suites=( "RRFS_sas" "FV3_RAP" "FV3_HRRR" "FV3_HRRR_gf" "FV3_GFS_v15_thompson_mynn_lam3km" "FV3_GFS_v17_p8" )
 if [[ ${suites[@]} =~ "${CCPP_PHYS_SUITE}" ]] ; then
   fileids=( "ss" "ls" )
   for fileid in "${fileids[@]}"; do


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR fixes three small issues related to using the saSAS convective scheme in the real-time parallel:
- parm/FV3.input.yml_ensphy is updated to fix the issues with the ensemble namelist generation.  imfdeepcnv, betadcu, and progsigma are now set properly for each ensemble member.
- "RRFS_sas" is added as a CCPP suite option to scripts/exrrfs_run_fcst.sh so that the oro_data_ls and oro_data_ss (orographic GWD suite files) can be located by the forecast task.
- A diag_table.RRFS_sas_clm file is added to the parm directory, which is needed by the forecast task.
- A similar PR to production/RRFS.v1 will be made today.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
These changes have been tested in the real-time parallel.  I also ran an offline test to generate the ensemble member namelists, and they are now generated correctly.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #491 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@JiliDong-NOAA @ShunLiu-NOAA  @MatthewPyle-NOAA
