### PR TITLE
update bufr2 ioda yamls

### DIFF
--- a/parm/prepbufr_adpsfc.yaml
+++ b/parm/prepbufr_adpsfc.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
@@ -20,7 +20,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_adpsfc.yaml
+++ b/parm/prepbufr_adpsfc.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,23 +6,25 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "./prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
         subsets:
           - ADPSFC    # SURFACE LAND (SYNOPTIC, METAR) REPORTS
-          - SFCSHP    # SURFACE MARINE (SHIP, BUOY, C-MAN/TIGE GAUGE PLATFORM) REPORTS
+          #- SFCSHP    # SURFACE MARINE (SHIP, BUOY, C-MAN/TIGE GAUGE PLATFORM) REPORTS
         variables:
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/DHR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/XOB"
           latitude:
@@ -31,11 +33,11 @@ observations:
             query: "*/SID"
           stationElevation:
             query: "*/ELV"
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
-
           prepbufrDataLvlCat:
             query: "*/CAT"
 
@@ -43,19 +45,24 @@ observations:
             query: "*/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
-          pressureQualityMarker:
+          stationPressure:
+            query: "*/P___INFO/P__EVENT{1}/POB"
+            transforms:
+              - scale: 100
+          stationPressureQualityMarker:
             query: "*/P___INFO/P__EVENT{1}/PQM"
-          pressureError:
+          stationPressureError:
             query: "*/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
-          pressureTunedError:
+          stationPressureTunedError:
             query: "*/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
 
           heightOfObservation:
             query: "*/Z___INFO/Z__EVENT{1}/ZOB"
+            #type: float
           heightOfObservationQualityMark:
             query: "*/Z___INFO/Z__EVENT{1}/ZQM"
 
@@ -125,13 +132,13 @@ observations:
           heightOfWaves:
             query: "*/WAVE_SEQ/HOWV"
             type: float
-          
+
           presentWeather:
             query: "*/PREWXSEQ{1}/PRWE"
 
           maximumWindGustSpeed:
             query: "*/GUST1SEQ/MXGS"
-          
+
           verticalSignificance:
             query: "*/CLOUDSEQ{1}/VSSO"
           cloudAmount:
@@ -150,7 +157,6 @@ observations:
     ioda:
       backend: netcdf
       obsdataout: "./ioda_adpsfc.nc"
-
 
       dimensions:
         - name: pevent_Dim
@@ -177,8 +183,8 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
@@ -190,21 +196,21 @@ observations:
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degrees_east"
+          units: "degree_east"
           range: [0, 360]
 
         - name: "MetaData/latitude"
           coordinates: "longitude latitude"
           source: variables/latitude
           longName: "Latitude"
-          units: "degrees_north"
+          units: "degree_north"
           range: [-90, 90]
 
         - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
           source: variables/stationElevation
-          longName: "Height of Station"
-          units: "Meter"
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
@@ -224,22 +230,23 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
-        - name: "MetaData/pressure"
+        - name: "MetaData/seaTemperatureMethod"
           coordinates: "longitude latitude"
-          source: variables/pressure
-          longName: "Pressure"
-          units: "Pa"
+          source: variables/seaTemperatureMethod
+          longName: "Method of Sea Temperature Measurement"
+          units: ""
 
         - name: "MetaData/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservation
           longName: "Height"
-          units: "Meter"
+          units: "m"
 
-        - name: "MetaData/seaTemperatureMethod"
+        - name: "MetaData/pressure"
           coordinates: "longitude latitude"
-          source: variables/seaTemperatureMethod
-          longName: "Method of Sea Temperature Measurement"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
 
         # ObsType
         - name: "ObsType/specificHumidity"
@@ -266,6 +273,12 @@ observations:
           longName: "windNorthward Report Type"
           units: ""
 
+        - name: "ObsType/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "Pressure"
+          units: ""
+
         # ObsValue
         - name: "ObsValue/specificHumidity"
           coordinates: "longitude latitude"
@@ -277,25 +290,31 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperature
           longName: "Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/dewpointTemperature"
           coordinates: "longitude latitude"
           source: variables/dewpointTemperature
           longName: "Dewpoint Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
           longName: "Eastward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
 
         - name: "ObsValue/windNorthward"
           coordinates: "longitude latitude"
           source: variables/windNorthward
           longName: "Northward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
+
+        - name: "ObsValue/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/stationPressure
+          longName: "Station Pressure"
+          units: "Pa"
 
         - name: "ObsValue/pressureReducedToMeanSeaLevel"
           coordinates: "longitude latitude"
@@ -307,20 +326,20 @@ observations:
           coordinates: "longitude latitude"
           source: variables/seaTemperature
           longName: "Sea Temperature"
-          units: "Kelvin"
-        
+          units: "K"
+
         - name: "ObsValue/depthBelowSeaSurface"
           coordinates: "longitude latitude"
           source: variables/depthBelowSeaSurface
           longName: "Depth Below Sea Surface"
-          units: "Meter"
+          units: "m"
 
         - name: "ObsValue/heightOfWaves"
           coordinates: "longitude latitude"
           source: variables/heightOfWaves
           longName: "Height of Waves"
-          units: "Meter"
-        
+          units: "m"
+
         - name: "ObsValue/presentWeather"
           coordinates: "longitude latitude"
           source: variables/presentWeather
@@ -330,123 +349,140 @@ observations:
           coordinates: "longitude latitude"
           source: variables/maximumWindGustSpeed
           longName: "Maximum Wind Gust Speed"
-          units: "Meter Second-1"
-        
+          units: "m s-1"
+
         - name: "ObsValue/verticalSignificance"
           coordinates: "longitude latitude"
           source: variables/verticalSignificance
           longName: "Description of Vertical Significance (Surface Observations)"
-        
+
         - name: "ObsValue/cloudAmount"
           coordinates: "longitude latitude"
           source: variables/cloudAmount
           longName: "Description of Cloud Amount"
-        
+
         - name: "ObsValue/heightOfBaseOfCloud"
           coordinates: "longitude latitude"
           source: variables/heightOfBaseOfCloud
           longName: "Height of Base of Cloud"
-          units: "Meter"
-        
+          units: "m"
+
         - name: "ObsValue/cloudCoverTotal"
           coordinates: "longitude latitude"
           source: variables/cloudCoverTotal
           longName: "Total Cloud Coverage"
           units: "1"
-        
+
         - name: "ObsValue/heightAboveSurfaceOfBaseOfLowestCloud"
           coordinates: "longitude latitude"
           source: variables/heightAboveSurfaceOfBaseOfLowestCloud
           longName: "Height above Surface of Base of Lowest Cloud Seen"
 
         # Quality Marker
-        - name: "QualityMarker/pressure"
+        - name: "QualityMarker/stationPressure"
           coordinates: "longitude latitude"
-          source: variables/pressureQualityMarker
+          source: variables/stationPressureQualityMarker
           longName: "Pressure Quality Marker"
-          
+
         - name: "QualityMarker/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservationQualityMark
           longName: "Height Quality Marker"
-          
+
         - name: "QualityMarker/specificHumidity"
           coordinates: "longitude latitude"
           source: variables/specificHumidityQualityMarker
           longName: "Specific Humidity Quality Marker"
-          
+
         - name: "QualityMarker/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureQualityMarker
           longName: "Temperature Quality Marker"
-          
-        - name: "QualityMarker/wind"
+
+        - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
-          longName: "U, V-Component of Wind Quality Marker"
+          longName: "windEastward Quality Marker"
+
+        - name: "QualityMarker/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windQualityMarker
+          longName: "windNorthward Quality Marker"
 
         - name: "QualityMarker/pressureReducedToMeanSeaLevel"
           coordinates: "longitude latitude"
           source: variables/pressureReducedToMeanSeaLevelQualityMarker
           longName: "Mean Sea Level Pressure Quality Marker"
-          
+
         - name: "QualityMarker/seaTemperature"
           coordinates: "longitude latitude"
           source: variables/seaTemperatureQualityMarker
           longName: "Sea Temperature Quality Marker"
 
         # ObsError
-        - name: "ObsError/pressure"
+        - name: "ObsError/stationPressure"
           coordinates: "longitude latitude"
-          source: variables/pressureError
+          source: variables/stationPressureError
           longName: "Pressure Observation Error"
           units: "Pa"
-          
+
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"
           source: variables/relativeHumidityError
           longName: "Relative Humidity Error"
           units: "1"
-          
+
         - name: "ObsError/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureError
           longName: "Temperature Error"
-          units: "Kelvin"
-          
-        - name: "ObsError/wind"
+          units: "K"
+
+        - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
           source: variables/windError
-          longName: "East and Northward wind error"
-          units: "Meter Second-1"        
-          
+          longName: "Eastward wind error"
+          units: "m s-1"
+
+        - name: "ObsError/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windError
+          longName: "Northward wind error"
+          units: "m s-1"
+
         - name: "ObsError/seaTemperature"
           coordinates: "longitude latitude"
           source: variables/seaTemperatureError
           longName: "Sea Temperature Observation Error"
-          units: "Kelvin"
+          units: "K"
 
-        # Tuned ObsError
-        - name: "TunedObsError/pressure"
-          coordinates: "longitude latitude"
-          source: variables/pressureTunedError
-          longName: "Analysis-Tuned Pressure Observation Error"
-          units: "Pa"
-          
-        - name: "TunedObsError/relativeHumidity"
-          coordinates: "longitude latitude"
-          source: variables/relativeHumidityTunedError
-          longName: "Analysis-Tuned Relative Humidity Error"
-          units: "1"
-          
-        - name: "TunedObsError/airTemperature"
-          coordinates: "longitude latitude"
-          source: variables/airTemperatureTunedError
-          longName: "Analysis-Tuned Temperature Error"
-          units: "Kelvin"
-          
-        - name: "TunedObsError/wind"
-          coordinates: "longitude latitude"
-          source: variables/windTunedError
-          longName: "Analysis-Tuned East and Northward wind error"
-          units: "Meter Second-1"
+#        # Tuned ObsError
+#        - name: "TunedObsError/stationPressure"
+#          coordinates: "longitude latitude"
+#          source: variables/stationPressureTunedError
+#          longName: "Analysis-Tuned Pressure Observation Error"
+#          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
+#
+#        - name: "TunedObsError/windEastward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Eastward wind error"
+#          units: "m s-1"
+#
+#        - name: "TunedObsError/windNorthward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Northward wind error"
+#          units: "m s-1"

--- a/parm/prepbufr_adpupa.yaml
+++ b/parm/prepbufr_adpupa.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         group_by_variable: prepbufrDataLvlCat
@@ -38,7 +38,7 @@ observations:
               timeOffset: "*/PRSLEVEL/DRFTINFO/HRDR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/PRSLEVEL/DRFTINFO/HRDR"
             transforms:

--- a/parm/prepbufr_adpupa.yaml
+++ b/parm/prepbufr_adpupa.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,8 +6,7 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "./prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
         group_by_variable: prepbufrDataLvlCat
@@ -33,14 +32,17 @@ observations:
           #- WDSATR    # WINDSAT SCATTEROMETER WIND DATA (REPROCESSED, SAID)
           #- ASCATW    # ASCAT SCATTEROMETER DATA (REPROCESSED, SAID)
         variables:
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/PRSLEVEL/DRFTINFO/HRDR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/PRSLEVEL/DRFTINFO/HRDR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/PRSLEVEL/DRFTINFO/XDR"
           latitude:
@@ -49,12 +51,11 @@ observations:
             query: "*/SID"
           stationElevation:
             query: "*/ELV"
-            type: float
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
-
           prepbufrDataLvlCat:
             query: "*/PRSLEVEL/CAT"
 
@@ -75,7 +76,7 @@ observations:
 
           heightOfObservation:
             query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZOB"
-            type: float
+            #type: float
           heightOfObservationQualityMark:
             query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZQM"
 
@@ -124,36 +125,6 @@ observations:
             transform:
               - scale: 0.514444
 
-          #seaTemperature:
-          #  query: "*/SST_INFO/SSTEVENT{1}/SST1"
-          #seaTemperatureQualityMarker:
-          #  query: "*/SST_INFO/SSTEVENT{1}/SSTQM"
-          #seaTemperatureError:
-          #  query: "*/SST_INFO/SSTBACKG/SSTOE"
-          #seaTemperatureMethod:
-          #  query: "*/SST_INFO/MSST"
-          #depthBelowSeaSurface:
-          #  query: "*/SST_INFO/DBSS_SEQ/DBSS"
-          #  type: float
-          #
-          #presentWeather:
-          #  query: "*/PREWXSEQ/PRWE"
-          #
-          #verticalSignificance:
-          #  query: "*/CLOUDSEQ{1}/VSSO"
-          #cloudAmount:
-          #  query: "*/CLOUDSEQ{1}/CLAM"
-          #heightOfBaseOfCloud:
-          #  query: "*/CLOUDSEQ{1}/HOCB"
-          #  type: float
-          #cloudCoverTotal:
-          #  query: "*/CLOU2SEQ{1}/TOCC"
-          #  type: float
-          #  transforms:
-          #    - scale: 0.01
-          #heightAboveSurfaceOfBaseOfLowestCloud:
-          #  query: "*/CLOU2SEQ/HBLCS"
-
     ioda:
       backend: netcdf
       obsdataout: "./ioda_adpupa.nc"
@@ -187,8 +158,8 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
@@ -200,21 +171,21 @@ observations:
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degrees_east"
+          units: "degree_east"
           range: [0, 360]
 
         - name: "MetaData/latitude"
           coordinates: "longitude latitude"
           source: variables/latitude
           longName: "Latitude"
-          units: "degrees_north"
+          units: "degree_north"
           range: [-90, 90]
 
         - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
           source: variables/stationElevation
-          longName: "Height of Station"
-          units: "Meter"
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
@@ -234,22 +205,18 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
-        - name: "MetaData/pressure"
-          coordinates: "longitude latitude"
-          source: variables/pressure
-          longName: "Pressure"
-          units: "Pa"
 
         - name: "MetaData/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservation
           longName: "Height"
-          units: "Meter"
-          
-        #- name: "MetaData/seaTemperatureMethod"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperatureMethod
-        #  longName: "Method of Sea Temperature Measurement"
+          units: "m"
+
+        - name: "MetaData/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
 
         # ObsType
         - name: "ObsType/specificHumidity"
@@ -287,153 +254,115 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperature
           longName: "Temperature"
-          units: "Kelvin"
-          
+          units: "K"
+
         - name: "ObsValue/dewpointTemperature"
           coordinates: "longitude latitude"
           source: variables/dewpointTemperature
           longName: "Dewpoint Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
           longName: "Eastward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
 
         - name: "ObsValue/windNorthward"
           coordinates: "longitude latitude"
           source: variables/windNorthward
           longName: "Northward Wind"
-          units: "Meter Second-1"
-          
-        #- name: "ObsValue/seaTemperature"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperature
-        #  longName: "Sea Temperature"
-        #  units: "Kelvin"
-         
-        #- name: "ObsValue/depthBelowSeaSurface"
-        #  coordinates: "longitude latitude"
-        #  source: variables/depthBelowSeaSurface
-        #  longName: "Depth Below Sea Surface"
-        #  units: "Meter"
-         
-        #- name: "ObsValue/presentWeather"
-        #  coordinates: "longitude latitude"
-        #  source: variables/presentWeather
-        #  longName: "Description of Present Weather"
-         
-        #- name: "ObsValue/verticalSignificance"
-        #  coordinates: "longitude latitude"
-        #  source: variables/verticalSignificance
-        #  longName: "Description of Vertical Significance (Surface Observations)"
-         
-        #- name: "ObsValue/cloudAmount"
-        #  coordinates: "longitude latitude"
-        #  source: variables/cloudAmount
-        #  longName: "Description of Cloud Amount"
-         
-        #- name: "ObsValue/heightOfBaseOfCloud"
-        #  coordinates: "longitude latitude"
-        #  source: variables/heightOfBaseOfCloud
-        #  longName: "Height of Base of Cloud"
-        #  units: "Meter"
-         
-        #- name: "ObsValue/cloudCoverTotal"
-        #  coordinates: "longitude latitude"
-        #  source: variables/cloudCoverTotal
-        #  longName: "Total Cloud Coverage"
-        #  units: "1"
-         
-        #- name: "ObsValue/heightAboveSurfaceOfBaseOfLowestCloud"
-        #  coordinates: "longitude latitude"
-        #  source: variables/heightAboveSurfaceOfBaseOfLowestCloud
-        #  longName: "Height above Surface of Base of Lowest Cloud Seen"
-          
+          units: "m s-1"
+
         # Quality Marker
         - name: "QualityMarker/pressure"
           coordinates: "longitude latitude"
           source: variables/pressureQualityMarker
           longName: "Pressure Quality Marker"
-          
+
         - name: "QualityMarker/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservationQualityMark
           longName: "Height Quality Marker"
-          
+
         - name: "QualityMarker/specificHumidity"
           coordinates: "longitude latitude"
           source: variables/specificHumidityQualityMarker
           longName: "Specific Humidity Quality Marker"
-          
+
         - name: "QualityMarker/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureQualityMarker
           longName: "Temperature Quality Marker"
-          
-        - name: "QualityMarker/wind"
+
+        - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
-          longName: "U, V-Component of Wind Quality Marker"
-          
-        #- name: "QualityMarker/seaTemperature"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperatureQualityMarker
-        #  longName: "Sea Temperature Quality Marker"
-        
+          longName: "windEastward Quality Marker"
+
+        - name: "QualityMarker/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windQualityMarker
+          longName: "windNorthward Quality Marker"
+
         # ObsError
         - name: "ObsError/pressure"
           coordinates: "longitude latitude"
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
-          
+
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"
           source: variables/relativeHumidityError
           longName: "Relative Humidity Error"
           units: "1"
-          
+
         - name: "ObsError/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureError
           longName: "Temperature Error"
-          units: "Kelvin"
-          
-        - name: "ObsError/wind"
+          units: "K"
+
+        - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
           source: variables/windError
-          longName: "East and Northward wind error"
-          units: "Meter Second-1"        
-          
-        #- name: "ObsError/seaTemperature"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperatureError
-        #  longName: "Sea Temperature Observation Error"
-        #  units: "Kelvin"
-          
-        # Tuned ObsError
-        - name: "TunedObsError/pressure"
+          longName: "Eastward wind error"
+          units: "m s-1"
+
+        - name: "ObsError/windNorthward"
           coordinates: "longitude latitude"
-          source: variables/pressureTunedError
-          longName: "Analysis-Tuned Pressure Observation Error"
-          units: "Pa"
-          
-        - name: "TunedObsError/relativeHumidity"
-          coordinates: "longitude latitude"
-          source: variables/relativeHumidityTunedError
-          longName: "Analysis-Tuned Relative Humidity Error"
-          units: "1"
-          
-        - name: "TunedObsError/airTemperature"
-          coordinates: "longitude latitude"
-          source: variables/airTemperatureTunedError
-          longName: "Analysis-Tuned Temperature Error"
-          units: "Kelvin"
-          
-        - name: "TunedObsError/wind"
-          coordinates: "longitude latitude"
-          source: variables/windTunedError
-          longName: "Analysis-Tuned East and Northward wind error"
-          units: "Meter Second-1"
+          source: variables/windError
+          longName: "Northward wind error"
+          units: "m s-1"
+
+#        # Tuned ObsError
+#        - name: "TunedObsError/pressure"
+#          coordinates: "longitude latitude"
+#          source: variables/pressureTunedError
+#          longName: "Analysis-Tuned Pressure Observation Error"
+#          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
+#
+#        - name: "TunedObsError/windEastward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Eastward wind error"
+#          units: "m s-1"
+#
+#        - name: "TunedObsError/windNorthward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Northward wind error"
+#          units: "m s-1"

--- a/parm/prepbufr_aircar.yaml
+++ b/parm/prepbufr_aircar.yaml
@@ -1,142 +1,140 @@
-# (C) Copyright 2022 NOAA/NWS/NCEP/EMC
-# #
-# # This software is licensed under the terms of the Apache Licence Version 2.0
-# # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 observations:
   - obs space:
       name: bufr
-      
-
-      obsdatain: "./prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
-        #group_by: prepbufrDataLevelCategory
+        #group_by: prepbufrDataLvlCat
         subsets:
           - AIRCAR    # MDCRS ACARS AIRCRAFT REPORTS (ACID)
-          - AIRCFT    # AIREP, PIREP, AMDAR, TAMDAR AIRCRAFT REPORTS (ACID)
+          #- AIRCFT    # AIREP, PIREP, AMDAR, TAMDAR AIRCRAFT REPORTS (ACID)
         variables:
-          #MetaData
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/DHR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/XOB"
           latitude:
             query: "*/YOB"
           stationIdentification:
             query: "*/SID"
-          aircraftFlightNumber:
-            query: "[*/ACID, */ACID_SEQ/ACID]"
-          prepbufrDataLevelCategory:
-            query: "*/PRSLEVLA/CAT"
+          stationElevation:
+            query: "*/ELV"
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
           prepbufrDataLvlCat:
-            query: "*/PRSLEVLA/CAT"
+            query: "*/PRSLEVLA{1}/CAT"
           aircraftPhase:
-            query: "*/PRSLEVLA/ACFT_SEQ/POAF"
-          stationElevation:
-            query: "*/ELV"
-            type: float
+            query: "*/PRSLEVLA{1}/ACFT_SEQ/POAF"
+          aircraftFlightNumber:
+            query: "[*/ACID, */ACID_SEQ/ACID]"
 
           pressure:
-            query: "*/PRSLEVLA/P___INFO/P__EVENT{1}/POB"
+            query: "*/PRSLEVLA{1}/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
           pressureQualityMarker:
-            query: "*/PRSLEVLA/P___INFO/P__EVENT{1}/PQM"
+            query: "*/PRSLEVLA{1}/P___INFO/P__EVENT{1}/PQM"
           pressureError:
-            query: "*/PRSLEVLA/P___INFO/P__BACKG/POE"
+            query: "*/PRSLEVLA{1}/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
           pressureTunedError:
-            query: "*/PRSLEVLA/P___INFO/P__POSTP/POETU"
+            query: "*/PRSLEVLA{1}/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
 
           heightOfObservation:
-            query: "*/PRSLEVLA/Z___INFO/Z__EVENT{1}/ZOB"
-            type: float
+            query: "*/PRSLEVLA{1}/Z___INFO/Z__EVENT{1}/ZOB"
+            #type: float
           heightOfObservationQualityMark:
-            query: "*/PRSLEVLA/Z___INFO/Z__EVENT{1}/ZQM"
+            query: "*/PRSLEVLA{1}/Z___INFO/Z__EVENT{1}/ZQM"
 
-          #ObsValue
           specificHumidity:
-            query: "*/PRSLEVLA/Q___INFO/Q__EVENT{1}/QOB"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QOB"
             type: float
             transforms:
               - scale: 0.000001
           specificHumidityQualityMarker:
-            query: "*/PRSLEVLA/Q___INFO/Q__EVENT{1}/QQM"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
-            query: "*/PRSLEVLA/Q___INFO/Q__BACKG/QOE"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__BACKG/QOE"
             transforms:
               - scale: 0.1
           relativeHumidityTunedError:
-            query: "*/PRSLEVLA/Q___INFO/Q__POSTP/QOETU"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__POSTP/QOETU"
             transforms:
               - scale: 0.1
 
           dewpointTemperature:
-            query: "*/PRSLEVLA/Q___INFO/TDO"
+            query: "*/PRSLEVLA{1}/Q___INFO/TDO"
             transforms:
               - offset: 273.15
 
           airTemperature:
-            query: "*/PRSLEVLA/T___INFO/T__EVENT{1}/TOB"
+            query: "*/PRSLEVLA{1}/T___INFO/T__EVENT{1}/TOB"
             transforms:
               - offset: 273.15
           airTemperatureQualityMarker:
-            query: "*/PRSLEVLA/T___INFO/T__EVENT{1}/TQM"
+            query: "*/PRSLEVLA{1}/T___INFO/T__EVENT{1}/TQM"
           airTemperatureError:
-            query: "*/PRSLEVLA/T___INFO/T__BACKG/TOE"
+            query: "*/PRSLEVLA{1}/T___INFO/T__BACKG/TOE"
           airTemperatureTunedError:
-            query: "*/PRSLEVLA/T___INFO/T__POSTP/TOETU"
+            query: "*/PRSLEVLA{1}/T___INFO/T__POSTP/TOETU"
 
           windEastward:
-            query: "*/PRSLEVLA/W___INFO/W__EVENT{1}/UOB"
+            query: "*/PRSLEVLA{1}/W___INFO/W__EVENT{1}/UOB"
           windNorthward:
-            query: "*/PRSLEVLA/W___INFO/W__EVENT{1}/VOB"
+            query: "*/PRSLEVLA{1}/W___INFO/W__EVENT{1}/VOB"
           windQualityMarker:
-            query: "*/PRSLEVLA/W___INFO/W__EVENT{1}/WQM"
+            query: "*/PRSLEVLA{1}/W___INFO/W__EVENT{1}/WQM"
           windError:
-            query: "*/PRSLEVLA/W___INFO/W__BACKG/WOE"
+            query: "*/PRSLEVLA{1}/W___INFO/W__BACKG/WOE"
           windTunedError:
-            query: "*/PRSLEVLA/W___INFO/W__POSTP/WOETU"
+            query: "*/PRSLEVLA{1}/W___INFO/W__POSTP/WOETU"
             transform:
               - scale: 0.514444
 
     ioda:
       backend: netcdf
-      obsdataout: "./ioda_aircraft.nc"
+      obsdataout: "./ioda_aircar.nc"
 
       dimensions:
         - name: Level
           path: "*/PRSLEVLA"
         - name: pevent_Dim
-          path: "*/PRSLEVLA/P___INFO/P__EVENT"
+          path: "*/PRSLEVLA{1}/P___INFO/P__EVENT"
         - name: qevent_Dim
-          path: "*/PRSLEVLA/Q___INFO/Q__EVENT"
+          path: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT"
         - name: tevent_Dim
-          path: "*/PRSLEVLA/T___INFO/T__EVENT"
+          path: "*/PRSLEVLA{1}/T___INFO/T__EVENT"
         - name: wevent_Dim
-          path: "*/PRSLEVLA/W___INFO/W__EVENT"
+          path: "*/PRSLEVLA{1}/W___INFO/W__EVENT"
         - name: zevent_Dim
-          path: "*/PRSLEVLA/Z___INFO/Z__EVENT"
+          path: "*/PRSLEVLA{1}/Z___INFO/Z__EVENT"
         - name: drft_Dim
-          path: "*/PRSLEVLA/DRFTINFO"
+          path: "*/PRSLEVLA{1}/DRFTINFO"
 
 
       variables:
-        #MetaData
+
+        # MetaData
         - name: "MetaData/dateTime"
           coordinates: "longitude latitude"
           source: variables/timestamp
@@ -146,20 +144,14 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
           source: variables/stationIdentification
           longName: "Station/Aircraft ID"
-
-        - name: "MetaData/latitude"
-          coordinates: "longitude latitude"
-          source: variables/latitude
-          longName: "Latitude"
-          units: "degree_north"
-          range: [-90, 90]
+          units: ""
 
         - name: "MetaData/longitude"
           coordinates: "longitude latitude"
@@ -168,20 +160,24 @@ observations:
           units: "degree_east"
           range: [0, 360]
 
-        - name: "MetaData/aircraftFlightNumber"
+        - name: "MetaData/latitude"
           coordinates: "longitude latitude"
-          source: variables/aircraftFlightNumber
-          longName: "Aircraft Flight Number"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
 
-        - name: "MetaData/prepbufrDataLevelCategory"
+        - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
-          source: variables/prepbufrDataLevelCategory
-          longName: "Prepbufr Data Level Category"
+          source: variables/stationElevation
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
           source: variables/prepbufrReportType
           longName: "Prepbufr Report Type"
+          units: ""
 
         - name: "MetaData/dumpReportType"
           coordinates: "longitude latitude"
@@ -199,18 +195,19 @@ observations:
           coordinates: "longitude latitude"
           source: variables/aircraftPhase
           longName: "Aircraft Flight Phase"
+          units: ""
 
-        - name: "MetaData/stationElevation"
+        - name: "MetaData/aircraftFlightNumber"
           coordinates: "longitude latitude"
-          source: variables/stationElevation
-          longName: "Elevation of Station"
-          units: "Meter"
+          source: variables/aircraftFlightNumber
+          longName: "Aircraft Flight Number"
+          units: ""
 
         - name: "MetaData/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservation
           longName: "Height"
-          units: "Meter"
+          units: "m"
 
         - name: "MetaData/pressure"
           coordinates: "longitude latitude"
@@ -243,7 +240,7 @@ observations:
           longName: "windNorthward Report Type"
           units: ""
 
-        #ObsValue
+        # ObsValue
         - name: "ObsValue/specificHumidity"
           coordinates: "longitude latitude"
           source: variables/specificHumidity
@@ -254,25 +251,25 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperature
           longName: "Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/dewpointTemperature"
           coordinates: "longitude latitude"
           source: variables/dewpointTemperature
           longName: "Dewpoint Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
-          longName: "U component of Wind"
-          units: "Meter Second-1"
+          longName: "Eastward Wind"
+          units: "m s-1"
 
         - name: "ObsValue/windNorthward"
           coordinates: "longitude latitude"
           source: variables/windNorthward
-          longName: "V component of Wind"
-          units: "Meter Second-1"
+          longName: "Northward Wind"
+          units: "m s-1"
 
         # Quality Marker
         - name: "QualityMarker/pressure"
@@ -295,10 +292,15 @@ observations:
           source: variables/airTemperatureQualityMarker
           longName: "Temperature Quality Marker"
 
-        - name: "QualityMarker/wind"
+        - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
-          longName: "U, V-Component of Wind Quality Marker"
+          longName: "windEastward Quality Marker"
+
+        - name: "QualityMarker/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windQualityMarker
+          longName: "windNorthward Quality Marker"
 
         # ObsError
         - name: "ObsError/pressure"
@@ -317,35 +319,47 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperatureError
           longName: "Temperature Error"
-          units: "Kelvin"
+          units: "K"
 
-        - name: "ObsError/wind"
+        - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
           source: variables/windError
-          longName: "East and Northward wind error"
-          units: "Meter Second-1"
+          longName: "Eastward wind error"
+          units: "m s-1"
 
-        # Tuned ObsError
-        - name: "TunedObsError/pressure"
+        - name: "ObsError/windNorthward"
           coordinates: "longitude latitude"
-          source: variables/pressureTunedError
-          longName: "Analysis-Tuned Pressure Observation Error"
-          units: "Pa"
+          source: variables/windError
+          longName: "Northward wind error"
+          units: "m s-1"
 
-        - name: "TunedObsError/relativeHumidity"
-          coordinates: "longitude latitude"
-          source: variables/relativeHumidityTunedError
-          longName: "Analysis-Tuned Relative Humidity Error"
-          units: "1"
-
-        - name: "TunedObsError/airTemperature"
-          coordinates: "longitude latitude"
-          source: variables/airTemperatureTunedError
-          longName: "Analysis-Tuned Temperature Error"
-          units: "Kelvin"
-
-        - name: "TunedObsError/wind"
-          coordinates: "longitude latitude"
-          source: variables/windTunedError
-          longName: "Analysis-Tuned East and Northward wind error"
-          units: "Meter Second-1"
+#        # Tuned ObsError
+#        - name: "TunedObsError/pressure"
+#          coordinates: "longitude latitude"
+#          source: variables/pressureTunedError
+#          longName: "Analysis-Tuned Pressure Observation Error"
+#          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
+#
+#        - name: "TunedObsError/windEastward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Eastward wind error"
+#          units: "m s-1"
+#
+#        - name: "TunedObsError/windNorthward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Northward wind error"
+#          units: "m s-1"

--- a/parm/prepbufr_aircar.yaml
+++ b/parm/prepbufr_aircar.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by: prepbufrDataLvlCat
@@ -20,7 +20,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_aircft.yaml
+++ b/parm/prepbufr_aircft.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by: prepbufrDataLvlCat
@@ -20,7 +20,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_aircft.yaml
+++ b/parm/prepbufr_aircft.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,23 +6,25 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "./prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
-        group_by_variable: prepbufrDataLvlCat
+        #group_by: prepbufrDataLvlCat
         subsets:
-          - PROFLR    # WIND PROFILER AND ACOUSTIC SOUNDER (SODAR) REPORTS
-          - VADWND    # VAD (NEXRAD) WIND REPORTS
+          #- AIRCAR    # MDCRS ACARS AIRCRAFT REPORTS (ACID)
+          - AIRCFT    # AIREP, PIREP, AMDAR, TAMDAR AIRCRAFT REPORTS (ACID)
         variables:
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/DHR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/XOB"
           latitude:
@@ -31,130 +33,103 @@ observations:
             query: "*/SID"
           stationElevation:
             query: "*/ELV"
-            type: float
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
-
           prepbufrDataLvlCat:
-            query: "*/PRSLEVEL/CAT"
+            query: "*/PRSLEVLA{1}/CAT"
+          aircraftPhase:
+            query: "*/PRSLEVLA{1}/ACFT_SEQ/POAF"
+          aircraftFlightNumber:
+            query: "[*/ACID, */ACID_SEQ/ACID]"
 
           pressure:
-            query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/POB"
+            query: "*/PRSLEVLA{1}/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
           pressureQualityMarker:
-            query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/PQM"
+            query: "*/PRSLEVLA{1}/P___INFO/P__EVENT{1}/PQM"
           pressureError:
-            query: "*/PRSLEVEL/P___INFO/P__BACKG/POE"
+            query: "*/PRSLEVLA{1}/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
           pressureTunedError:
-            query: "*/PRSLEVEL/P___INFO/P__POSTP/POETU"
+            query: "*/PRSLEVLA{1}/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
 
           heightOfObservation:
-            query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZOB"
-            type: float
+            query: "*/PRSLEVLA{1}/Z___INFO/Z__EVENT{1}/ZOB"
+            #type: float
           heightOfObservationQualityMark:
-            query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZQM"
+            query: "*/PRSLEVLA{1}/Z___INFO/Z__EVENT{1}/ZQM"
 
           specificHumidity:
-            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QOB"
             type: float
             transforms:
               - scale: 0.000001
           specificHumidityQualityMarker:
-            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
-            query: "*/PRSLEVEL/Q___INFO/Q__BACKG/QOE"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__BACKG/QOE"
             transforms:
               - scale: 0.1
           relativeHumidityTunedError:
-            query: "*/PRSLEVEL/Q___INFO/Q__POSTP/QOETU"
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__POSTP/QOETU"
             transforms:
               - scale: 0.1
 
           dewpointTemperature:
-            query: "*/PRSLEVEL/Q___INFO/TDO"
+            query: "*/PRSLEVLA{1}/Q___INFO/TDO"
             transforms:
               - offset: 273.15
 
           airTemperature:
-            query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TOB"
+            query: "*/PRSLEVLA{1}/T___INFO/T__EVENT{1}/TOB"
             transforms:
               - offset: 273.15
           airTemperatureQualityMarker:
-            query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TQM"
+            query: "*/PRSLEVLA{1}/T___INFO/T__EVENT{1}/TQM"
           airTemperatureError:
-            query: "*/PRSLEVEL/T___INFO/T__BACKG/TOE"
+            query: "*/PRSLEVLA{1}/T___INFO/T__BACKG/TOE"
           airTemperatureTunedError:
-            query: "*/PRSLEVEL/T___INFO/T__POSTP/TOETU"
+            query: "*/PRSLEVLA{1}/T___INFO/T__POSTP/TOETU"
 
           windEastward:
-            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/UOB"
+            query: "*/PRSLEVLA{1}/W___INFO/W__EVENT{1}/UOB"
           windNorthward:
-            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/VOB"
+            query: "*/PRSLEVLA{1}/W___INFO/W__EVENT{1}/VOB"
           windQualityMarker:
-            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/WQM"
+            query: "*/PRSLEVLA{1}/W___INFO/W__EVENT{1}/WQM"
           windError:
-            query: "*/PRSLEVEL/W___INFO/W__BACKG/WOE"
+            query: "*/PRSLEVLA{1}/W___INFO/W__BACKG/WOE"
           windTunedError:
-            query: "*/PRSLEVEL/W___INFO/W__POSTP/WOETU"
+            query: "*/PRSLEVLA{1}/W___INFO/W__POSTP/WOETU"
             transform:
               - scale: 0.514444
 
-          #seaTemperature:
-          #  query: "*/SST_INFO/SSTEVENT{1}/SST1"
-          #seaTemperatureQualityMarker:
-          #  query: "*/SST_INFO/SSTEVENT{1}/SSTQM"
-          #seaTemperatureError:
-          #  query: "*/SST_INFO/SSTBACKG/SSTOE"
-          #seaTemperatureMethod:
-          #  query: "*/SST_INFO/MSST"
-          #depthBelowSeaSurface:
-          #  query: "*/SST_INFO/DBSS_SEQ/DBSS"
-          #  type: float
-          #
-          #presentWeather:
-          #  query: "*/PREWXSEQ/PRWE"
-          #
-          #verticalSignificance:
-          #  query: "*/CLOUDSEQ{1}/VSSO"
-          #cloudAmount:
-          #  query: "*/CLOUDSEQ{1}/CLAM"
-          #heightOfBaseOfCloud:
-          #  query: "*/CLOUDSEQ{1}/HOCB"
-          #  type: float
-          #cloudCoverTotal:
-          #  query: "*/CLOU2SEQ{1}/TOCC"
-          #  type: float
-          #  transforms:
-          #    - scale: 0.01
-          #heightAboveSurfaceOfBaseOfLowestCloud:
-          #  query: "*/CLOU2SEQ/HBLCS"
-
     ioda:
       backend: netcdf
-      obsdataout: "./ioda_profiler.nc"
+      obsdataout: "./ioda_aircft.nc"
 
       dimensions:
         - name: Level
-          path: "*/PRSLEVEL"
+          path: "*/PRSLEVLA"
         - name: pevent_Dim
-          path: "*/PRSLEVEL/P___INFO/P__EVENT"
+          path: "*/PRSLEVLA{1}/P___INFO/P__EVENT"
         - name: qevent_Dim
-          path: "*/PRSLEVEL/Q___INFO/Q__EVENT"
+          path: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT"
         - name: tevent_Dim
-          path: "*/PRSLEVEL/T___INFO/T__EVENT"
+          path: "*/PRSLEVLA{1}/T___INFO/T__EVENT"
         - name: wevent_Dim
-          path: "*/PRSLEVEL/W___INFO/W__EVENT"
+          path: "*/PRSLEVLA{1}/W___INFO/W__EVENT"
         - name: zevent_Dim
-          path: "*/PRSLEVEL/Z___INFO/Z__EVENT"
+          path: "*/PRSLEVLA{1}/Z___INFO/Z__EVENT"
         - name: drft_Dim
-          path: "*/PRSLEVEL/DRFTINFO"
+          path: "*/PRSLEVLA{1}/DRFTINFO"
 
 
       variables:
@@ -169,34 +144,34 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
           source: variables/stationIdentification
-          longName: "Station ID"
+          longName: "Station/Aircraft ID"
           units: ""
 
         - name: "MetaData/longitude"
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degrees_east"
+          units: "degree_east"
           range: [0, 360]
 
         - name: "MetaData/latitude"
           coordinates: "longitude latitude"
           source: variables/latitude
           longName: "Latitude"
-          units: "degrees_north"
+          units: "degree_north"
           range: [-90, 90]
 
         - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
           source: variables/stationElevation
-          longName: "Height of Station"
-          units: "Meter"
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
@@ -216,22 +191,29 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
-        - name: "MetaData/pressure"
+        - name: "MetaData/aircraftFlightPhase"
           coordinates: "longitude latitude"
-          source: variables/pressure
-          longName: "Pressure"
-          units: "Pa"
+          source: variables/aircraftPhase
+          longName: "Aircraft Flight Phase"
+          units: ""
+
+        - name: "MetaData/aircraftFlightNumber"
+          coordinates: "longitude latitude"
+          source: variables/aircraftFlightNumber
+          longName: "Aircraft Flight Number"
+          units: ""
 
         - name: "MetaData/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservation
           longName: "Height"
-          units: "Meter"
-          
-        #- name: "MetaData/seaTemperatureMethod"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperatureMethod
-        #  longName: "Method of Sea Temperature Measurement"
+          units: "m"
+
+        - name: "MetaData/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
 
         # ObsType
         - name: "ObsType/specificHumidity"
@@ -269,153 +251,115 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperature
           longName: "Temperature"
-          units: "Kelvin"
-          
+          units: "K"
+
         - name: "ObsValue/dewpointTemperature"
           coordinates: "longitude latitude"
           source: variables/dewpointTemperature
           longName: "Dewpoint Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
           longName: "Eastward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
 
         - name: "ObsValue/windNorthward"
           coordinates: "longitude latitude"
           source: variables/windNorthward
           longName: "Northward Wind"
-          units: "Meter Second-1"
-          
-        #- name: "ObsValue/seaTemperature"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperature
-        #  longName: "Sea Temperature"
-        #  units: "Kelvin"
-         
-        #- name: "ObsValue/depthBelowSeaSurface"
-        #  coordinates: "longitude latitude"
-        #  source: variables/depthBelowSeaSurface
-        #  longName: "Depth Below Sea Surface"
-        #  units: "Meter"
-         
-        #- name: "ObsValue/presentWeather"
-        #  coordinates: "longitude latitude"
-        #  source: variables/presentWeather
-        #  longName: "Description of Present Weather"
-         
-        #- name: "ObsValue/verticalSignificance"
-        #  coordinates: "longitude latitude"
-        #  source: variables/verticalSignificance
-        #  longName: "Description of Vertical Significance (Surface Observations)"
-         
-        #- name: "ObsValue/cloudAmount"
-        #  coordinates: "longitude latitude"
-        #  source: variables/cloudAmount
-        #  longName: "Description of Cloud Amount"
-         
-        #- name: "ObsValue/heightOfBaseOfCloud"
-        #  coordinates: "longitude latitude"
-        #  source: variables/heightOfBaseOfCloud
-        #  longName: "Height of Base of Cloud"
-        #  units: "Meter"
-         
-        #- name: "ObsValue/cloudCoverTotal"
-        #  coordinates: "longitude latitude"
-        #  source: variables/cloudCoverTotal
-        #  longName: "Total Cloud Coverage"
-        #  units: "1"
-         
-        #- name: "ObsValue/heightAboveSurfaceOfBaseOfLowestCloud"
-        #  coordinates: "longitude latitude"
-        #  source: variables/heightAboveSurfaceOfBaseOfLowestCloud
-        #  longName: "Height above Surface of Base of Lowest Cloud Seen"
-          
+          units: "m s-1"
+
         # Quality Marker
         - name: "QualityMarker/pressure"
           coordinates: "longitude latitude"
           source: variables/pressureQualityMarker
           longName: "Pressure Quality Marker"
-          
+
         - name: "QualityMarker/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservationQualityMark
           longName: "Height Quality Marker"
-          
+
         - name: "QualityMarker/specificHumidity"
           coordinates: "longitude latitude"
           source: variables/specificHumidityQualityMarker
           longName: "Specific Humidity Quality Marker"
-          
+
         - name: "QualityMarker/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureQualityMarker
           longName: "Temperature Quality Marker"
-          
-        - name: "QualityMarker/wind"
+
+        - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
-          longName: "U, V-Component of Wind Quality Marker"
-          
-        #- name: "QualityMarker/seaTemperature"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperatureQualityMarker
-        #  longName: "Sea Temperature Quality Marker"
-        
+          longName: "windEastward Quality Marker"
+
+        - name: "QualityMarker/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windQualityMarker
+          longName: "windNorthward Quality Marker"
+
         # ObsError
         - name: "ObsError/pressure"
           coordinates: "longitude latitude"
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
-          
+
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"
           source: variables/relativeHumidityError
           longName: "Relative Humidity Error"
           units: "1"
-          
+
         - name: "ObsError/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureError
           longName: "Temperature Error"
-          units: "Kelvin"
-          
-        - name: "ObsError/wind"
+          units: "K"
+
+        - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
           source: variables/windError
-          longName: "East and Northward wind error"
-          units: "Meter Second-1"        
-          
-        #- name: "ObsError/seaTemperature"
-        #  coordinates: "longitude latitude"
-        #  source: variables/seaTemperatureError
-        #  longName: "Sea Temperature Observation Error"
-        #  units: "Kelvin"
-          
-        # Tuned ObsError
-        - name: "TunedObsError/pressure"
+          longName: "Eastward wind error"
+          units: "m s-1"
+
+        - name: "ObsError/windNorthward"
           coordinates: "longitude latitude"
-          source: variables/pressureTunedError
-          longName: "Analysis-Tuned Pressure Observation Error"
-          units: "Pa"
-          
-        - name: "TunedObsError/relativeHumidity"
-          coordinates: "longitude latitude"
-          source: variables/relativeHumidityTunedError
-          longName: "Analysis-Tuned Relative Humidity Error"
-          units: "1"
-          
-        - name: "TunedObsError/airTemperature"
-          coordinates: "longitude latitude"
-          source: variables/airTemperatureTunedError
-          longName: "Analysis-Tuned Temperature Error"
-          units: "Kelvin"
-          
-        - name: "TunedObsError/wind"
-          coordinates: "longitude latitude"
-          source: variables/windTunedError
-          longName: "Analysis-Tuned East and Northward wind error"
-          units: "Meter Second-1"
+          source: variables/windError
+          longName: "Northward wind error"
+          units: "m s-1"
+
+#        # Tuned ObsError
+#        - name: "TunedObsError/pressure"
+#          coordinates: "longitude latitude"
+#          source: variables/pressureTunedError
+#          longName: "Analysis-Tuned Pressure Observation Error"
+#          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
+#
+#        - name: "TunedObsError/windEastward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Eastward wind error"
+#          units: "m s-1"
+#
+#        - name: "TunedObsError/windNorthward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Northward wind error"
+#          units: "m s-1"

--- a/parm/prepbufr_ascatw.yaml
+++ b/parm/prepbufr_ascatw.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_gpsipw.yaml
+++ b/parm/prepbufr_gpsipw.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_gpsipw.yaml
+++ b/parm/prepbufr_gpsipw.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,22 +6,24 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "./prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
         subsets:
           - GPSIPW    # GPS - INTEGRATED PRECIPITABLE WATER AND TOTAL ZENITH DELAY REPORTS
         variables:
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/DHR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/XOB"
           latitude:
@@ -30,11 +32,11 @@ observations:
             query: "*/SID"
           stationElevation:
             query: "*/ELV"
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
-
           prepbufrDataLvlCat:
             query: "*/CAT"
 
@@ -72,8 +74,8 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
@@ -85,21 +87,21 @@ observations:
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degrees_east"
+          units: "degree_east"
           range: [0, 360]
 
         - name: "MetaData/latitude"
           coordinates: "longitude latitude"
           source: variables/latitude
           longName: "Latitude"
-          units: "degrees_north"
+          units: "degree_north"
           range: [-90, 90]
 
         - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
           source: variables/stationElevation
-          longName: "Height of Station"
-          units: "Meter"
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
@@ -137,24 +139,24 @@ observations:
           coordinates: "longitude latitude"
           source: variables/totalPrecipitableWater
           longName: "Total Precipitable Water"
-          units: "Millimeter"
+          units: "mm"
 
         # Quality Marker
         - name: "QualityMarker/totalPrecipitableWater"
           coordinates: "longitude latitude"
           source: variables/pwQualityMarker
           longName: "Total Precipitable Water Quality Marker"
-          
+
         # ObsError
         - name: "ObsError/totalPrecipitableWater"
           coordinates: "longitude latitude"
           source: variables/pwError
           longName: "Total Precipitable Water Observation Error"
-          units: "Millimeter"
-          
-        # Tuned ObsError
-        - name: "TunedObsError/totalPrecipitableWater"
-          coordinates: "longitude latitude"
-          source: variables/pwTunedError
-          longName: "Analysis-Tuned Total Precipitable Water Observation Error"
-          units: "Millimeter"
+          units: "mm"
+
+#        # Tuned ObsError
+#        - name: "TunedObsError/totalPrecipitableWater"
+#          coordinates: "longitude latitude"
+#          source: variables/pwTunedError
+#          longName: "Analysis-Tuned Total Precipitable Water Observation Error"
+#          units: "mm"

--- a/parm/prepbufr_msonet.yaml
+++ b/parm/prepbufr_msonet.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,22 +6,24 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
         subsets:
           - MSONET    # MESONET SURFACE REPORTS
         variables:
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/DHR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/XOB"
           latitude:
@@ -30,33 +32,40 @@ observations:
             query: "*/SID"
           stationElevation:
             query: "*/ELV"
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
-
-          mesonetProvider:
-            query: "*/PRVSTG"
           prepbufrDataLvlCat:
             query: "*/CAT"
+          dataProviderOrigin:
+            query: "*/PRVSTG"
+          dataProviderSubOrigin:
+            query: "*/SPRVSTG"
 
           pressure:
             query: "*/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
-          pressureQualityMarker:
+          stationPressure:
+            query: "*/P___INFO/P__EVENT{1}/POB"
+            transforms:
+              - scale: 100
+          stationPressureQualityMarker:
             query: "*/P___INFO/P__EVENT{1}/PQM"
-          pressureError:
+          stationPressureError:
             query: "*/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
-          pressureTunedError:
+          stationPressureTunedError:
             query: "*/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
 
           heightOfObservation:
             query: "*/Z___INFO/Z__EVENT{1}/ZOB"
+            #type: float
           heightOfObservationQualityMark:
             query: "*/Z___INFO/Z__EVENT{1}/ZQM"
 
@@ -117,11 +126,10 @@ observations:
             type: float
           maximumWindGustSpeed:
             query: "*/GUST2SEQ/MXGS"
-          
+
     ioda:
       backend: netcdf
-      obsdataout: "./ioda_mesonet.nc"
-
+      obsdataout: "./ioda_msonet.nc"
 
       dimensions:
         - name: pevent_Dim
@@ -148,8 +156,8 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
@@ -161,21 +169,21 @@ observations:
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degrees_east"
+          units: "degree_east"
           range: [0, 360]
 
         - name: "MetaData/latitude"
           coordinates: "longitude latitude"
           source: variables/latitude
           longName: "Latitude"
-          units: "degrees_north"
+          units: "degree_north"
           range: [-90, 90]
 
         - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
           source: variables/stationElevation
-          longName: "Height of Station"
-          units: "Meter"
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
@@ -189,29 +197,35 @@ observations:
           longName: "Data Dump Report Type"
           units: ""
 
-        - name: "MetaData/mesonetProvider"
-          coordinates: "longitude latitude"
-          source: variables/mesonetProvider
-          longName: "Mesonet Provider ID String"
-          units: ""
-
         - name: "MetaData/prepbufrDataLvlCat"
           coordinates: "longitude latitude"
           source: variables/prepbufrDataLvlCat
           longName: "Prepbufr Data Level Category"
           units: ""
 
-        - name: "MetaData/pressure"
+        - name: "MetaData/dataProviderOrigin"
           coordinates: "longitude latitude"
-          source: variables/pressure
-          longName: "Pressure"
-          units: "Pa"
+          source: variables/dataProviderOrigin
+          longName: "Mesonet Provider ID String"
+          units: ""
+
+        - name: "MetaData/dataProviderSubOrigin"
+          coordinates: "longitude latitude"
+          source: variables/dataProviderSubOrigin
+          longName: "Mesonet SubProvider ID String"
+          units: ""
 
         - name: "MetaData/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservation
           longName: "Height"
-          units: "Meter"
+          units: "m"
+
+        - name: "MetaData/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
 
         # ObsType
         - name: "ObsType/specificHumidity"
@@ -238,6 +252,12 @@ observations:
           longName: "windNorthward Report Type"
           units: ""
 
+        - name: "ObsType/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "Pressure"
+          units: ""
+
         # ObsValue
         - name: "ObsValue/specificHumidity"
           coordinates: "longitude latitude"
@@ -249,25 +269,31 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperature
           longName: "Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/dewpointTemperature"
           coordinates: "longitude latitude"
           source: variables/dewpointTemperature
           longName: "Dewpoint Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
           longName: "Eastward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
 
         - name: "ObsValue/windNorthward"
           coordinates: "longitude latitude"
           source: variables/windNorthward
           longName: "Northward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
+
+        - name: "ObsValue/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/stationPressure
+          longName: "Station Pressure"
+          units: "Pa"
 
         - name: "ObsValue/pressureReducedToMeanSeaLevel"
           coordinates: "longitude latitude"
@@ -279,91 +305,108 @@ observations:
           coordinates: "longitude latitude"
           source: variables/horizontalVisibility
           longName: "Horizontal Visibility"
-          units: "Meter"
+          units: "m"
 
         - name: "ObsValue/maximumWindGustSpeed"
           coordinates: "longitude latitude"
           source: variables/maximumWindGustSpeed
           longName: "Maximum Wind Gust Speed"
-          units: "Meter Second-1"
-        
+          units: "m s-1"
+
         # Quality Marker
-        - name: "QualityMarker/pressure"
+        - name: "QualityMarker/stationPressure"
           coordinates: "longitude latitude"
-          source: variables/pressureQualityMarker
+          source: variables/stationPressureQualityMarker
           longName: "Pressure Quality Marker"
-          
+
         - name: "QualityMarker/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservationQualityMark
           longName: "Height Quality Marker"
-          
+
         - name: "QualityMarker/specificHumidity"
           coordinates: "longitude latitude"
           source: variables/specificHumidityQualityMarker
           longName: "Specific Humidity Quality Marker"
-          
+
         - name: "QualityMarker/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureQualityMarker
           longName: "Temperature Quality Marker"
-          
-        - name: "QualityMarker/wind"
+
+        - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
-          longName: "U, V-Component of Wind Quality Marker"
+          longName: "windEastward Quality Marker"
+
+        - name: "QualityMarker/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windQualityMarker
+          longName: "windNorthward Quality Marker"
 
         - name: "QualityMarker/pressureReducedToMeanSeaLevel"
           coordinates: "longitude latitude"
           source: variables/pressureReducedToMeanSeaLevelQualityMarker
           longName: "Mean Sea Level Pressure Quality Marker"
-          
+
         # ObsError
-        - name: "ObsError/pressure"
+        - name: "ObsError/stationPressure"
           coordinates: "longitude latitude"
-          source: variables/pressureError
+          source: variables/stationPressureError
           longName: "Pressure Observation Error"
           units: "Pa"
-          
+
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"
           source: variables/relativeHumidityError
           longName: "Relative Humidity Error"
           units: "1"
-          
+
         - name: "ObsError/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureError
           longName: "Temperature Error"
-          units: "Kelvin"
-          
-        - name: "ObsError/wind"
+          units: "K"
+
+        - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
           source: variables/windError
-          longName: "East and Northward wind error"
-          units: "Meter Second-1"        
-          
-        # Tuned ObsError
-        - name: "TunedObsError/pressure"
+          longName: "Eastward wind error"
+          units: "m s-1"
+
+        - name: "ObsError/windNorthward"
           coordinates: "longitude latitude"
-          source: variables/pressureTunedError
-          longName: "Analysis-Tuned Pressure Observation Error"
-          units: "Pa"
-          
-        - name: "TunedObsError/relativeHumidity"
-          coordinates: "longitude latitude"
-          source: variables/relativeHumidityTunedError
-          longName: "Analysis-Tuned Relative Humidity Error"
-          units: "1"
-          
-        - name: "TunedObsError/airTemperature"
-          coordinates: "longitude latitude"
-          source: variables/airTemperatureTunedError
-          longName: "Analysis-Tuned Temperature Error"
-          units: "Kelvin"
-          
-        - name: "TunedObsError/wind"
-          coordinates: "longitude latitude"
-          source: variables/windTunedError
-          longName: "Analysis-Tuned East and Northward wind error"
-          units: "Meter Second-1"
+          source: variables/windError
+          longName: "Northward wind error"
+          units: "m s-1"
+
+#        # Tuned ObsError
+#        - name: "TunedObsError/stationPressure"
+#          coordinates: "longitude latitude"
+#          source: variables/stationPressureTunedError
+#          longName: "Analysis-Tuned Pressure Observation Error"
+#          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
+#
+#        - name: "TunedObsError/windEastward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Eastward wind error"
+#          units: "m s-1"
+#
+#        - name: "TunedObsError/windNorthward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Northward wind error"
+#          units: "m s-1"

--- a/parm/prepbufr_msonet.yaml
+++ b/parm/prepbufr_msonet.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_proflr.yaml
+++ b/parm/prepbufr_proflr.yaml
@@ -9,9 +9,9 @@ observations:
       obsdatain: "./bufr/prepbufr"
 
       exports:
-        #group_by_variable: prepbufrDataLvlCat
+        group_by_variable: prepbufrDataLvlCat
         subsets:
-          - ASCATW    # ASCAT SCATTEROMETER DATA (REPROCESSED, SAID)
+          - PROFLR    # WIND PROFILER AND ACOUSTIC SOUNDER (SODAR) REPORTS
         variables:
           # MetaData
           timestamp:
@@ -38,47 +38,94 @@ observations:
           dumpReportType:
             query: "*/T29"
           prepbufrDataLvlCat:
-            query: "*/CAT"
-          satelliteID:
-            query: "*/SAID"
+            query: "*/PRSLEVEL/CAT"
 
           pressure:
-            query: "*/P___INFO/P__EVENT{1}/POB"
+            query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
           pressureQualityMarker:
-            query: "*/P___INFO/P__EVENT{1}/PQM"
+            query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/PQM"
           pressureError:
-            query: "*/P___INFO/P__BACKG/POE"
+            query: "*/PRSLEVEL/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
           pressureTunedError:
-            query: "*/P___INFO/P__POSTP/POETU"
+            query: "*/PRSLEVEL/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
 
+          heightOfObservation:
+            query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZOB"
+            #type: float
+          heightOfObservationQualityMark:
+            query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZQM"
+
+          specificHumidity:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.000001
+          specificHumidityQualityMarker:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
+          relativeHumidityError:
+            query: "*/PRSLEVEL/Q___INFO/Q__BACKG/QOE"
+            transforms:
+              - scale: 0.1
+          relativeHumidityTunedError:
+            query: "*/PRSLEVEL/Q___INFO/Q__POSTP/QOETU"
+            transforms:
+              - scale: 0.1
+
+          dewpointTemperature:
+            query: "*/PRSLEVEL/Q___INFO/TDO"
+            transforms:
+              - offset: 273.15
+
+          airTemperature:
+            query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TOB"
+            transforms:
+              - offset: 273.15
+          airTemperatureQualityMarker:
+            query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TQM"
+          airTemperatureError:
+            query: "*/PRSLEVEL/T___INFO/T__BACKG/TOE"
+          airTemperatureTunedError:
+            query: "*/PRSLEVEL/T___INFO/T__POSTP/TOETU"
+
           windEastward:
-            query: "*/W___INFO/W__EVENT{1}/UOB"
+            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/UOB"
           windNorthward:
-            query: "*/W___INFO/W__EVENT{1}/VOB"
+            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/VOB"
           windQualityMarker:
-            query: "*/W___INFO/W__EVENT{1}/WQM"
+            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/WQM"
           windError:
-            query: "*/W___INFO/W__BACKG/WOE"
+            query: "*/PRSLEVEL/W___INFO/W__BACKG/WOE"
           windTunedError:
-            query: "*/W___INFO/W__POSTP/WOETU"
+            query: "*/PRSLEVEL/W___INFO/W__POSTP/WOETU"
             transform:
               - scale: 0.514444
 
+
     ioda:
       backend: netcdf
-      obsdataout: "./ioda_ascatw.nc"
+      obsdataout: "./ioda_proflr.nc"
 
       dimensions:
+        - name: Level
+          path: "*/PRSLEVEL"
         - name: pevent_Dim
-          path: "*/P___INFO/P__EVENT"
+          path: "*/PRSLEVEL/P___INFO/P__EVENT"
+        - name: qevent_Dim
+          path: "*/PRSLEVEL/Q___INFO/Q__EVENT"
+        - name: tevent_Dim
+          path: "*/PRSLEVEL/T___INFO/T__EVENT"
         - name: wevent_Dim
-          path: "*/W___INFO/W__EVENT"
+          path: "*/PRSLEVEL/W___INFO/W__EVENT"
+        - name: zevent_Dim
+          path: "*/PRSLEVEL/Z___INFO/Z__EVENT"
+        - name: drft_Dim
+          path: "*/PRSLEVEL/DRFTINFO"
 
 
       variables:
@@ -100,12 +147,6 @@ observations:
           coordinates: "longitude latitude"
           source: variables/stationIdentification
           longName: "Station ID"
-          units: ""
-
-        - name: "MetaData/satelliteIdentification"
-          coordinates: "longitude latitude"
-          source: variables/satelliteID
-          longName: "Satellite Identification"
           units: ""
 
         - name: "MetaData/longitude"
@@ -146,6 +187,13 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
+
+        - name: "MetaData/height"
+          coordinates: "longitude latitude"
+          source: variables/heightOfObservation
+          longName: "Height"
+          units: "m"
+
         - name: "MetaData/pressure"
           coordinates: "longitude latitude"
           source: variables/pressure
@@ -153,6 +201,18 @@ observations:
           units: "Pa"
 
         # ObsType
+        - name: "ObsType/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "specificHumidity Report Type"
+          units: ""
+
+        - name: "ObsType/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "airTemperature report Type"
+          units: ""
+
         - name: "ObsType/windEastward"
           coordinates: "longitude latitude"
           source: variables/prepbufrReportType
@@ -166,6 +226,24 @@ observations:
           units: ""
 
         # ObsValue
+        - name: "ObsValue/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidity
+          longName: "Specific Humidity"
+          units: "Kilogram Kilogram-1"
+
+        - name: "ObsValue/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperature
+          longName: "Temperature"
+          units: "K"
+
+        - name: "ObsValue/dewpointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewpointTemperature
+          longName: "Dewpoint Temperature"
+          units: "K"
+
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
@@ -184,6 +262,21 @@ observations:
           source: variables/pressureQualityMarker
           longName: "Pressure Quality Marker"
 
+        - name: "QualityMarker/height"
+          coordinates: "longitude latitude"
+          source: variables/heightOfObservationQualityMark
+          longName: "Height Quality Marker"
+
+        - name: "QualityMarker/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityQualityMarker
+          longName: "Specific Humidity Quality Marker"
+
+        - name: "QualityMarker/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureQualityMarker
+          longName: "Temperature Quality Marker"
+
         - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
@@ -200,6 +293,18 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/relativeHumidity"
+          coordinates: "longitude latitude"
+          source: variables/relativeHumidityError
+          longName: "Relative Humidity Error"
+          units: "1"
+
+        - name: "ObsError/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureError
+          longName: "Temperature Error"
+          units: "K"
 
         - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
@@ -219,6 +324,18 @@ observations:
 #          source: variables/pressureTunedError
 #          longName: "Analysis-Tuned Pressure Observation Error"
 #          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
 #
 #        - name: "TunedObsError/windEastward"
 #          coordinates: "longitude latitude"

--- a/parm/prepbufr_proflr.yaml
+++ b/parm/prepbufr_proflr.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_rassda.yaml
+++ b/parm/prepbufr_rassda.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -6,22 +6,24 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "./prepbufr"
+      obsdatain: "./bufr/prepbufr"
 
       exports:
         group_by_variable: prepbufrDataLvlCat
         subsets:
           - RASSDA    # RADIO ACOUSTIC SOUNDING SYSTEM (RASS) VIRTUAL TEMPERATURE PROFILE REPORTS
         variables:
+          # MetaData
           timestamp:
             timeoffset:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: @referenceTime@
+              referenceTime: "@REFERENCETIME@"
           timeOffset:
             query: "*/DHR"
+            transforms:
+              - scale: 3600
           longitude:
             query: "*/XOB"
           latitude:
@@ -30,12 +32,11 @@ observations:
             query: "*/SID"
           stationElevation:
             query: "*/ELV"
-            type: float
+            #type: float
           prepbufrReportType:
             query: "*/TYP"
           dumpReportType:
             query: "*/T29"
-
           prepbufrDataLvlCat:
             query: "*/PRSLEVEL/CAT"
 
@@ -56,7 +57,7 @@ observations:
 
           heightOfObservation:
             query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZOB"
-            type: float
+            #type: float
           heightOfObservationQualityMark:
             query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZQM"
 
@@ -168,8 +169,8 @@ observations:
         - name: "MetaData/timeOffset"
           coordinates: "longitude latitude"
           source: variables/timeOffset
-          longName: "Observation Time Offset from Reference Time"
-          units: "Seconds"
+          longName: "Observation Time Minus Reference Time"
+          units: "s"
 
         - name: "MetaData/stationIdentification"
           coordinates: "longitude latitude"
@@ -181,21 +182,21 @@ observations:
           coordinates: "longitude latitude"
           source: variables/longitude
           longName: "Longitude"
-          units: "degrees_east"
+          units: "degree_east"
           range: [0, 360]
 
         - name: "MetaData/latitude"
           coordinates: "longitude latitude"
           source: variables/latitude
           longName: "Latitude"
-          units: "degrees_north"
+          units: "degree_north"
           range: [-90, 90]
 
         - name: "MetaData/stationElevation"
           coordinates: "longitude latitude"
           source: variables/stationElevation
-          longName: "Height of Station"
-          units: "Meter"
+          longName: "Elevation of Station"
+          units: "m"
 
         - name: "MetaData/prepbufrReportType"
           coordinates: "longitude latitude"
@@ -215,17 +216,18 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
-        - name: "MetaData/pressure"
-          coordinates: "longitude latitude"
-          source: variables/pressure
-          longName: "Pressure"
-          units: "Pa"
 
         - name: "MetaData/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservation
           longName: "Height"
-          units: "Meter"
+          units: "m"
+
+        - name: "MetaData/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
 
         # ObsType
         - name: "ObsType/specificHumidity"
@@ -263,98 +265,115 @@ observations:
           coordinates: "longitude latitude"
           source: variables/airTemperature
           longName: "Temperature"
-          units: "Kelvin"
-          
+          units: "K"
+
         - name: "ObsValue/dewpointTemperature"
           coordinates: "longitude latitude"
           source: variables/dewpointTemperature
           longName: "Dewpoint Temperature"
-          units: "Kelvin"
+          units: "K"
 
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
           longName: "Eastward Wind"
-          units: "Meter Second-1"
+          units: "m s-1"
 
         - name: "ObsValue/windNorthward"
           coordinates: "longitude latitude"
           source: variables/windNorthward
           longName: "Northward Wind"
-          units: "Meter Second-1"
-          
+          units: "m s-1"
+
         # Quality Marker
         - name: "QualityMarker/pressure"
           coordinates: "longitude latitude"
           source: variables/pressureQualityMarker
           longName: "Pressure Quality Marker"
-          
+
         - name: "QualityMarker/height"
           coordinates: "longitude latitude"
           source: variables/heightOfObservationQualityMark
           longName: "Height Quality Marker"
-          
+
         - name: "QualityMarker/specificHumidity"
           coordinates: "longitude latitude"
           source: variables/specificHumidityQualityMarker
           longName: "Specific Humidity Quality Marker"
-          
+
         - name: "QualityMarker/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureQualityMarker
           longName: "Temperature Quality Marker"
-          
-        - name: "QualityMarker/wind"
+
+        - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
-          longName: "U, V-Component of Wind Quality Marker"
-          
+          longName: "windEastward Quality Marker"
+
+        - name: "QualityMarker/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windQualityMarker
+          longName: "windNorthward Quality Marker"
+
         # ObsError
         - name: "ObsError/pressure"
           coordinates: "longitude latitude"
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
-          
+
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"
           source: variables/relativeHumidityError
           longName: "Relative Humidity Error"
           units: "1"
-          
+
         - name: "ObsError/airTemperature"
           coordinates: "longitude latitude"
           source: variables/airTemperatureError
           longName: "Temperature Error"
-          units: "Kelvin"
-          
-        - name: "ObsError/wind"
+          units: "K"
+
+        - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
           source: variables/windError
-          longName: "East and Northward wind error"
-          units: "Meter Second-1"        
-          
-        # Tuned ObsError
-        - name: "TunedObsError/pressure"
+          longName: "Eastward wind error"
+          units: "m s-1"
+
+        - name: "ObsError/windNorthward"
           coordinates: "longitude latitude"
-          source: variables/pressureTunedError
-          longName: "Analysis-Tuned Pressure Observation Error"
-          units: "Pa"
-          
-        - name: "TunedObsError/relativeHumidity"
-          coordinates: "longitude latitude"
-          source: variables/relativeHumidityTunedError
-          longName: "Analysis-Tuned Relative Humidity Error"
-          units: "1"
-          
-        - name: "TunedObsError/airTemperature"
-          coordinates: "longitude latitude"
-          source: variables/airTemperatureTunedError
-          longName: "Analysis-Tuned Temperature Error"
-          units: "Kelvin"
-          
-        - name: "TunedObsError/wind"
-          coordinates: "longitude latitude"
-          source: variables/windTunedError
-          longName: "Analysis-Tuned East and Northward wind error"
-          units: "Meter Second-1"
+          source: variables/windError
+          longName: "Northward wind error"
+          units: "m s-1"
+
+#        # Tuned ObsError
+#        - name: "TunedObsError/pressure"
+#          coordinates: "longitude latitude"
+#          source: variables/pressureTunedError
+#          longName: "Analysis-Tuned Pressure Observation Error"
+#          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
+#
+#        - name: "TunedObsError/windEastward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Eastward wind error"
+#          units: "m s-1"
+#
+#        - name: "TunedObsError/windNorthward"
+#          coordinates: "longitude latitude"
+#          source: variables/windTunedError
+#          longName: "Analysis-Tuned Northward wind error"
+#          units: "m s-1"

--- a/parm/prepbufr_rassda.yaml
+++ b/parm/prepbufr_rassda.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_satwnd.yaml
+++ b/parm/prepbufr_satwnd.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_sfcshp.yaml
+++ b/parm/prepbufr_sfcshp.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         #group_by_variable: prepbufrDataLvlCat
@@ -20,7 +20,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_sfcshp.yaml
+++ b/parm/prepbufr_sfcshp.yaml
@@ -11,7 +11,8 @@ observations:
       exports:
         #group_by_variable: prepbufrDataLvlCat
         subsets:
-          - SATWND    # SATELLITE-DERIVED WIND REPORTS (SAID)
+          #- ADPSFC    # SURFACE LAND (SYNOPTIC, METAR) REPORTS
+          - SFCSHP    # SURFACE MARINE (SHIP, BUOY, C-MAN/TIGE GAUGE PLATFORM) REPORTS
         variables:
           # MetaData
           timestamp:
@@ -39,20 +40,22 @@ observations:
             query: "*/T29"
           prepbufrDataLvlCat:
             query: "*/CAT"
-          satelliteID:
-            query: "*/SAID"
 
           pressure:
             query: "*/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
-          pressureQualityMarker:
+          stationPressure:
+            query: "*/P___INFO/P__EVENT{1}/POB"
+            transforms:
+              - scale: 100
+          stationPressureQualityMarker:
             query: "*/P___INFO/P__EVENT{1}/PQM"
-          pressureError:
+          stationPressureError:
             query: "*/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
-          pressureTunedError:
+          stationPressureTunedError:
             query: "*/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
@@ -108,12 +111,52 @@ observations:
             transform:
               - scale: 0.514444
 
-          percentConfidence:
-            query: "*/PCCF_SEQ/QIFN"
+          pressureReducedToMeanSeaLevel:
+            query: "*/PMSL_SEQ/PMO"
+            transforms:
+              - scale: 100
+          pressureReducedToMeanSeaLevelQualityMarker:
+            query: "*/PMSL_SEQ/PMQ"
+
+          seaTemperature:
+            query: "*/SST_INFO/SSTEVENT{1}/SST1"
+          seaTemperatureQualityMarker:
+            query: "*/SST_INFO/SSTEVENT{1}/SSTQM"
+          seaTemperatureError:
+            query: "*/SST_INFO/SSTBACKG/SSTOE"
+          seaTemperatureMethod:
+            query: "*/SST_INFO/MSST"
+          depthBelowSeaSurface:
+            query: "*/SST_INFO/DBSS_SEQ/DBSS"
+            type: float
+          heightOfWaves:
+            query: "*/WAVE_SEQ/HOWV"
+            type: float
+
+          presentWeather:
+            query: "*/PREWXSEQ{1}/PRWE"
+
+          maximumWindGustSpeed:
+            query: "*/GUST1SEQ/MXGS"
+
+          verticalSignificance:
+            query: "*/CLOUDSEQ{1}/VSSO"
+          cloudAmount:
+            query: "*/CLOUDSEQ{1}/CLAM"
+          heightOfBaseOfCloud:
+            query: "*/CLOUDSEQ{1}/HOCB"
+            type: float
+          cloudCoverTotal:
+            query: "*/CLOU2SEQ{1}/TOCC"
+            type: float
+            transforms:
+              - scale: 0.01
+          heightAboveSurfaceOfBaseOfLowestCloud:
+            query: "*/CLOU2SEQ/HBLCS"
 
     ioda:
       backend: netcdf
-      obsdataout: "./ioda_satwnd.nc"
+      obsdataout: "./ioda_sfcshp.nc"
 
       dimensions:
         - name: pevent_Dim
@@ -147,12 +190,6 @@ observations:
           coordinates: "longitude latitude"
           source: variables/stationIdentification
           longName: "Station ID"
-          units: ""
-
-        - name: "MetaData/satelliteIdentification"
-          coordinates: "longitude latitude"
-          source: variables/satelliteID
-          longName: "Satellite Identification"
           units: ""
 
         - name: "MetaData/longitude"
@@ -193,10 +230,10 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
-        - name: "MetaData/percentConfidence"
+        - name: "MetaData/seaTemperatureMethod"
           coordinates: "longitude latitude"
-          source: variables/percentConfidence
-          longName: "Percent Confidence Based on EUMETSAT Quality Index without Forecast"
+          source: variables/seaTemperatureMethod
+          longName: "Method of Sea Temperature Measurement"
           units: ""
 
         - name: "MetaData/height"
@@ -236,6 +273,12 @@ observations:
           longName: "windNorthward Report Type"
           units: ""
 
+        - name: "ObsType/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "Pressure"
+          units: ""
+
         # ObsValue
         - name: "ObsValue/specificHumidity"
           coordinates: "longitude latitude"
@@ -267,10 +310,78 @@ observations:
           longName: "Northward Wind"
           units: "m s-1"
 
-        # Quality Marker
-        - name: "QualityMarker/pressure"
+        - name: "ObsValue/stationPressure"
           coordinates: "longitude latitude"
-          source: variables/pressureQualityMarker
+          source: variables/stationPressure
+          longName: "Station Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/pressureReducedToMeanSeaLevel"
+          coordinates: "longitude latitude"
+          source: variables/pressureReducedToMeanSeaLevel
+          longName: "Mean Sea-Level Pressure"
+          units: "Pa"
+
+        - name: "ObsValue/seaTemperature"
+          coordinates: "longitude latitude"
+          source: variables/seaTemperature
+          longName: "Sea Temperature"
+          units: "K"
+
+        - name: "ObsValue/depthBelowSeaSurface"
+          coordinates: "longitude latitude"
+          source: variables/depthBelowSeaSurface
+          longName: "Depth Below Sea Surface"
+          units: "m"
+
+        - name: "ObsValue/heightOfWaves"
+          coordinates: "longitude latitude"
+          source: variables/heightOfWaves
+          longName: "Height of Waves"
+          units: "m"
+
+        - name: "ObsValue/presentWeather"
+          coordinates: "longitude latitude"
+          source: variables/presentWeather
+          longName: "Description of Present Weather"
+
+        - name: "ObsValue/maximumWindGustSpeed"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustSpeed
+          longName: "Maximum Wind Gust Speed"
+          units: "m s-1"
+
+        - name: "ObsValue/verticalSignificance"
+          coordinates: "longitude latitude"
+          source: variables/verticalSignificance
+          longName: "Description of Vertical Significance (Surface Observations)"
+
+        - name: "ObsValue/cloudAmount"
+          coordinates: "longitude latitude"
+          source: variables/cloudAmount
+          longName: "Description of Cloud Amount"
+
+        - name: "ObsValue/heightOfBaseOfCloud"
+          coordinates: "longitude latitude"
+          source: variables/heightOfBaseOfCloud
+          longName: "Height of Base of Cloud"
+          units: "m"
+
+        - name: "ObsValue/cloudCoverTotal"
+          coordinates: "longitude latitude"
+          source: variables/cloudCoverTotal
+          longName: "Total Cloud Coverage"
+          units: "1"
+
+        - name: "ObsValue/heightAboveSurfaceOfBaseOfLowestCloud"
+          coordinates: "longitude latitude"
+          source: variables/heightAboveSurfaceOfBaseOfLowestCloud
+          longName: "Height above Surface of Base of Lowest Cloud Seen"
+
+        # Quality Marker
+        - name: "QualityMarker/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/stationPressureQualityMarker
           longName: "Pressure Quality Marker"
 
         - name: "QualityMarker/height"
@@ -298,10 +409,20 @@ observations:
           source: variables/windQualityMarker
           longName: "windNorthward Quality Marker"
 
-        # ObsError
-        - name: "ObsError/pressure"
+        - name: "QualityMarker/pressureReducedToMeanSeaLevel"
           coordinates: "longitude latitude"
-          source: variables/pressureError
+          source: variables/pressureReducedToMeanSeaLevelQualityMarker
+          longName: "Mean Sea Level Pressure Quality Marker"
+
+        - name: "QualityMarker/seaTemperature"
+          coordinates: "longitude latitude"
+          source: variables/seaTemperatureQualityMarker
+          longName: "Sea Temperature Quality Marker"
+
+        # ObsError
+        - name: "ObsError/stationPressure"
+          coordinates: "longitude latitude"
+          source: variables/stationPressureError
           longName: "Pressure Observation Error"
           units: "Pa"
 
@@ -329,10 +450,16 @@ observations:
           longName: "Northward wind error"
           units: "m s-1"
 
+        - name: "ObsError/seaTemperature"
+          coordinates: "longitude latitude"
+          source: variables/seaTemperatureError
+          longName: "Sea Temperature Observation Error"
+          units: "K"
+
 #        # Tuned ObsError
-#        - name: "TunedObsError/pressure"
+#        - name: "TunedObsError/stationPressure"
 #          coordinates: "longitude latitude"
-#          source: variables/pressureTunedError
+#          source: variables/stationPressureTunedError
 #          longName: "Analysis-Tuned Pressure Observation Error"
 #          units: "Pa"
 #

--- a/parm/prepbufr_vadwnd.yaml
+++ b/parm/prepbufr_vadwnd.yaml
@@ -6,7 +6,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./bufr/prepbufr"
+      obsdatain: "./prepbufr"
 
       exports:
         group_by_variable: prepbufrDataLvlCat
@@ -19,7 +19,7 @@ observations:
               timeOffset: "*/DHR"
               transforms:
                 - scale: 3600
-              referenceTime: "@REFERENCETIME@"
+              referenceTime: "@referenceTime@"
           timeOffset:
             query: "*/DHR"
             transforms:

--- a/parm/prepbufr_vadwnd.yaml
+++ b/parm/prepbufr_vadwnd.yaml
@@ -9,9 +9,9 @@ observations:
       obsdatain: "./bufr/prepbufr"
 
       exports:
-        #group_by_variable: prepbufrDataLvlCat
+        group_by_variable: prepbufrDataLvlCat
         subsets:
-          - ASCATW    # ASCAT SCATTEROMETER DATA (REPROCESSED, SAID)
+          - VADWND    # VAD (NEXRAD) WIND REPORTS
         variables:
           # MetaData
           timestamp:
@@ -38,47 +38,94 @@ observations:
           dumpReportType:
             query: "*/T29"
           prepbufrDataLvlCat:
-            query: "*/CAT"
-          satelliteID:
-            query: "*/SAID"
+            query: "*/PRSLEVEL/CAT"
 
           pressure:
-            query: "*/P___INFO/P__EVENT{1}/POB"
+            query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/POB"
             transforms:
               - scale: 100
           pressureQualityMarker:
-            query: "*/P___INFO/P__EVENT{1}/PQM"
+            query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/PQM"
           pressureError:
-            query: "*/P___INFO/P__BACKG/POE"
+            query: "*/PRSLEVEL/P___INFO/P__BACKG/POE"
             transforms:
               - scale: 100
           pressureTunedError:
-            query: "*/P___INFO/P__POSTP/POETU"
+            query: "*/PRSLEVEL/P___INFO/P__POSTP/POETU"
             transforms:
               - scale: 100
 
+          heightOfObservation:
+            query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZOB"
+            #type: float
+          heightOfObservationQualityMark:
+            query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZQM"
+
+          specificHumidity:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.000001
+          specificHumidityQualityMarker:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
+          relativeHumidityError:
+            query: "*/PRSLEVEL/Q___INFO/Q__BACKG/QOE"
+            transforms:
+              - scale: 0.1
+          relativeHumidityTunedError:
+            query: "*/PRSLEVEL/Q___INFO/Q__POSTP/QOETU"
+            transforms:
+              - scale: 0.1
+
+          dewpointTemperature:
+            query: "*/PRSLEVEL/Q___INFO/TDO"
+            transforms:
+              - offset: 273.15
+
+          airTemperature:
+            query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TOB"
+            transforms:
+              - offset: 273.15
+          airTemperatureQualityMarker:
+            query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TQM"
+          airTemperatureError:
+            query: "*/PRSLEVEL/T___INFO/T__BACKG/TOE"
+          airTemperatureTunedError:
+            query: "*/PRSLEVEL/T___INFO/T__POSTP/TOETU"
+
           windEastward:
-            query: "*/W___INFO/W__EVENT{1}/UOB"
+            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/UOB"
           windNorthward:
-            query: "*/W___INFO/W__EVENT{1}/VOB"
+            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/VOB"
           windQualityMarker:
-            query: "*/W___INFO/W__EVENT{1}/WQM"
+            query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/WQM"
           windError:
-            query: "*/W___INFO/W__BACKG/WOE"
+            query: "*/PRSLEVEL/W___INFO/W__BACKG/WOE"
           windTunedError:
-            query: "*/W___INFO/W__POSTP/WOETU"
+            query: "*/PRSLEVEL/W___INFO/W__POSTP/WOETU"
             transform:
               - scale: 0.514444
 
+
     ioda:
       backend: netcdf
-      obsdataout: "./ioda_ascatw.nc"
+      obsdataout: "./ioda_vadwnd.nc"
 
       dimensions:
+        - name: Level
+          path: "*/PRSLEVEL"
         - name: pevent_Dim
-          path: "*/P___INFO/P__EVENT"
+          path: "*/PRSLEVEL/P___INFO/P__EVENT"
+        - name: qevent_Dim
+          path: "*/PRSLEVEL/Q___INFO/Q__EVENT"
+        - name: tevent_Dim
+          path: "*/PRSLEVEL/T___INFO/T__EVENT"
         - name: wevent_Dim
-          path: "*/W___INFO/W__EVENT"
+          path: "*/PRSLEVEL/W___INFO/W__EVENT"
+        - name: zevent_Dim
+          path: "*/PRSLEVEL/Z___INFO/Z__EVENT"
+        - name: drft_Dim
+          path: "*/PRSLEVEL/DRFTINFO"
 
 
       variables:
@@ -100,12 +147,6 @@ observations:
           coordinates: "longitude latitude"
           source: variables/stationIdentification
           longName: "Station ID"
-          units: ""
-
-        - name: "MetaData/satelliteIdentification"
-          coordinates: "longitude latitude"
-          source: variables/satelliteID
-          longName: "Satellite Identification"
           units: ""
 
         - name: "MetaData/longitude"
@@ -146,6 +187,13 @@ observations:
           longName: "Prepbufr Data Level Category"
           units: ""
 
+
+        - name: "MetaData/height"
+          coordinates: "longitude latitude"
+          source: variables/heightOfObservation
+          longName: "Height"
+          units: "m"
+
         - name: "MetaData/pressure"
           coordinates: "longitude latitude"
           source: variables/pressure
@@ -153,6 +201,18 @@ observations:
           units: "Pa"
 
         # ObsType
+        - name: "ObsType/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "specificHumidity Report Type"
+          units: ""
+
+        - name: "ObsType/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/prepbufrReportType
+          longName: "airTemperature report Type"
+          units: ""
+
         - name: "ObsType/windEastward"
           coordinates: "longitude latitude"
           source: variables/prepbufrReportType
@@ -166,6 +226,24 @@ observations:
           units: ""
 
         # ObsValue
+        - name: "ObsValue/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidity
+          longName: "Specific Humidity"
+          units: "Kilogram Kilogram-1"
+
+        - name: "ObsValue/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperature
+          longName: "Temperature"
+          units: "K"
+
+        - name: "ObsValue/dewpointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewpointTemperature
+          longName: "Dewpoint Temperature"
+          units: "K"
+
         - name: "ObsValue/windEastward"
           coordinates: "longitude latitude"
           source: variables/windEastward
@@ -184,6 +262,21 @@ observations:
           source: variables/pressureQualityMarker
           longName: "Pressure Quality Marker"
 
+        - name: "QualityMarker/height"
+          coordinates: "longitude latitude"
+          source: variables/heightOfObservationQualityMark
+          longName: "Height Quality Marker"
+
+        - name: "QualityMarker/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityQualityMarker
+          longName: "Specific Humidity Quality Marker"
+
+        - name: "QualityMarker/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureQualityMarker
+          longName: "Temperature Quality Marker"
+
         - name: "QualityMarker/windEastward"
           coordinates: "longitude latitude"
           source: variables/windQualityMarker
@@ -200,6 +293,18 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/relativeHumidity"
+          coordinates: "longitude latitude"
+          source: variables/relativeHumidityError
+          longName: "Relative Humidity Error"
+          units: "1"
+
+        - name: "ObsError/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureError
+          longName: "Temperature Error"
+          units: "K"
 
         - name: "ObsError/windEastward"
           coordinates: "longitude latitude"
@@ -219,6 +324,18 @@ observations:
 #          source: variables/pressureTunedError
 #          longName: "Analysis-Tuned Pressure Observation Error"
 #          units: "Pa"
+#
+#        - name: "TunedObsError/relativeHumidity"
+#          coordinates: "longitude latitude"
+#          source: variables/relativeHumidityTunedError
+#          longName: "Analysis-Tuned Relative Humidity Error"
+#          units: "1"
+#
+#        - name: "TunedObsError/airTemperature"
+#          coordinates: "longitude latitude"
+#          source: variables/airTemperatureTunedError
+#          longName: "Analysis-Tuned Temperature Error"
+#          units: "K"
 #
 #        - name: "TunedObsError/windEastward"
 #          coordinates: "longitude latitude"

--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -13,15 +13,18 @@ execfile=${HOMErrfs}/sorc/RDASApp/build/bin/bufr2ioda.x
 # generate the namelist on the fly
 REFERENCE_TIME="${CDATE:0:4}-${CDATE:4:2}-${CDATE:6:2}T${CDATE:8:2}:00:00Z"
 yaml_list=(
-"prepbufr_aircraft.yaml" 
-#"prepbufr_ascatw.yaml" 
-#"prepbufr_gpsipw.yaml" 
-#"prepbufr_mesonet.yaml" 
-#"prepbufr_profiler.yaml" 
-#"prepbufr_rassda.yaml" 
-#"prepbufr_satwnd.yaml" 
-#"prepbufr_adpsfc.yaml" 
+#"prepbufr_adpsfc.yaml"
 "prepbufr_adpupa.yaml"
+"prepbufr_aircar.yaml"
+#"prepbufr_aircft.yaml"
+#"prepbufr_ascatw.yaml"
+#"prepbufr_gpsipw.yaml"
+#"prepbufr_msonet.yaml"
+#"prepbufr_proflr.yaml"
+#"prepbufr_rassda.yaml"
+#"prepbufr_satwnd.yaml"
+#"prepbufr_sfcshp.yaml"
+#"prepbufr_vadwnd.yaml"
 )
 
 # run bufr2ioda.x


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Update the prepbufr2ioda yamls to be consistent with what is used in RDASApp (with a few minor differences). The differences include only renaming placeholder(s) to what is expected in the workflow and the path to the prepbufr file as expected in the workflow.
- A few of the files were renamed to the 6 character string mnemonics (for example: `prepbufr_mesonet.yaml` --> `prepbufr_msonet.yaml`)
- A few files were separated out for clarity (for example: `prepbufr_aircraft.yaml` --> 1) `prepbufr_aircar.yaml`, 2) `prepbufr_aircft.yaml`. This will just make future debugging easier.

## TESTS CONDUCTED: 
Tested on Hera conus 12km retro runs.

## ISSUE: 
- Follows https://github.com/NOAA-EMC/RDASApp/pull/183

