### PR TITLE
Changing neighbor interpolation to bilinear interpolation for AEMFLX

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -429,6 +429,7 @@ else
             wgrib2 ${infile} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
              -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
              -new_grid_interpolation neighbor \
+	     -if ":(AEMFLX):" -new_grid_interpolation bilinear -fi \
              -new_grid ${grid_specs} ${subdir}/${fhr}/tmp_${grid}.grib2
           fi
 


### PR DESCRIPTION
Modifying interpolation of AEMFLX (smoke emissions) to retain all emission points going from NA_3km grid to CONUS grid.

## DESCRIPTION OF CHANGES: 
Add an if statement within the wgrib2 interpolation call going from RRFS_NA_3km domain to CONUS 3 km domain, to use bilinear interpolation instead of nearest neighbor.

## TESTS CONDUCTED: 
Tested on Jet for a real-time RRFS_NA_3km case.

### Machines/Platforms:
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
- Fixes the issue(s) mentioned in #546