### PR TITLE
Picks up latest UPP with an important fix for smoke and dust

### DIFF
--- a/fix/upp/postxconfig-NT-rrfs.txt
+++ b/fix/upp/postxconfig-NT-rrfs.txt
@@ -11377,7 +11377,7 @@ spec_hgt_lvl_above_grnd
 ?
 0
 ?
-?
+total_aerosol
 ?
 smaller_than_first_limit
 7

--- a/fix/upp/postxconfig-NT-rrfs_f01.txt
+++ b/fix/upp/postxconfig-NT-rrfs_f01.txt
@@ -11209,7 +11209,7 @@ spec_hgt_lvl_above_grnd
 ?
 0
 ?
-?
+total_aerosol
 ?
 smaller_than_first_limit
 7

--- a/fix/upp/rrfs_post_avblflds.xml
+++ b/fix/upp/rrfs_post_avblflds.xml
@@ -7001,6 +7001,7 @@
        <pname>MASSDEN</pname>
        <stats_proc>AVE</stats_proc>
        <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <aerosol_type>total_aerosol</aerosol_type>
        <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
        <scale_fact_1st_size>7</scale_fact_1st_size>
        <scale_val_1st_size>25</scale_val_1st_size>

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = 35296b9
+hash = b37e67e
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Simply updates the hash of UPP to the latest (12/2/2024) commit for the rrfsv1 release branch that fixed two issues with how smoke and dust output was labeled in GRIB output.
- Also updates needed UPP fix files to properly label total_aerosol for the time-averaged product.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others:  Just pulled and compiled the code, and confirmed that it had grabbed the required version of UPP.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@EricJames-NOAA made the UPP fix, and Partha let me know about it when I asked him about what I was seeing in S&D output.
