### PR TITLE
mark the correct branch for MPASSIT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,5 +21,5 @@
 [submodule "sorc/MPASSIT"]
 	path = sorc/MPASSIT
 	url = https://github.com/NOAA-GSL/MPASSIT.git
-        branch = develop
+        branch = gsl/develop
         ignore = all


### PR DESCRIPTION
NOAA-GSL/MPASSIT does not have a `develop` branch. 
It does have a `gsl/develop` branch

This PR is to correct this and does not affect any current functionalities.