### PR TITLE
Add the fcst task

### DIFF
--- a/doc/build_and_run.md
+++ b/doc/build_and_run.md
@@ -48,7 +48,7 @@ Refer to [this guide](https://github.com/NOAA-EMC/rrfs-workflow/wiki/deploy-a-re
     
 This Python script creates an experiment directory (i.e. `EXPDIR`), writes out a runtime version of `exp.setup` under EXPDIR, and  then copies runtime config files from `HOMErrfs` to `EXPDIR`.
        
-Users usually need to set up `ACCOUT`, `QUEUE`, `PARTITION`, or `RESERVATION` by modifying `resources/config.${machine}` or you may export those variables in the current environment before running setp_exp.py, or export those variables in `exp.setup`.  
+Users usually need to set up `ACCOUT`, `QUEUE`, `PARTITION`, or `RESERVATION` by modifying `config_resources/config.${machine}` or you may export those variables in the current environment before running setp_exp.py, or export those variables in `exp.setup`.  
     
 The workflow uses a cascade config structure to separate concerns so that a task/job/application/function_group only defines relevant environmental variables required in runtime. Refer to [this guide](https://github.com/NOAA-EMC/rrfs-workflow/wiki/The-cascade-config-structure) for more information.
 

--- a/doc/build_and_run.md
+++ b/doc/build_and_run.md
@@ -48,7 +48,7 @@ Refer to [this guide](https://github.com/NOAA-EMC/rrfs-workflow/wiki/deploy-a-re
     
 This Python script creates an experiment directory (i.e. `EXPDIR`), writes out a runtime version of `exp.setup` under EXPDIR, and  then copies runtime config files from `HOMErrfs` to `EXPDIR`.
        
-Users usually need to set up `ACCOUT`, `QUEUE`, `PARTITION`, or `RESERVATION` by modifying `config_resources/config.${machine}` or you may export those variables in the current environment before running setp_exp.py, or export those variables in `exp.setup`.  
+Users usually need to set up `ACCOUNT`, `QUEUE`, `PARTITION`, or `RESERVATION` by modifying `config_resources/config.${machine}` or you may export those variables in the current environment before running setp_exp.py, or export those variables in `exp.setup`.  
     
 The workflow uses a cascade config structure to separate concerns so that a task/job/application/function_group only defines relevant environmental variables required in runtime. Refer to [this guide](https://github.com/NOAA-EMC/rrfs-workflow/wiki/The-cascade-config-structure) for more information.
 

--- a/jobs/JRRFS_DA
+++ b/jobs/JRRFS_DA
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+date
+#
+# source the config cascade
+source ${EXPDIR}/exp.setup
+source ${EXPDIR}/config/config.${MACHINE}
+source ${EXPDIR}/config/config.base
+[[ -s ${EXPDIR}/config/config.da ]] && source ${EXPDIR}/config/config.da
+#
+export pid=${pid:-$$}
+export RUN=${RUN:-rrfs}
+export jobid=${jobid:-${RUN}_da_${cyc}}
+
+export DATA=${DATA:-${DATAROOT}/${jobid}}
+if [ -d ${DATA} ]; then # remove the ${DATA} directory if existed
+  rm -rf ${DATA}
+fi
+mkdir -p ${DATA}
+#
+export COMINgfs=${COMINgfs:-$(compath.py $envir/gfs/$gfs_ver)}
+export COMINrrfs=${COMINrrfs:-$(compath.py $envir/rrfs/$rrfs_ver)}
+export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
+mkdir -p ${COMOUT}/da
+#
+#----------------------------------------
+# Execute the script.
+#----------------------------------------
+export pgmout="${DATA}/OUTPUT.$$"
+${HOMErrfs}/scripts/exrrfs_da.sh
+export err=$?; err_chk
+
+if [ -e "$pgmout" ]; then
+  cat $pgmout
+fi
+#
+#----------------------------------------
+# Remove the Temporary working directory
+#----------------------------------------
+cd ${DATAROOT}
+[[ "${KEEPDATA}" == "NO" ]] && rm -rf ${DATA}
+#
+date
+echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"
+exit 0

--- a/jobs/JRRFS_FCST
+++ b/jobs/JRRFS_FCST
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+date
+#
+# source the config cascade
+source ${EXPDIR}/exp.setup
+[[ ! -z "${ENS_INDEX}" ]] && source ${EXPDIR}/config/config.ens
+source ${EXPDIR}/config/config.${MACHINE}
+source ${EXPDIR}/config/config.base
+[[ -s ${EXPDIR}/config/config.fcst ]] && source ${EXPDIR}/config/config.fcst
+#
+export pid=${pid:-$$}
+if [[ -z "${ENS_INDEX}" ]]; then
+  export RUN="rrfs"
+else
+  export RUN="ensrrfs"
+fi
+export jobid=${jobid:-${RUN}_fcst_${cyc}}
+
+export DATA=${DATA:-${DATAROOT}/${jobid}}
+if [ -d ${DATA} ]; then # remove the ${DATA} directory if existed
+  rm -rf ${DATA}
+fi
+mkdir -p ${DATA}
+#
+export COMINgfs=${COMINgfs:-$(compath.py $envir/gfs/$gfs_ver)}
+export COMINrrfs=${COMINrrfs:-$(compath.py $envir/rrfs/$rrfs_ver)}
+export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
+if [[ -z "${ENS_INDEX}" ]]; then
+  mkdir -p ${COMOUT}/fcst
+else
+  mkdir -p ${COMOUT}/mem${ENS_INDEX}/fcst
+fi
+#
+#----------------------------------------
+# Execute the script.
+#----------------------------------------
+export pgmout="${DATA}/OUTPUT.$$"
+${HOMErrfs}/scripts/exrrfs_fcst.sh
+export err=$?; err_chk
+
+if [ -e "$pgmout" ]; then
+  cat $pgmout
+fi
+#
+#----------------------------------------
+# Remove the Temporary working directory
+#----------------------------------------
+cd ${DATAROOT}
+[[ "${KEEPDATA}" == "NO" ]] && rm -rf ${DATA}
+#
+date
+echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"
+exit 0

--- a/scripts/exrrfs_da.sh
+++ b/scripts/exrrfs_da.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+cpreq=${cpreq:-cpreq}
+prefix='GFS'
+BUMPLOC=${BUMPLOC:-"conus12km-401km11levels"}
+
+cd ${DATA}
+CDATEm1=$($NDATE -1 ${CDATE})
+start_time=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%Y-%m-%d_%H:%M:%S) 
+timestr=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%Y-%m-%d_%H.%M.%S) 
+# determine whether to begin new cycles
+IFS=' ' read -r -a array <<< "${PROD_BGN_AT_HRS}"
+begin="NO"
+for hr in "${array[@]}"; do
+  if [[ "${cyc}" == "$(printf '%02d' ${hr})" ]]; then
+    begin="YES"; break
+  fi
+done
+#
+${cpreq} ${FIXrrfs}/physics/${PHYSICS_SUITE}/* .
+ln -snf VEGPARM.TBL.da VEGPARM.TBL #gge.debug temp
+mkdir -p graphinfo stream_list
+${cpreq} ${FIXrrfs}/graphinfo/* graphinfo/
+${cpreq} ${FIXrrfs}/jedi/obsop_name_map.yaml .                  
+${cpreq} ${FIXrrfs}/jedi/keptvars.yaml .              
+${cpreq} ${FIXrrfs}/jedi/geovars.yaml . 
+${cpreq} ${FIXrrfs}/stream_list/${PHYSICS_SUITE}/* stream_list/
+mkdir -p data; cd data                   
+mkdir -p bumploc obs ens
+${cpreq} ${FIXrrfs}/bumploc/${BUMPLOC} bumploc/
+${cpreq} ${FIXrrfs}/meshes/${NET}.static.nc static.nc
+if [[ "${begin}" == "YES" ]]; then
+  # mpasjedi cannot run on init.nc due to the miss of pressure values
+  : #do nothing
+else
+  cpfs ${DATAROOT}/${NET}/${rrfs_ver}/${RUN}.${CDATEm1:0:8}/${CDATEm1:8:2}/fcst/restart.${timestr}.nc .
+fi
+#${cpreq} ${COMINioda}/..../obs/* obs/                            
+#${cpreq} ${COMINgdas}/..../ens/* ens/
+#
+# generate the namelist on the fly
+# namelist.atmosphere and streams.atmosphere
+#sed -e "s/@restart_interval@/${restart_interval}/" -e "s/@history_interval@/${history_interval}/" \
+#    -e "s/@diag_interval@/${diag_interval}/" -e "s/@lbc_interval@/${lbc_interval}/" \
+#    ${PARMrrfs}/streams.atmosphere_fcst > streams.atmosphere
+
+# run mpasjedi_variational.x
+export OOPS_TRACE=1
+export OMP_NUM_THREADS=1
+ulimit -s unlimited
+ulimit -v unlimited
+ulimit -a
+
+source prep_step
+${cpreq} ${EXECrrfs}/mpasjedi_variational.x .
+#${MPI_RUN_CMD} ./mpasjedi_variational.x  ./$inputfile    log.out
+# check the status
+export err=$?
+err_chk
+
+# copy output to COMOUT
+if [[ "${begin}" == "YES" ]]; then
+  : # do nothing on init.nc for now
+else
+  ${cpreq} ${DATA}/data/restart.${timestr}.nc ${COMOUT}/da/
+fi

--- a/scripts/exrrfs_da.sh
+++ b/scripts/exrrfs_da.sh
@@ -60,8 +60,6 @@ export err=$?
 err_chk
 
 # copy output to COMOUT
-if [[ "${begin}" == "YES" ]]; then
-  : # do nothing on init.nc for now
-else
+if [[ "${begin}" != "YES" ]]; then
   ${cpreq} ${DATA}/data/restart.${timestr}.nc ${COMOUT}/da/
 fi

--- a/scripts/exrrfs_da.sh
+++ b/scripts/exrrfs_da.sh
@@ -30,10 +30,7 @@ mkdir -p data; cd data
 mkdir -p bumploc obs ens
 ${cpreq} ${FIXrrfs}/bumploc/${BUMPLOC} bumploc/
 ${cpreq} ${FIXrrfs}/meshes/${NET}.static.nc static.nc
-if [[ "${begin}" == "YES" ]]; then
-  # mpasjedi cannot run on init.nc due to the miss of pressure values
-  : #do nothing
-else
+if [[ "${begin}" != "YES" ]]; then
   cpfs ${DATAROOT}/${NET}/${rrfs_ver}/${RUN}.${CDATEm1:0:8}/${CDATEm1:8:2}/fcst/restart.${timestr}.nc .
 fi
 #${cpreq} ${COMINioda}/..../obs/* obs/                            

--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+cpreq=${cpreq:-cpreq}
+
+cd ${DATA}
+timestr=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%Y-%m-%d_%H.%M.%S) 
+if [[ -z "${ENS_INDEX}" ]]; then
+  IFS=' ' read -r -a array <<< "${PROD_BGN_AT_HRS}"
+  ensindexstr=""
+  lbc_interval=${LBC_INTERVAL:-3}
+else
+  IFS=' ' read -r -a array <<< "${ENS_PROD_BGN_AT_HRS}"
+  ensindexstr="/mem${ENS_INDEX}"
+  lbc_interval=${ENS_LBC_INTERVAL:-3}
+fi
+# determine whether to begin new cycles
+begin="NO"
+for hr in "${array[@]}"; do
+  if [[ "${cyc}" == "$(printf '%02d' ${hr})" ]]; then
+    begin="YES"; break
+  fi
+done
+if [[ "${begin}" == "YES" ]]; then
+  ${cpreq} ${COMINrrfs}/${RUN}.${PDY}/${cyc}${ensindexstr}/ic/init.nc .
+  do_restart='false'
+else
+  ${cpreq} ${COMINrrfs}/${RUN}.${PDY}/${cyc}${ensindexstr}/da/restart.${timestr}.nc .
+  do_restart='true'
+fi
+offset=$((10#${cyc}%6))
+CDATElbc=$($NDATE -${offset} ${CDATE})
+${cpreq} ${COMINrrfs}/${RUN}.${CDATElbc:0:8}/${CDATElbc:8:2}${ensindexstr}/lbc/lbc*.nc .
+${cpreq} ${FIXrrfs}/physics/${PHYSICS_SUITE}/* .
+ln -snf VEGPARM.TBL.fcst VEGPARM.TBL #gge.debug temp
+mkdir -p graphinfo stream_list
+${cpreq} ${FIXrrfs}/graphinfo/* graphinfo/
+cpreq ${FIXrrfs}/stream_list/${PHYSICS_SUITE}/* stream_list/
+
+# generate the namelist on the fly
+# do_restart already defined in the above
+start_time=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%Y-%m-%d_%H:%M:%S) 
+run_duration=${FCST_LENGTH:-6}:00:00
+physics_suite=${PHYSICS_SUITE:-'mesoscale_reference'}
+jedi_da="false" #true
+
+if [[ "${NET}" == "conus12km" ]]; then
+  pio_num_iotasks=6
+  pio_stride=20
+elif [[ "${NET}" == "conus3km" ]]; then
+  pio_num_iotasks=40
+  pio_stride=20
+fi
+file_content=$(< ${PARMrrfs}/${physics_suite}/namelist.atmosphere) # read in all content
+eval "echo \"${file_content}\"" > namelist.atmosphere
+
+# generate the streams file on the fly using sed as this file contains "filename_template='lbc.$Y-$M-$D_$h.$m.$s.nc'"
+# lbc_interval is defined in the beginning
+restart_interval=${RESTART_INTERVAL:-1}
+history_interval=${HISTORY_INTERVAL:-1}
+diag_interval=${DIAG_INTERVAL:-1}
+sed -e "s/@restart_interval@/${restart_interval}/" -e "s/@history_interval@/${history_interval}/" \
+    -e "s/@diag_interval@/${diag_interval}/" -e "s/@lbc_interval@/${lbc_interval}/" \
+    ${PARMrrfs}/streams.atmosphere_fcst > streams.atmosphere
+
+# run the MPAS model
+ulimit -s unlimited
+ulimit -v unlimited
+ulimit -a
+source prep_step
+${cpreq} ${EXECrrfs}/atmosphere_model.x .
+${MPI_RUN_CMD} ./atmosphere_model.x 
+# check the status
+if [[ -f './log.atmosphere.0000.err' ]]; then # has to use '-f" as the 0000 err file may be size 0
+  echo "FATAL ERROR: MPAS model run failed"
+  err_exit
+fi
+
+# copy output to COMOUT
+CDATEp1=$($NDATE 1 ${CDATE})
+timestr=$(date -d "${CDATEp1:0:8} ${CDATEp1:8:2}" +%Y-%m-%d_%H.%M.%S) 
+if [[ -z "${ENS_INDEX}" ]]; then
+  dstdir="${COMOUT}/fcst/"
+else
+  dstdir="${COMOUT}/mem${ENS_INDEX}/fcst/"
+fi
+${cpreq} ${DATA}/restart.${timestr}.nc ${dstdir}
+${cpreq} ${DATA}/diag.*.nc ${dstdir}
+${cpreq} ${DATA}/history.*.nc ${dstdir}

--- a/scripts/exrrfs_lbc.sh
+++ b/scripts/exrrfs_lbc.sh
@@ -63,4 +63,4 @@ if (( $? != 0 )); then
 fi
 
 # copy lbc*.nc to COMOUT
-${cpreq} ${DATA}/lbc*.nc ${COMOUT}${ensindexstr}/ioda_bufr/
+${cpreq} ${DATA}/lbc*.nc ${COMOUT}${ensindexstr}/lbc/

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -56,9 +56,9 @@ def setup_xml(HOMErrfs, expdir):
       ungrib_lbc(xmlFile,expdir)
       ic(xmlFile,expdir)
       lbc(xmlFile,expdir)
-      #if os.getenv("FCST_ONLY","FALSE").upper()=="FALSE":
-      #  da(xmlFile,expdir)
-      #fcst(xmlFile,expdir)
+      if os.getenv("FCST_ONLY","FALSE").upper()=="FALSE":
+        da(xmlFile,expdir)
+      fcst(xmlFile,expdir)
       #mpassit(xmlFile,expdir)
       #upp(xmlFile,expdir)
       #
@@ -72,8 +72,8 @@ def setup_xml(HOMErrfs, expdir):
       ungrib_lbc(xmlFile,expdir,do_ensemble=True)
       ic(xmlFile,expdir,do_ensemble=True)
       lbc(xmlFile,expdir,do_ensemble=True)
-      #if os.getenv("ENS_FCST_ONLY","FALSE").upper()=="FALSE":
-      #  ens_da(xmlFile,expdir)
+      if os.getenv("ENS_FCST_ONLY","FALSE").upper()=="FALSE":
+        ens_da(xmlFile,expdir)
       #fcst(xmlFile,expdir,do_ensemble=True)
       #mpassit(xmlFile,expdir,do_ensemble=True)
       #upp(xmlFile,expdir,do_ensemble=True)


### PR DESCRIPTION
We will add the `fcst` task with 3 PRs to facilitate the review process and keep a change record.

1. commit what we have right now (a `fcst` task as well as "pass-through" `da` task for the stop and start fcst capability)
2. update to use the latest MPAS v8.2.2 code and the mpasout files
3. complete the left-over part to enable the `forecast_only` capability in the workflow 

This PR is the first one.
The workflow has been tested on Hera and Jet