### PR TITLE
minor fix to set up GWD links when using RRFS_sas.

### DIFF
--- a/ush/link_fix.sh
+++ b/ush/link_fix.sh
@@ -253,7 +253,7 @@ Creating links in the FIXLAM directory to the grid files..."
     "C*${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH0}.nc" \
     "C*${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH4}.nc" \
         )
-    suites=( "FV3_HRRR" "FV3_RAP" "FV3_HRRR_gf" "FV3_GFS_v15_thompson_mynn_lam3km" )
+    suites=( "FV3_HRRR" "FV3_RAP" "FV3_HRRR_gf" "RRFS_sas" "FV3_GFS_v15_thompson_mynn_lam3km" )
     if [[ ${suites[@]} =~ "${CCPP_PHYS_SUITE}" ]] ; then
       fns+=( \
       "C*${DOT_OR_USCORE}oro_data_ss.tile${TILE_RGNL}.halo${NH0}.nc" \

--- a/ush/set_rrfs_config.sh
+++ b/ush/set_rrfs_config.sh
@@ -168,9 +168,11 @@ if [[ $DO_RETRO == "TRUE" ]] ; then
   # for winter 2022  
     #RETRODATAPATH="/lfs/h2/emc/lam/noscrub/emc.lam/rrfs_retro_data"
   # for spring 2023  
-    RETRODATAPATH="/lfs/h2/emc/lam/noscrub/donald.e.lippi/rrfs-stagedata"
+ #   RETRODATAPATH="/lfs/h2/emc/lam/noscrub/donald.e.lippi/rrfs-stagedata"
   #for Feb 2022
 #    RETRODATAPATH="/lfs/h2/emc/da/noscrub/donald.e.lippi/rrfs-stagedata"
+  # for Jan 2024
+    RETRODATAPATH="/lfs/h3/emc/rrfstemp/donald.e.lippi/rrfs-stagedata"
     if [[ ${DO_ENSEMBLE} == "TRUE" ]]; then
       if [[ ${EXTRN_MDL_NAME_ICS} == "GEFS" ]]; then
         EXTRN_MDL_SOURCE_BASEDIR_ICS="${RETRODATAPATH}/GEFS/dsg"

--- a/ush/set_rrfs_config_general.sh
+++ b/ush/set_rrfs_config_general.sh
@@ -87,8 +87,8 @@ elif [[ $MACHINE == "wcoss2" ]] ; then
   fi
   if [[ $MACHINETYPE == "backup" ]] ; then
     QUEUE_DEFAULT="devhigh"
-    QUEUE_FCST="devmax"
-    QUEUE_ANALYSIS="devmax"
+    QUEUE_FCST="devhigh"
+    QUEUE_ANALYSIS="devhigh"
     QUEUE_POST="devhigh"
     QUEUE_PRDGEN="devhigh"
     QUEUE_GRAPHICS="devhigh"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -1147,6 +1147,7 @@ fi
 GWD_HRRRsuite_DIR=""
 if [ "${CCPP_PHYS_SUITE}" = "FV3_HRRR" ] || \
    [ "${CCPP_PHYS_SUITE}" = "FV3_HRRR_gf" ]  || \
+   [ "${CCPP_PHYS_SUITE}" = "RRFS_sas" ]  || \
    [ "${CCPP_PHYS_SUITE}" = "FV3_RAP" ]  || \
    [ "${CCPP_PHYS_SUITE}" = "FV3_GFS_v15_thompson_mynn_lam3km" ]; then
   #


### PR DESCRIPTION
Seems we need to add RRFS_sas option in two locations for setting GWD. I do not know if this is matter but does not hurt to set it with reasonable values.

This is compared with setups for winter retro v1.0.3 on Dogwood.
