### PR TITLE
[dev-sci] Reverts to older profdat file due to ongoing trouble with expanded list

### DIFF
--- a/scripts/exrrfs_bufrsnd.sh
+++ b/scripts/exrrfs_bufrsnd.sh
@@ -155,7 +155,7 @@ cd $DATA/bufrpost
 
 export tmmark=tm00
 
-NSTAT=2000
+NSTAT=1850
 
 cp $PARMfv3/${PREDEF_GRID_NAME}/rrfs_profdat.${NSTAT} regional_profdat
 
@@ -431,7 +431,7 @@ SNOUTF   = ${outfilbase}.snd
 SFOUTF   = ${outfilbase}.sfc+
 SNPRMF   = snrrfs.prm
 SFPRMF   = sfrrfs.prm
-TIMSTN   = 85/2000
+TIMSTN   = 85/1850
 r
 
 exit


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Changes NSTAT from 2000 to 1850 in bufrsnd script.  
- May investigate a smaller upper limit for number of stations (only using 1875 with updated list - created breathing room that might be more problematic with 84 h forecast).
- The NSTAT 2000 profdat file seemed to hang within the sndp executable after the first program had processed through 84 h.  

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

