### PR TITLE
fixed PEP8 F633, and PEP8 problems in the documentation build

### DIFF
--- a/.github/workflows/pytest_flake8.yml
+++ b/.github/workflows/pytest_flake8.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors
-        flake8 . --count --select=E9,F7 --show-source --statistics
+        flake8 . --count --select=E9,F7,F6 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ush/python_utils/__pycache__/
 
 __pycache__
 *.swp
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ush/python_utils/__pycache__/
 __pycache__
 *.swp
 .venv
+*~

--- a/doc/UsersGuide/source/conf.py
+++ b/doc/UsersGuide/source/conf.py
@@ -16,8 +16,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
-
-
 # -- Project information -----------------------------------------------------
 
 project = 'RRFS-Workflow Users Guide'
@@ -56,7 +54,7 @@ extensions = [
 ]
 
 bibtex_bibfiles = ['references.bib']
-#bibtex_bibfiles = ['refs.bib']
+# bibtex_bibfiles = ['refs.bib']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -104,9 +102,10 @@ html_theme_options = {"body_max_width": "none"}
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = []
+# html_static_path = []
 html_static_path = ['_static']
 html_context = {}
+
 
 def setup(app):
     app.add_css_file('custom.css')  # may also be an URL
@@ -134,19 +133,19 @@ htmlhelp_basename = 'rrfs-workflow'
 latex_engine = 'pdflatex'
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-      'papersize': 'letterpaper',
+    'papersize': 'letterpaper',
 
     # The font size ('10pt', '11pt' or '12pt').
-      'pointsize': '11pt',
+    'pointsize': '11pt',
 
     # Additional stuff for the LaTeX preamble.
-      'preamble': r'''
+    'preamble': r'''
         \usepackage{charter}
         \usepackage[defaultsans]{lato}
         \usepackage{inconsolata}
     ''',
     # Release name prefix
-      'releasename': ' ',
+    'releasename': ' ',
 
     # Latex figure (float) alignment
     #

--- a/ush/rocoto/rocoto_viewer.py
+++ b/ush/rocoto/rocoto_viewer.py
@@ -118,7 +118,7 @@ def sigwinch_handler(signum, frame):
 
 def usage(message=None):
     curses.endwin()
-    print>>sys.stderr, '''
+    print('''
 Usage: rocoto_status_viewer.py  -w workflow.xml -d database.db [--listtasks]\n                                                               [--html=filename.html]\n                                                               [--perfmetrics={True,False}]
 
 Mandatory arguments:
@@ -128,10 +128,10 @@ Optional arguments:
   --listtasks             --- print out a list of all tasks
   --html=filename.html    --- creates an HTML document of status
   --perfmetrics=True      --- turn on/off extra columns for performance metrics 
-  --help                  --- print this usage message'''
+  --help                  --- print this usage message''', file=sys.stderr)
 
     if message is not None:
-        print>>sys.stderr,'\n'+str(message).rstrip()+'\n'
+        print('\n'+str(message).rstrip()+'\n', file=sys.stderr)
     sys.exit(-1)
 
 def augment_SQLite3(filename):


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
We have some PEP8 tests working, but I had to turn one of them off (F633) when we switched to the new main branch. There were some python2 style print statements in the code.

This PR fixes those print statements and turns that checking back on in CI.

Also I fix the PEP8 problems of the documentation conf.py file. This is documentation code, not workflow code, so seems safe to fix. (More work on the documentation build is coming so fixing these now is helpful).

## TESTS CONDUCTED: 
N/A

### Machines/Platforms:
N/A

### Test cases: 
N/A

## ISSUE: 
Part of #456 


