### PR TITLE
[dev-sci] Folds in local change made to fix missing subdomain files in retro

### DIFF
--- a/scripts/exrrfs_run_prdgen.sh
+++ b/scripts/exrrfs_run_prdgen.sh
@@ -366,7 +366,7 @@ if [ "${DO_PARALLEL_PRDGEN}" = "TRUE" ]; then
     #-- Upscale & subset FAA requested information
     #-- FAA grib2 output is not generated for ensemble forecasts
     
-     # echo "$USHrrfs/rrfs_prdgen_faa_subpiece.sh $fhr $cyc $prslev $natlev $ififip $aviati ${COMOUT} &" >> $DATAprdgen/poescript_faa_${fhr}
+     # echo "$USHrrfs/rrfs_prdgen_faa_subpiece.sh $fhr $cyc $prslev $natlev $ififip $aviati ${COMOUT}" >> $DATAprdgen/poescript_faa_${fhr}
 
     if [ ${DO_ENSFCST} = "FALSE" ]; then
       ${USHrrfs}/rrfs_prdgen_faa_subpiece.sh $fhr $cyc $prslev $natlev $ififip $aviati ${COMOUT} ${USHrrfs}


### PR DESCRIPTION
Fix was previously made in "main".

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Removes a "&" within poe-script generation.  WCOSS update made things stricter, and we don't want detached processes with a poe-script.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->


### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others: v1.1.2 retro system has been running with this fix.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

