### PR TITLE
Update FVCOM preparation script for WCOSS2

### DIFF
--- a/ush/fvcom_prep.sh
+++ b/ush/fvcom_prep.sh
@@ -130,15 +130,15 @@ fi
 
 # Find the most recent FVCOM files
 if [ "$MACHINE" = "WCOSS2" ]; then
-  erie="${FVCOM_DIR}/leofs.${PDYf}/nos.leofs.fields.f${fhr}.${PDYf}.t${cycf}z.nc"
-  mh="${FVCOM_DIR}/lmhofs.${PDYf}/nos.lmhofs.fields.f${fhr}.${PDYf}.t${cycf}z.nc"
-  sup="${FVCOM_DIR}/lsofs.${PDYf}/nos.lsofs.fields.f${fhr}.${PDYf}.t${cycf}z.nc"
-  ont="${FVCOM_DIR}/loofs.${PDYf}/nos.loofs.fields.f${fhr}.${PDYf}.t${cycf}z.nc"
+  erie="${FVCOM_DIR}/leofs.${PDYf}/leofs.t${cycf}z.${PDYf}.fields.f${fhr}.nc"
+  mh="${FVCOM_DIR}/lmhofs.${PDYf}/lmhofs.t${cycf}z.${PDYf}.fields.f${fhr}.nc"
+  sup="${FVCOM_DIR}/lsofs.${PDYf}/lsofs.t${cycf}z.${PDYf}.fields.f${fhr}.nc"
+  ont="${FVCOM_DIR}/loofs.${PDYf}/loofs.t${cycf}z.${PDYf}.fields.f${fhr}.nc"
 
-  erie2="${FVCOM_DIR}/leofs.${PDYfm1}/nos.leofs.fields.f${fhrm1}.${PDYfm1}.t${cycfm1}z.nc"
-  mh2="${FVCOM_DIR}/lmhofs.${PDYfm1}/nos.lmhofs.fields.f${fhrm1}.${PDYfm1}.t${cycfm1}z.nc"
-  sup2="${FVCOM_DIR}/lsofs.${PDYfm1}/nos.lsofs.fields.f${fhrm1}.${PDYfm1}.t${cycfm1}z.nc"
-  ont2="${FVCOM_DIR}/loofs.${PDYfm1}/nos.loofs.fields.f${fhrm1}.${PDYfm1}.t${cycfm1}z.nc"
+  erie2="${FVCOM_DIR}/leofs.${PDYfm1}/leofs.t${cycfm1}z.${PDYfm1}.fields.f${fhrm1}.nc"
+  mh2="${FVCOM_DIR}/lmhofs.${PDYfm1}/lmhofs.t${cycfm1}z.${PDYfm1}.fields.f${fhrm1}.nc"
+  sup2="${FVCOM_DIR}/lsofs.${PDYfm1}/lsofs.t${cycfm1}z.${PDYfm1}.fields.f${fhrm1}.nc"
+  ont2="${FVCOM_DIR}/loofs.${PDYfm1}/loofs.t${cycfm1}z.${PDYfm1}.fields.f${fhrm1}.nc"
 
 else
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The filenames for the operational GLOFS which is used for the FVCOM processing have changed on WCOSS2.  Here is an example:
    `nos.leofs.fields.f${fhr}.${PDYf}.t${cycf}z.nc -> leofs.t${cycf}z.${PDYf}.fields.f${fhr}.nc`
- The ush/fvcom_prep.sh is updated accordingly.  These filename changes were tested successfully with the real-time parallel on WCOSS2 - the ncap2/netcdf issue is unrelated to these changes.  I wanted to get these local changes submitted now so that they aren't forgotten about because we do want to switch to using the operational GLOFS data once the module/library issue is fixed.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested successfully in the real-time parallel on WCOSS2.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Continues work on issue #554 

