### PR TITLE
Extends bufrsnd job to 84 h

### DIFF
--- a/scripts/exrrfs_bufrsnd.sh
+++ b/scripts/exrrfs_bufrsnd.sh
@@ -168,7 +168,7 @@ INCR=01
 if [[ "${NET}" = "RTMA"* ]]; then
 FHRLIM=00
 else
-FHRLIM=60
+FHRLIM=84
 fi   
 
 
@@ -187,7 +187,7 @@ startd=$YYYY$MM$DD
 startdate=$CYCLE
 
 STARTDATE=${YYYY}-${MM}-${DD}_${cyc}:00:00
-endtime=$(date +%Y%m%d%H -d "${START_DATE} +60 hours")
+endtime=$(date +%Y%m%d%H -d "${START_DATE} +84 hours")
 
 YYYY=`echo $endtime | cut -c1-4`
 MM=`echo $endtime | cut -c5-6`
@@ -434,7 +434,7 @@ SNOUTF   = ${outfilbase}.snd
 SFOUTF   = ${outfilbase}.sfc+
 SNPRMF   = snrrfs.prm
 SFPRMF   = sfrrfs.prm
-TIMSTN   = 61/1600
+TIMSTN   = 85/1600
 r
 
 exit


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Makes bufrsnd script changes that hopefully extend bufrsnd processing to cover 84 h.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- Not tested, but could try a local change in RT RRFS tomorrow if desired.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

