### PR TITLE
allow jedivar to run on different MPI layouts

### DIFF
--- a/fix/bumploc/conus12km_L60_40_401km11levels
+++ b/fix/bumploc/conus12km_L60_40_401km11levels
@@ -1,0 +1,1 @@
+../.agent/bumploc/conus12km_L60_40_401km11levels

--- a/fix/bumploc/conus12km_L60_80_401km11levels
+++ b/fix/bumploc/conus12km_L60_80_401km11levels
@@ -1,0 +1,1 @@
+../.agent/bumploc/conus12km_L60_80_401km11levels

--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -82,20 +82,18 @@ ln -snf ${initial_file} mpasin.nc
 run_duration=1:00:00
 physics_suite=${PHYSICS_SUITE:-'mesoscale_reference'}
 jedi_da="true" #true
+pio_num_iotasks=${NODES}
+pio_stride=${PPN}
 if [[ "${MESH_NAME}" == "conus12km" ]]; then
   dt=60
   substeps=2
   disp=12000.0
   radt=30
-  pio_num_iotasks=1
-  pio_stride=40
 elif [[ "${MESH_NAME}" == "conus3km" ]]; then
   dt=20
   substeps=4
   disp=3000.0
   radt=15
-  pio_num_iotasks=40
-  pio_stride=20
 else
   echo "Unknown MESH_NAME, exit!"
   err_exit

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -52,7 +52,7 @@ export NODES_LBC="<nodes>1:ppn=40</nodes>"
 export NODES_FCST="<nodes>2:ppn=40</nodes>"
 export NODES_MPASSIT="<nodes>1:ppn=40</nodes>"
 export NODES_UPP="<nodes>1:ppn=40</nodes>"
-export NODES_JEDIVAR="<nodes>6:ppn=20</nodes>"
+export NODES_JEDIVAR="<nodes>4:ppn=20</nodes>"
 #
 export WALLTIME_FCST="1:30:00"
 export WALLTIME_SAVE_FCST="1:30:00"

--- a/workflow/exp/exp.rt_jet_conus12km
+++ b/workflow/exp/exp.rt_jet_conus12km
@@ -53,7 +53,7 @@ export NODES_LBC="<nodes>1:ppn=40</nodes>"
 export NODES_FCST="<nodes>2:ppn=40</nodes>"
 export NODES_MPASSIT="<nodes>1:ppn=40</nodes>"
 export NODES_UPP="<nodes>1:ppn=40</nodes>"
-export NODES_JEDIVAR="<nodes>6:ppn=20</nodes>"
+export NODES_JEDIVAR="<nodes>4:ppn=20</nodes>"
 #
 export WALLTIME_FCST="1:30:00"
 export WALLTIME_SAVE_FCST="1:30:00"

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -15,9 +15,11 @@ source ${HOMErrfs}/workflow/ush/detect_machine.sh
 echo "run on ${MACHINE}"
 #
 export NTASKS=${SLURM_NTASKS}
+export NODES=${SLURM_JOB_NUM_NODES}
+export PPN=${SLURM_TASKS_PER_NODE%%(*} # remove the (x6) part of 20(x6)
 #
 echo "load rrfs-workflow modules by default"
-set +x # supress messy output in the module load process
+set +x # suppress messy output in the module load process
 source /etc/profile
 module use ${HOMErrfs}/modulefiles
 # load corresponding modules for different tasks


### PR DESCRIPTION
allow jedivar to run on different MPI layouts
add new conus12k bumploc and static_bec files for 40 and 80 cores
Thank @Junjun-NOAA for generating new fix files and testing them by running jedivar experiments.
