### PR TITLE
Reduce nodes used for CONUS 12km and update UPP grib2 file name

### DIFF
--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -67,8 +67,8 @@ physics_suite=${PHYSICS_SUITE:-'mesoscale_reference'}
 jedi_da="true" #true
 
 if [[ "${MESH_NAME}" == "conus12km" ]]; then
-  pio_num_iotasks=6
-  pio_stride=20
+  pio_num_iotasks=1
+  pio_stride=40
 elif [[ "${MESH_NAME}" == "conus3km" ]]; then
   pio_num_iotasks=40
   pio_stride=20

--- a/scripts/exrrfs_upp.sh
+++ b/scripts/exrrfs_upp.sh
@@ -8,6 +8,19 @@ ulimit -a
 
 cpreq=${cpreq:-cpreq}
 cd ${DATA}
+
+#
+# determine domain name
+#
+
+if [[ ${MESH_NAME} == "conus12km" ]]; then
+  domain="conus."
+elif [[ ${MESH_NAME} == "conus3km" ]]; then
+  domain="conus."
+else
+  domain=""
+fi
+
 #
 #  cpy excutable and fix files; decide mesh
 #
@@ -106,10 +119,11 @@ EOF
       mv ${wrfnat}.two ${wrfnat}
 
       # copy products to COMOUT
-      ${cpreq} ${wrfprs} ${COMOUT}${MEMDIR}/upp/${RUN}_prs_${CDATE}_f${fhr2}.grib2
-      ${cpreq} ${wrfnat} ${COMOUT}${MEMDIR}/upp/${RUN}_nat_${CDATE}_f${fhr2}.grib2
-      ${cpreq} ${wrftwo} ${COMOUT}${MEMDIR}/upp/${RUN}_two_${CDATE}_f${fhr2}.grib2
-      ln -snf  ${COMOUT}${MEMDIR}/upp/${RUN}_prs_${CDATE}_f${fhr2}.grib2 ${COMOUT}${MEMDIR}/upp/${YYJJJHH}0000${fhr2}
+      fhr3=$(printf %03d ${fhr})
+      ${cpreq} ${wrfprs} ${COMOUT}${MEMDIR}/upp/${NET}.t${cyc}z.prslev.f${fhr3}.${domain}grib2
+      ${cpreq} ${wrfnat} ${COMOUT}${MEMDIR}/upp/${NET}.t${cyc}z.natlev.f${fhr3}.${domain}grib2
+      ${cpreq} ${wrftwo} ${COMOUT}${MEMDIR}/upp/${NET}.t${cyc}z.testbed.f${fhr3}.${domain}grib2
+      ln -snf  ${COMOUT}${MEMDIR}/upp/${NET}.t${cyc}z.prslev.f${fhr3}.${domain}grib2 ${COMOUT}${MEMDIR}/upp/${YYJJJHH}0000${fhr2}
 
     else
       echo "FATAL ERROR: cannot find mpass file at ${timestr}"

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -5,8 +5,8 @@ export NET=rrfs                    # rrfs, rtma,
 export MESH_NAME=conus12km         # conus12km, conus3km, atl3km, etc
 export WGF="enkf"   # working group function = "det", "enkf", "ensf", "firewx"
 export EXP_NAME=rrfs${WGF}
-export VERSION=v2.0.2
-export TAG=c3v202
+export VERSION=v2.0.3
+export TAG=c3v203
 export OPSROOT=/lfs5/BMC/nrtrr/NCO_dirs/${VERSION}
 export EXPDIR=${OPSROOT}/${EXP_NAME}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
@@ -28,7 +28,7 @@ export COMINgefs="/lfs5/BMC/wrfruc/Chunhua.Zhou/w4/data/GEFS"
 export FCST_ONLY="false"
 export CYC_INTERVAL=3
 export FCST_LENGTH=3
-export FCST_LEN_HRS_CYCLES="12 03 03 03 03 03 12 03 03 03 03 03 12 03 03 03 03 03 12 03 03 03 03 03"
+export FCST_LEN_HRS_CYCLES="06 03 03 03 03 03 06 03 03 03 03 03 06 03 03 03 03 03 06 03 03 03 03 03"
 export HISTORY_INTERVAL=1
 export RESTART_INTERVAL=61
 export MPASSIT_GROUP_TOTAL_NUM=1
@@ -50,11 +50,11 @@ export LBC_EXTRN_MDL_NAME_PATTERN_B="/pgrb2b/gep#gmem#/@y@j@H000fHHH"
 export LBC_UNGRIB_GROUP_TOTAL_NUM=1
 export LBC_GROUP_TOTAL_NUM=1
 #
-export RUN_PERIOD="2024122100-2024122100"
+export RUN_PERIOD="2025011000-2025011000"
 export CYCLEDEF_IC="   &STARTYEAR;&STARTMONTH;&STARTDAY;0000 &ENDYEAR;&ENDMONTH;&ENDDAY;2300 06:00:00 "
 export CYCLEDEF_LBC="  &STARTYEAR;&STARTMONTH;&STARTDAY;0000 &ENDYEAR;&ENDMONTH;&ENDDAY;2300 06:00:00 "
 export CYCLEDEF_PROD=" &STARTYEAR;&STARTMONTH;&STARTDAY;0000 &ENDYEAR;&ENDMONTH;&ENDDAY;2300 03:00:00 "
-export CYCL_HRS_COLDSTART="00 06 12 18"
+export CYCL_HRS_COLDSTART="00 12"
 #
 export ACCOUNT="rtwrfruc"
 export QUEUE="rth"
@@ -72,14 +72,14 @@ export STARTTIME_UPP="00:35:01"
 export STARTTIME_PREP_IC="00:30:00"
 export STARTTIME_PREP_LBC="00:30:00"
 #
-export NODES_IC="<nodes>6:ppn=40</nodes>"
-export NODES_LBC="<nodes>6:ppn=40</nodes>"
-export NODES_FCST="<nodes>3:ppn=40</nodes>"
+export NODES_IC="<nodes>1:ppn=40</nodes>"
+export NODES_LBC="<nodes>1:ppn=40</nodes>"
+export NODES_FCST="<nodes>1:ppn=40</nodes>"
 export NODES_MPASSIT="<nodes>1:ppn=40</nodes>"
 export NODES_UPP="<nodes>1:ppn=40</nodes>"
 #
-export WALLTIME_FCST="01:00:00"
-export WALLTIME_SAVE_FCST="1:00:00"
+export WALLTIME_FCST="01:30:00"
+export WALLTIME_SAVE_FCST="1:30:00"
 export WALLTIME_MPASSIT="1:00:00"
 export WALLTIME_UPP="1:00:00"
 #

--- a/workflow/exp/exp.jet_conus12km
+++ b/workflow/exp/exp.jet_conus12km
@@ -5,8 +5,8 @@ export NET=rrfs                    # rrfs, rtma,
 export MESH_NAME=conus12km         # conus12km, conus3km, atl3km, etc
 export WGF="det"   # working group function = "det", "enkf", "ensf", "firewx"
 export EXP_NAME=rrfs${WGF}
-export VERSION=v2.0.2
-export TAG=c3v202
+export VERSION=v2.0.3
+export TAG=c3v203
 export OPSROOT=/lfs5/BMC/nrtrr/NCO_dirs/${VERSION}
 export EXPDIR=${OPSROOT}/${EXP_NAME}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
@@ -22,7 +22,7 @@ export COMINrap='/lfs5/BMC/nrtrr/NCO_data/rap'
 export COMINgefs="/lfs5/BMC/wrfruc/Chunhua.Zhou/w4/data/GEFS"
 #
 export FCST_ONLY="false"
-export CYC_INTERVAL=3
+export CYC_INTERVAL=1
 export FCST_LENGTH=3
 export FCST_LEN_HRS_CYCLES="12 03 03 03 03 03 12 03 03 03 03 03 12 03 03 03 03 03 12 03 03 03 03 03"
 export HISTORY_INTERVAL=1
@@ -37,17 +37,17 @@ export IC_EXTRN_MDL_NAME_PATTERN="@y@j@H000fHHH"
 export LBC_EXTRN_MDL_NAME='GFS'
 export LBC_OFFSET=6
 export LBC_LENGTH=18
-export LBC_INTERVAL=3
+export LBC_INTERVAL=1
 export LBC_EXTRN_MDL_BASEDIR="/public/data/grids/gfs/0p25deg/grib2"
 export LBC_EXTRN_MDL_NAME_PATTERN="@y@j@H000fHHH"
 export LBC_UNGRIB_GROUP_TOTAL_NUM=1
 export LBC_GROUP_TOTAL_NUM=1
 
-export RUN_PERIOD="2024122100-2024122100"
+export RUN_PERIOD="2025011000-2025011000"
 export CYCLEDEF_IC="   &STARTYEAR;&STARTMONTH;&STARTDAY;0000 &ENDYEAR;&ENDMONTH;&ENDDAY;2300 06:00:00 "
 export CYCLEDEF_LBC="  &STARTYEAR;&STARTMONTH;&STARTDAY;0000 &ENDYEAR;&ENDMONTH;&ENDDAY;2300 06:00:00 "
 export CYCLEDEF_PROD=" &STARTYEAR;&STARTMONTH;&STARTDAY;0000 &ENDYEAR;&ENDMONTH;&ENDDAY;2300 03:00:00 "
-export CYCL_HRS_COLDSTART="00 06 12 18"
+export CYCL_HRS_COLDSTART="00 12"
 #
 export ACCOUNT="rtwrfruc"
 export QUEUE="rth"
@@ -65,14 +65,14 @@ export STARTTIME_UPP="00:35:01"
 export STARTTIME_PREP_IC="00:30:00"
 export STARTTIME_PREP_LBC="00:30:00"
 
-export NODES_IC="<nodes>6:ppn=40</nodes>"
-export NODES_LBC="<nodes>6:ppn=40</nodes>"
-export NODES_FCST="<nodes>3:ppn=40</nodes>"
+export NODES_IC="<nodes>1:ppn=40</nodes>"
+export NODES_LBC="<nodes>1:ppn=40</nodes>"
+export NODES_FCST="<nodes>2:ppn=40</nodes>"
 export NODES_MPASSIT="<nodes>1:ppn=40</nodes>"
 export NODES_UPP="<nodes>1:ppn=40</nodes>"
 #
-export WALLTIME_FCST="1:00:00"
-export WALLTIME_SAVE_FCST="1:00:00"
+export WALLTIME_FCST="1:30:00"
+export WALLTIME_SAVE_FCST="1:30:00"
 export WALLTIME_MPASSIT="1:00:00"
 export WALLTIME_UPP="1:00:00"
 #


### PR DESCRIPTION
1) The resources used for running CONUS12km are tuned. All the tasks can be run with only 1 node (ppn=40) on JET.
2) The UPP grib2 file name is updated to match the RRFS v1, which is more close to operation.

Those changes are tested on JET with CONUS12km real-time runs.