### PR TITLE
Enable surface temperature data assimilation using GSL's surface operator which makes adjustment based on local lapse rate

### DIFF
--- a/sorc/_workaround_/CMakeLists.txt
+++ b/sorc/_workaround_/CMakeLists.txt
@@ -1,0 +1,222 @@
+# (C) Copyright 2017-2022 UCAR.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+include(ufo_functions)
+
+add_subdirectory( basis )
+add_subdirectory( errors )
+add_subdirectory( filters )
+add_subdirectory( fov )
+add_subdirectory( obslocalization )
+add_subdirectory( predictors )
+add_subdirectory( profile )
+add_subdirectory( superob )
+add_subdirectory( utils )
+add_subdirectory( variabletransforms )
+
+# Operators
+add_subdirectory( operators/aerosols )
+add_subdirectory( operators/atmvertinterplay )
+add_subdirectory( operators/atmsfcinterp )
+add_subdirectory( operators/columnretrieval )
+add_subdirectory( operators/backgrounderroridentity )
+add_subdirectory( operators/backgrounderrorvertinterp )
+add_subdirectory( operators/categoricaloper )
+add_subdirectory( operators/compositeoper )
+if( crtm_FOUND )
+    add_subdirectory( operators/crtm )
+endif()
+add_subdirectory( operators/gnssro )
+add_subdirectory( operators/groundgnss )
+add_subdirectory( operators/identity )
+add_subdirectory( operators/insitupm )
+add_subdirectory( operators/logarithm )
+add_subdirectory( operators/marine )
+if(oasim_FOUND)
+    add_subdirectory( operators/oasim)
+endif()
+add_subdirectory( operators/product )
+add_subdirectory( operators/radardopplerwind )
+add_subdirectory( operators/radarradialvelocity )
+add_subdirectory( operators/radarreflectivity)
+if( rttov_FOUND )
+    add_subdirectory( operators/rttov )
+    add_subdirectory( operators/rttovcpp )
+endif()
+add_subdirectory( operators/sattcwv )
+add_subdirectory( operators/scatwind )
+add_subdirectory( operators/sfcpcorrected )
+add_subdirectory( operators/sfccorrected )
+add_subdirectory( operators/timeoper )
+add_subdirectory( operators/vertinterp )
+add_subdirectory( operators/lightning )
+add_subdirectory( operators/windspeed )
+
+
+# Base files
+
+list( APPEND ufo_src_files
+    Fortran.h
+    AnalyticInit.cc
+    AnalyticInit.h
+    GeoVaLs.cc
+    GeoVaLs.h
+    GeoVaLs.interface.F90
+    GeoVaLs.interface.h
+    instantiateObsErrorFactory.h
+    instantiateObsFilterFactory.h
+    instantiateObsLocFactory.h
+    LinearObsBiasOperator.cc
+    LinearObsBiasOperator.h
+    LinearObsOperator.cc
+    LinearObsOperator.h
+    LinearObsOperatorBase.cc
+    LinearObsOperatorBase.h
+    ObsBias.cc
+    ObsBias.h
+    ObsBiasCovariance.cc
+    ObsBiasCovariance.h
+    ObsBiasIncrement.cc
+    ObsBiasIncrement.h
+    ObsBiasOperator.cc
+    ObsBiasOperator.h
+    ObsBiasParameters.h
+    ObsBiasPreconditioner.cc
+    ObsBiasPreconditioner.h
+    ObsDiagnostics.cc
+    ObsDiagnostics.h
+    ObsFilter.cc
+    ObsFilter.h
+    ObsFilterBase.cc
+    ObsFilterBase.h
+    ObsFilterParametersBase.h
+    ObsFilters.cc
+    ObsFilters.h
+    ObsOperator.cc
+    ObsOperator.h
+    ObsOperatorBase.cc
+    ObsOperatorBase.h
+    ObsOperatorParametersBase.h
+    ObsTraits.h
+    SampledLocations.cc
+    SampledLocations.h
+    sampled_locations_f.cc
+    sampled_locations_f.h
+    ScopedDefaultGeoVaLFormatChange.h
+    ufo_geovals_mod.F90
+    ufo_sampled_locations_mod.F90
+    ufo_variables_mod.F90
+    ufo_constants_mod.F90
+)
+
+
+list( APPEND ufo_src_files
+    ${base_src_files}
+    ${basis_src_files}
+    ${errors_src_files}
+    ${filters_src_files}
+
+    ${utils_src_files}
+    ${predictor_src_files}
+    ${obslocalization_src_files}
+    ${identity_src_files}
+    ${logarithm_src_files}
+    ${product_src_files}
+    ${vertinterp_src_files}
+    ${atmvertinterplay_src_files}
+    ${atmsfcinterp_src_files}
+    ${columnretrieval_src_files}
+    ${crtm_src_files}
+    ${rttov_src_files}
+    ${rttovcpp_src_files}
+    ${gnssro_src_files}
+    ${insitupm_src_files}
+    ${aerosols_src_files}
+    ${sfcpcorrected_src_files}
+    ${sfccorrected_src_files}
+    ${radardopplerwind_src_files}
+    ${radarradialvelocity_src_files}
+    ${radarreflectivity_src_files}
+    ${profile_src_files}
+    ${groundgnss_src_files}
+    ${variabletransforms_src_files}
+    ${scatwind_src_files}
+    ${sattcwv_src_files}
+    ${compositeoper_src_files}
+    ${backgrounderrorvertinterp_src_files}
+    ${backgrounderroridentity_src_files}
+    ${categoricaloper_src_files}
+    ${fov_src_files}
+    ${marine_src_files}
+    ${oasim_src_files}
+    ${timeoper_src_files}
+    ${lightning_src_files}
+    ${superob_src_files}
+    ${windspeed_src_files}
+)
+
+## Create Library target
+ecbuild_add_library( TARGET   ufo
+                     SOURCES  ${ufo_src_files}
+                     INSTALL_HEADERS LISTED
+                     HEADER_DESTINATION ${INSTALL_INCLUDE_DIR}/${PROJECT_NAME}
+                    )
+
+# Mark Boost as a system library to silence compiler warnings from Boost headers
+target_include_directories( ${PROJECT_NAME} SYSTEM PUBLIC ${Boost_INCLUDE_DIRS} )
+
+## Link dependencies
+target_link_libraries(ufo PUBLIC MPI::MPI_C MPI::MPI_CXX MPI::MPI_Fortran)
+target_link_libraries(ufo PUBLIC Boost::boost)
+target_link_libraries(ufo PUBLIC NetCDF::NetCDF_C NetCDF::NetCDF_Fortran)
+target_link_libraries(ufo PUBLIC Eigen3::Eigen)
+target_link_libraries(ufo PUBLIC gsl::gsl-lite)
+target_link_libraries(ufo PUBLIC eckit)
+target_link_libraries(ufo PUBLIC fckit)
+target_link_libraries(ufo PUBLIC ioda)
+target_link_libraries(ufo PUBLIC oops)
+
+target_compile_options( ufo PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,PGI,NVHPC>:-Wc,--pending_instantiations=128> )
+
+# Optional dependencies
+if(crtm_FOUND)
+    target_link_libraries(ufo PUBLIC crtm)
+endif()
+
+if(geos-aero_FOUND)
+    target_link_libraries(ufo PUBLIC geos-aero)
+endif()
+
+if(gsw_FOUND)
+    target_link_libraries(ufo PUBLIC gsw)
+    target_compile_definitions(ufo PUBLIC GSW_FOUND)
+endif()
+
+if(ropp-ufo_FOUND)
+    target_link_libraries(ufo PUBLIC ropp-ufo)
+endif()
+
+if(rttov_FOUND)
+    target_link_libraries(ufo PUBLIC rttov)
+    target_compile_definitions(ufo PUBLIC RTTOV_FOUND)
+endif()
+
+if(oasim_FOUND)
+    target_link_libraries(ufo PUBLIC oasim)
+endif()
+
+
+## Include paths
+target_include_directories(ufo PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+                                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+
+## Fortran modules
+set(MODULE_DIR ${PROJECT_NAME}/module)
+set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
+target_include_directories(${PROJECT_NAME} INTERFACE
+                            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
+                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR}>)
+

--- a/sorc/_workaround_/sfccorrected/CMakeLists.txt
+++ b/sorc/_workaround_/sfccorrected/CMakeLists.txt
@@ -1,0 +1,21 @@
+# (C) Copyright 2017-2018 UCAR.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+set ( sfccorrected_files
+    ObsSfcCorrected.h
+    ObsSfcCorrected.cc
+    ObsSfcCorrectedParameters.cc
+    ObsSfcCorrectedParameters.h
+    ObsSfcCorrected.interface.F90
+    ObsSfcCorrected.interface.h
+    ufo_sfccorrected_mod.F90
+)
+
+PREPEND( _p_sfccorrected_files     "operators/sfccorrected"     ${sfccorrected_files} )
+
+set ( sfccorrected_src_files
+      ${_p_sfccorrected_files}
+      PARENT_SCOPE
+)

--- a/sorc/_workaround_/sfccorrected/ObsSfcCorrected.cc
+++ b/sorc/_workaround_/sfccorrected/ObsSfcCorrected.cc
@@ -1,0 +1,66 @@
+/*
+ * (C) Copyright 2024 UCAR
+ * 
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
+ */
+
+#include "ufo/operators/sfccorrected/ObsSfcCorrected.h"
+
+#include <ostream>
+#include <vector>
+
+#include "ioda/ObsVector.h"
+
+#include "oops/base/Variables.h"
+
+#include "ufo/filters/Variables.h"
+#include "ufo/GeoVaLs.h"
+#include "ufo/operators/sfccorrected/ObsSfcCorrected.interface.h"
+#include "ufo/utils/OperatorUtils.h"  // for getOperatorVariables
+
+namespace ufo {
+
+// -----------------------------------------------------------------------------
+static ObsOperatorMaker<ObsSfcCorrected> makerSfcCorrected_("SfcCorrected");
+// -----------------------------------------------------------------------------
+
+ObsSfcCorrected::ObsSfcCorrected(const ioda::ObsSpace & odb,
+                                   const Parameters_ & params)
+  : ObsOperatorBase(odb), keyOper_(0), odb_(odb), varin_()
+{
+  std::vector<int> operatorVarIndices;
+  getOperatorVariables(params.variables.value(), odb.assimvariables(),
+                       operatorVars_, operatorVarIndices);
+
+  ufo_sfccorrected_setup_f90(keyOper_, params.toConfiguration(),
+                              operatorVars_, operatorVarIndices.data(), operatorVarIndices.size(),
+                              varin_);
+  oops::Log::trace() << "ObsSfcCorrected created." << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+ObsSfcCorrected::~ObsSfcCorrected() {
+  ufo_sfccorrected_delete_f90(keyOper_);
+  oops::Log::trace() << "ObsSfcCorrected destructed" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+void ObsSfcCorrected::simulateObs(const GeoVaLs & gv, ioda::ObsVector & ovec,
+                             ObsDiagnostics & d, const QCFlags_t & qc_flags) const {
+  ufo_sfccorrected_simobs_f90(keyOper_, gv.toFortran(), odb_, ovec.nvars(), ovec.nlocs(),
+                         ovec.toFortran());
+  oops::Log::trace() << "ObsSfcCorrected: observation operator run" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+void ObsSfcCorrected::print(std::ostream & os) const {
+  os << "ObsSfcCorrected::print not implemented";
+}
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo

--- a/sorc/_workaround_/sfccorrected/ObsSfcCorrected.h
+++ b/sorc/_workaround_/sfccorrected/ObsSfcCorrected.h
@@ -1,0 +1,67 @@
+/*
+ * (C) Copyright 2024- UCAR
+ * 
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
+ */
+
+#ifndef UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTED_H_
+#define UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTED_H_
+
+#include <ostream>
+#include <string>
+
+#include "ioda/ObsDataVector.h"
+#include "oops/base/Variables.h"
+#include "oops/util/ObjectCounter.h"
+#include "ufo/Fortran.h"
+#include "ufo/ObsOperatorBase.h"
+#include "ufo/operators/sfccorrected/ObsSfcCorrectedParameters.h"
+
+/// Forward declarations
+namespace ioda {
+  class ObsSpace;
+  class ObsVector;
+}
+
+namespace ufo {
+  class GeoVaLs;
+  class ObsDiagnostics;
+
+// -----------------------------------------------------------------------------
+/// SfcCorrected observation operator class
+class ObsSfcCorrected : public ObsOperatorBase,
+                   private util::ObjectCounter<ObsSfcCorrected> {
+ public:
+  typedef ObsSfcCorrectedParameters Parameters_;
+  typedef ioda::ObsDataVector<int> QCFlags_t;
+
+  static const std::string classname() {return "ufo::ObsSfcCorrected";}
+
+  ObsSfcCorrected(const ioda::ObsSpace &, const Parameters_ &);
+  virtual ~ObsSfcCorrected();
+
+// Obs Operator
+  void simulateObs(const GeoVaLs &, ioda::ObsVector &, ObsDiagnostics &,
+                   const QCFlags_t &) const override;
+
+// Other
+  const oops::Variables & requiredVars() const override {return varin_;}
+
+  oops::ObsVariables simulatedVars() const override {return operatorVars_;}
+
+  int & toFortran() {return keyOper_;}
+  const int & toFortran() const {return keyOper_;}
+
+ private:
+  void print(std::ostream &) const override;
+  F90hop keyOper_;
+  const ioda::ObsSpace& odb_;
+  oops::Variables varin_;
+  oops::ObsVariables operatorVars_;
+};
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo
+#endif  // UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTED_H_

--- a/sorc/_workaround_/sfccorrected/ObsSfcCorrected.interface.F90
+++ b/sorc/_workaround_/sfccorrected/ObsSfcCorrected.interface.F90
@@ -1,0 +1,104 @@
+! (C) Copyright 2017-2019 UCAR
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+!> Fortran sfccorrected module for functions on the interface between C++ and Fortran
+!  to handle observation operators
+
+module ufo_sfccorrected_mod_c
+
+  use iso_c_binding
+  use ufo_sfccorrected_mod 
+  implicit none
+  private
+
+  ! ------------------------------------------------------------------------------
+#define LISTED_TYPE ufo_sfccorrected
+
+  !> Linked list interface - defines registry_t type
+#include "oops/util/linkedList_i.f"
+
+  !> Global registry
+  type(registry_t) :: ufo_sfccorrected_registry
+
+  ! ------------------------------------------------------------------------------
+
+contains
+
+  ! ------------------------------------------------------------------------------
+  !> Linked list implementation
+#include "oops/util/linkedList_c.f"
+
+! ------------------------------------------------------------------------------
+
+subroutine ufo_sfccorrected_setup_c(c_key_self, c_conf, c_obsvars, c_obsvarindices, c_nobsvars, &
+                                     c_geovars) bind(c,name='ufo_sfccorrected_setup_f90')
+use fckit_configuration_module, only: fckit_configuration
+use oops_variables_mod
+use obs_variables_mod
+implicit none
+integer(c_int), intent(inout)     :: c_key_self
+type(c_ptr), value, intent(in)    :: c_conf
+type(c_ptr), value, intent(in)    :: c_obsvars ! variables to be simulated
+integer(c_int), value, intent(in) :: c_nobsvars
+integer(c_int), intent(in)        :: c_obsvarindices(c_nobsvars)  ! ... and their global indices
+type(c_ptr), value, intent(in)    :: c_geovars ! variables requested from the model
+
+type(ufo_sfccorrected), pointer :: self
+type(fckit_configuration) :: f_conf
+
+call ufo_sfccorrected_registry%setup(c_key_self, self)
+f_conf = fckit_configuration(c_conf)
+
+self%obsvars = obs_variables(c_obsvars)
+allocate(self%obsvarindices(self%obsvars%nvars()))
+self%obsvarindices(:) = c_obsvarindices(:) + 1  ! Convert from C to Fortran indexing
+self%geovars = oops_variables(c_geovars)
+
+call self%setup(f_conf)
+
+end subroutine ufo_sfccorrected_setup_c
+
+! ------------------------------------------------------------------------------
+
+subroutine ufo_sfccorrected_delete_c(c_key_self) bind(c,name='ufo_sfccorrected_delete_f90')
+implicit none
+integer(c_int), intent(inout) :: c_key_self
+
+type(ufo_sfccorrected), pointer :: self
+
+call ufo_sfccorrected_registry%get(c_key_self, self)
+
+! the obsvarindices array is allocated in the interface layer, so we deallocate here as well
+if (allocated(self%obsvarindices)) deallocate(self%obsvarindices)
+
+call ufo_sfccorrected_registry%remove(c_key_self)
+
+end subroutine ufo_sfccorrected_delete_c
+
+! ------------------------------------------------------------------------------
+
+subroutine ufo_sfccorrected_simobs_c(c_key_self, c_key_geovals, c_obsspace, c_nvars, c_nlocs, &
+                                c_hofx) bind(c,name='ufo_sfccorrected_simobs_f90')
+use ufo_geovals_mod,   only: ufo_geovals
+use ufo_geovals_mod_c, only: ufo_geovals_registry
+implicit none
+integer(c_int), intent(in) :: c_key_self
+integer(c_int), intent(in) :: c_key_geovals
+type(c_ptr), value, intent(in) :: c_obsspace
+integer(c_int), intent(in)     :: c_nvars, c_nlocs
+real(c_double), intent(inout)  :: c_hofx(c_nvars, c_nlocs)
+
+type(ufo_sfccorrected), pointer :: self
+type(ufo_geovals), pointer :: geovals
+
+call ufo_sfccorrected_registry%get(c_key_self, self)
+call ufo_geovals_registry%get(c_key_geovals, geovals)
+call self%simobs(geovals, c_obsspace, c_nvars, c_nlocs, c_hofx)
+
+end subroutine ufo_sfccorrected_simobs_c
+
+! ------------------------------------------------------------------------------
+
+end module ufo_sfccorrected_mod_c

--- a/sorc/_workaround_/sfccorrected/ObsSfcCorrected.interface.h
+++ b/sorc/_workaround_/sfccorrected/ObsSfcCorrected.interface.h
@@ -1,0 +1,65 @@
+/*
+ * (C) Copyright 2024 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTED_INTERFACE_H_
+#define UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTED_INTERFACE_H_
+
+#include "ufo/Fortran.h"
+
+namespace eckit {
+  class Configuration;
+}
+
+namespace ioda {
+  class ObsSpace;
+}
+
+namespace oops {
+  class Variables;
+}
+
+namespace ufo {
+
+/// Interface to Fortran UFO sfccorrected routines
+
+extern "C" {
+
+// -----------------------------------------------------------------------------
+//  SfcCorrected observation operator
+// -----------------------------------------------------------------------------
+
+  /// \param operatorVars
+  ///   Variables to be simulated by this operator.
+  /// \param operatorVarIndices
+  ///   Indices of the variables from \p operatorVar in the list of all simulated
+  ///   variables in the ObsSpace.
+  /// \param numOperatorVarIndices
+  ///   Size of the \p operatorVarIndices array (must be the same as the number of variables in
+  ///   \p operatorVars).
+  /// \param[out] requiredVars
+  ///   GeoVaLs required for the simulation of the variables \p operatorVars.
+  ///
+  /// Example: if the list of simulated variables in the ObsSpace is
+  /// [airTemperature, windNorthward, windEastward] and \p operatorVars is
+  /// [windNorthward, windEastward], then \p operatorVarIndices should be set to [1, 2].
+
+// -----------------------------------------------------------------------------
+
+  void ufo_sfccorrected_setup_f90(F90hop &, const eckit::Configuration &,
+                                   const oops::ObsVariables&operatorVars,
+                                   const int *operatorVarIndices, const int numOperatorVarIndices,
+                                   oops::Variables &requiredVars);
+  void ufo_sfccorrected_delete_f90(F90hop &);
+  void ufo_sfccorrected_simobs_f90(const F90hop &, const F90goms &, const ioda::ObsSpace &,
+                               const int &, const int &, double &);
+
+// -----------------------------------------------------------------------------
+
+}  // extern C
+
+}  // namespace ufo
+#endif  // UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTED_INTERFACE_H_

--- a/sorc/_workaround_/sfccorrected/ObsSfcCorrectedParameters.cc
+++ b/sorc/_workaround_/sfccorrected/ObsSfcCorrectedParameters.cc
@@ -1,0 +1,18 @@
+/*
+ * (C) Copyright 2021- UCAR
+ * 
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
+ */
+
+#include "ufo/operators/sfccorrected/ObsSfcCorrectedParameters.h"
+
+namespace ufo {
+
+// -----------------------------------------------------------------------------
+// Required for enum Parameters
+constexpr char SfcCorrectionTypeParameterTraitsHelper::enumTypeName[];
+constexpr util::NamedEnumerator<SfcCorrectionType>
+          SfcCorrectionTypeParameterTraitsHelper::namedValues[];
+
+}  // namespace ufo

--- a/sorc/_workaround_/sfccorrected/ObsSfcCorrectedParameters.h
+++ b/sorc/_workaround_/sfccorrected/ObsSfcCorrectedParameters.h
@@ -1,0 +1,132 @@
+/*
+ * (C) Copyright 2021- UCAR
+ * 
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
+ */
+
+#ifndef UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTEDPARAMETERS_H_
+#define UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTEDPARAMETERS_H_
+
+#include <string>
+#include <vector>
+
+#include "oops/util/parameters/OptionalParameter.h"
+#include "oops/util/parameters/Parameter.h"
+#include "oops/util/parameters/Parameters.h"
+#include "ufo/filters/Variable.h"
+#include "ufo/ObsOperatorParametersBase.h"
+#include "ufo/utils/parameters/ParameterTraitsVariable.h"
+
+namespace ufo {
+
+/// enum type for surface correction type, and ParameterTraitsHelper for it
+enum class SfcCorrectionType {
+  UKMO, WRFDA, GSL
+};
+struct SfcCorrectionTypeParameterTraitsHelper {
+  typedef SfcCorrectionType EnumType;
+  static constexpr char enumTypeName[] = "SfcCorrectionType";
+  static constexpr util::NamedEnumerator<SfcCorrectionType> namedValues[] = {
+    { SfcCorrectionType::UKMO, "UKMO" },
+    { SfcCorrectionType::WRFDA, "WRFDA" },
+    { SfcCorrectionType::GSL, "GSL" }
+  };
+};
+
+}  // namespace ufo
+
+namespace oops {
+
+/// Extraction of SfcCorrectionType parameters from config
+template <>
+struct ParameterTraits<ufo::SfcCorrectionType> :
+    public EnumParameterTraits<ufo::SfcCorrectionTypeParameterTraitsHelper>
+{};
+
+}  // namespace oops
+
+namespace ufo {
+
+/// Configuration options recognized by the SfcCorrected operator.
+class ObsSfcCorrectedParameters : public ObsOperatorParametersBase {
+  OOPS_CONCRETE_PARAMETERS(ObsSfcCorrectedParameters, ObsOperatorParametersBase)
+
+ public:
+  /// An optional `variables` parameter, which controls which ObsSpace
+  /// variables will be simulated. This option should only be set if this operator is used as a
+  /// component of the Composite operator. If `variables` is not set, the operator will simulate
+  /// all ObsSpace variables. Please see the documentation of the Composite operator for further
+  /// details.
+  oops::OptionalParameter<std::vector<ufo::Variable>> variables{
+     "variables",
+     "List of variables to be simulated",
+     this};
+
+  oops::Parameter<SfcCorrectionType> correctionType{"da_sfc_scheme",
+     "Scheme used for surface temperature correction (UKMO, WRFDA or GSL)",
+     SfcCorrectionType::UKMO, this};
+
+  /// Note: "height" default value has to be consistent with var_geomz defined
+  /// in ufo_variables_mod.F90
+  oops::Parameter<std::string> geovarGeomZ{"geovar_geomz",
+     "Model variable for height of vertical levels",
+     "height_above_mean_sea_level", this};
+
+  /// Note: "surface_altitude" default value has to be consistent with var_sfc_geomz
+  /// in ufo_variables_mod.F90
+  oops::Parameter<std::string> geovarSfcGeomZ{"geovar_sfc_geomz",
+     "Model variable for surface height",
+     "height_above_mean_sea_level_at_surface", this};
+
+  /// Note: "station_altitude" default value is "stationElevation"
+  oops::Parameter<std::string> ObsHeightName{"station_altitude", "stationElevation", this};
+  
+  /// Note: Only relevant if \c SfcCorrectionType is set to GSL, "lapse_rate_option" default value is "Local"
+  oops::Parameter<std::string> LapseRateOption{"lapse_rate_option", "Lapse rate option for surface temperature correction (Constant, Local or NoAdjustment)", "Local", this};
+
+  /// Note: Only relevant if \c SfcCorrectionType is set to GSL and \c LapseRateOption is set to "Constant", "lapse_rate" default value is adiabatic lapse rate 9.8 K/km
+  oops::Parameter<float> LapseRateValue
+    {"lapse_rate", 
+     "The lapse rate (K/km) used to adjust the observed surface temperature to "
+     "the model's surface level. Used if lapse rate option is set to constant, "
+     "otherwise ignored.",
+     9.8, 
+     this};
+
+  /// Note: Only relevant if \c SfcCorrectionType is set to GSL and \c LapseRateOption is set to "Local"
+  oops::Parameter<int> LocalLapseRateLevel
+    {"local_lapse_rate_level",
+     "The highest model level used to calculate the local lapse rate, "
+     "which adjusts the observed surface temperature to the model's surface level. "
+     "Used if lapse rate option is set to local, otherwise ignored.",
+     5,
+     this};
+
+  /// Should the local lapse rate be restricted to a specific range
+  /// Note: Only relevant if \c SfcCorrectionType is set to GSL and \c LapseRateOption is set to "Local"
+  oops::Parameter<bool> Threshold{"threshold", true, this};
+
+  /// Note: Only relevant if \c SfcCorrectionType is set to GSL, \c LapseRateOption is set to "Local", and \c Threshold is set to true
+  oops::Parameter<float> MinThreshold
+    {"min_threshold",
+     "The minimum lapse rate (K/km) can be applied to adjust the "
+     "observed surface temperature to the model's surface level. "
+     "Used if lapse rate option is set to local, otherwise ignored.",
+     0.5,
+     this};
+
+  /// Note: Only relevant if \c SfcCorrectionType is set to GSL, \c LapseRateOption is set to "Local", and \c Threshold is set to true
+  oops::Parameter<float> MaxThreshold
+    {"max_threshold",
+     "The maximum lapse rate (K/km) can be applied to adjust the "
+     "observed surface temperature to the model's surface level. "
+     "Used if lapse rate option is set to local, otherwise ignored.",
+     10.0,
+     this};
+};
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo
+#endif  // UFO_OPERATORS_SFCCORRECTED_OBSSFCCORRECTEDPARAMETERS_H_

--- a/sorc/_workaround_/sfccorrected/ufo_sfccorrected_mod.F90
+++ b/sorc/_workaround_/sfccorrected/ufo_sfccorrected_mod.F90
@@ -1,0 +1,614 @@
+! (C) Copyright 2017-2022 UCAR
+! (C) Copyright 2024 NOAA NCEP EMC
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+!> Fortran module for sfccorrected observation operator
+
+module ufo_sfccorrected_mod
+
+ use oops_variables_mod
+ use obs_variables_mod
+ use ufo_vars_mod
+ use missing_values_mod
+ use iso_c_binding
+ use kinds
+ use ufo_constants_mod, only : grav, rd, Lclr, t2tv
+ use gnssro_mod_transform, only : geop2geometric, geometric2geop
+ use mpi
+
+ implicit none
+ private
+ integer, parameter :: max_string = 800
+
+! Fortran derived type for observation type
+ type, public :: ufo_sfccorrected
+ private
+   type(obs_variables), public :: obsvars ! Variables to be simulated
+   integer, allocatable, public :: obsvarindices(:) ! Indices of obsvars in the list of all
+                                                    ! simulated variables in the ObsSpace.
+                                                    ! allocated/deallocated at interface layer
+   type(oops_variables), public :: geovars
+   character(len=MAXVARLEN)     :: da_sfc_scheme
+   character(len=MAXVARLEN)     :: station_altitude
+   character(len=MAXVARLEN)     :: lapse_rate_option
+   real(kind_real)              :: lapse_rate
+   integer                      :: local_lapse_rate_level
+   logical                      :: threshold
+   real(kind_real)              :: min_threshold, max_threshold
+ contains
+   procedure :: setup  => ufo_sfccorrected_setup
+   procedure :: simobs => ufo_sfccorrected_simobs
+ end type ufo_sfccorrected
+
+ character(len=MAXVARLEN), dimension(6) :: geovars_list = (/ var_ps, var_geomz, var_sfc_geomz, var_ts, var_prs, var_sfc_t2m /)
+
+contains
+
+! ------------------------------------------------------------------------------
+subroutine ufo_sfccorrected_setup(self, f_conf)
+use fckit_configuration_module, only: fckit_configuration
+use fckit_log_module,  only : fckit_log
+implicit none
+class(ufo_sfccorrected), intent(inout)     :: self
+type(fckit_configuration), intent(in) :: f_conf
+character(len=:), allocatable         :: str_sfc_scheme, str_var_sfc_geomz, str_var_geomz, str_lapse_rate_option
+character(len=:), allocatable         :: str_obs_height
+real(kind_real)                       :: constant_lapse_rate
+integer                               :: local_lapse_rate_level
+logical                               :: threshold
+real(kind_real)                       :: min_threshold, max_threshold
+
+character(max_string)                 :: debug_msg
+
+!> In case where a user wants to specify geoVaLs variable name of model
+!> height of vertical levels and/or sfc height.  Example: MPAS is height
+!> but FV-3 uses geopotential_height.
+
+call f_conf%get_or_die("geovar_geomz", str_var_geomz)
+write(debug_msg,*) "ufo_sfccorrected_mod.F90: var_geomz is", trim(str_var_geomz)
+call fckit_log%debug(debug_msg)
+geovars_list(2) = trim(str_var_geomz)
+
+call f_conf%get_or_die("geovar_sfc_geomz", str_var_sfc_geomz)
+write(debug_msg,*) "ufo_sfccorrected_mod.F90: var_sfc_geomz is ", trim(str_var_sfc_geomz)
+call fckit_log%debug(debug_msg)
+geovars_list(3) = trim(str_var_sfc_geomz)
+
+call self%geovars%push_back(geovars_list)
+
+call f_conf%get_or_die("da_sfc_scheme",str_sfc_scheme)
+self%da_sfc_scheme = str_sfc_scheme
+
+call f_conf%get_or_die("station_altitude", str_obs_height)
+self%station_altitude = str_obs_height
+
+if (self%da_sfc_scheme.eq."GSL") then
+   call f_conf%get_or_die("lapse_rate_option", str_lapse_rate_option)
+   self%lapse_rate_option = str_lapse_rate_option
+   select case (trim(self%lapse_rate_option))
+   case ("Constant")
+      call f_conf%get_or_die("lapse_rate", constant_lapse_rate)
+      self%lapse_rate = constant_lapse_rate * 0.001
+   case ("Local")
+      call f_conf%get_or_die("local_lapse_rate_level", local_lapse_rate_level)
+      self%local_lapse_rate_level = local_lapse_rate_level
+      call f_conf%get_or_die("threshold", threshold)
+      self%threshold = threshold
+      if (self%threshold) then
+         call f_conf%get_or_die("min_threshold", min_threshold)
+         self%min_threshold = min_threshold * 0.001
+         call f_conf%get_or_die("max_threshold", max_threshold)
+         self%max_threshold = max_threshold * 0.001
+      end if
+   case ("NoAdjustment")
+      ! Do nothing in this case
+   case default
+      write(debug_msg,*) "ufo_sfccorrected: lapse_rate_option not recognized"
+      call fckit_log%debug(debug_msg)
+      call abor1_ftn(debug_msg)
+   end select
+endif
+
+end subroutine ufo_sfccorrected_setup
+
+! ------------------------------------------------------------------------------
+subroutine ufo_sfccorrected_simobs(self, geovals, obss, nvars, nlocs, hofx)
+use ufo_geovals_mod, only: ufo_geovals, ufo_geoval, ufo_geovals_get_var
+use obsspace_mod
+use vert_interp_mod
+use fckit_log_module,  only : fckit_log
+implicit none
+class(ufo_sfccorrected), intent(in) :: self
+integer, intent(in)               :: nvars, nlocs
+type(ufo_geovals),  intent(in)    :: geovals
+real(c_double),     intent(inout) :: hofx(nvars, nlocs)
+type(c_ptr), value, intent(in)    :: obss
+
+! Local variables
+real(c_double)                    :: missing
+real(kind_real)                   :: H2000 = 2000.0
+integer                           :: nobs, iobs, ivar, iobsvar, k, kbot, ktop_lr, idx_geop
+real(kind_real),    allocatable   :: cor_tsfc(:)
+type(ufo_geoval),   pointer       :: model_ps, model_p, model_sfc_geomz, model_t, model_geomz, model_t2m
+character(len=*), parameter       :: myname_="ufo_sfccorrected_simobs"
+character(max_string)             :: err_msg
+real(kind_real)                   :: wf
+integer                           :: wi
+logical                           :: variable_present, variable_present_t, variable_present_q
+real(kind_real), dimension(:), allocatable :: obs_height, obs_t, obs_q, obs_psfc, obs_lat, obs_lon, obs_tv
+real(kind_real), dimension(:), allocatable :: model_ts, model_zs, model_level1, model_p_2000, model_t_2000, model_psfc, lr
+real(kind_real), dimension(:), allocatable :: H2000_geop
+real(kind_real), dimension(:), allocatable :: avg_tv
+real(kind_real)                            :: model_znew
+
+integer :: rank, ierr, unit_lr
+character(len=30) :: filename
+
+missing = missing_value(missing)
+nobs    = obsspace_get_nlocs(obss)
+
+! check if nobs is consistent in geovals & nlocs
+if (geovals%nlocs /= nobs) then
+   write(err_msg,*) myname_, 'error: nlocs of model and obs is inconsistent!'
+   call abor1_ftn(err_msg)
+endif
+
+! cor_tsfc: model sfc temp at obs height or observed temp at model sfc height
+allocate(cor_tsfc(nobs))
+cor_tsfc = missing
+
+! get obs variables
+allocate(obs_height(nobs))
+allocate(obs_psfc(nobs))
+call obsspace_get_db(obss, "MetaData", trim(self%station_altitude),obs_height)
+call obsspace_get_db(obss, "ObsValue", "stationPressure", obs_psfc)
+
+! get model variables; geovars_list = (/ var_ps, var_geomz, var_sfc_geomz, var_ts, var_prs /)
+! MPAS-JEDI: var_sfc_geomz = lowest zgrid interface (surface), geom%zgrid(1,:)
+!            var_geomz     = midpoint model layer, geom%height
+
+write(err_msg,'(a)') 'ufo_sfccorrected:'//new_line('a')// &
+             'retrieving GeoVaLs with names: '//trim(geovars_list(1))// &
+             ', '//trim(geovars_list(2))//', '//trim(geovars_list(3))// &
+             ', '//trim(geovars_list(4))//', '//trim(geovars_list(5))// &
+             ', '//trim(geovars_list(6))
+call fckit_log%debug(err_msg)
+call ufo_geovals_get_var(geovals, trim(geovars_list(1)), model_ps)
+call ufo_geovals_get_var(geovals, trim(geovars_list(2)), model_geomz)
+call ufo_geovals_get_var(geovals, trim(geovars_list(3)), model_sfc_geomz)
+call ufo_geovals_get_var(geovals, trim(geovars_list(4)), model_t)
+call ufo_geovals_get_var(geovals, trim(geovars_list(5)), model_p)
+call ufo_geovals_get_var(geovals, trim(geovars_list(6)), model_t2m)
+
+! discover if the model vertical profiles are ordered top-bottom or not
+kbot = 1
+do iobs = 1, nlocs
+  if (model_geomz%vals(1,iobs) .ne. missing) then
+    if (model_geomz%vals(1,iobs) .gt. model_geomz%vals(model_geomz%nval,iobs)) then
+      write(err_msg,'(a)') '  ufo_sfccorrected:'//new_line('a')//                   &
+                          '  Model vertical height profile is from top to bottom'
+      call fckit_log%debug(err_msg)
+      kbot = model_geomz%nval
+    endif
+    exit
+  endif
+enddo
+
+allocate(model_zs(nobs))
+allocate(model_level1(nobs))
+allocate(model_psfc(nobs))
+
+! Sijie Pan, read lat and lon
+if (.not. allocated(obs_lat)) then
+   variable_present = obsspace_has(obss, "MetaData", "latitude")
+   if (variable_present) then
+      call fckit_log%debug(' allocating obs_lat array')
+      allocate(obs_lat(nobs))
+      call obsspace_get_db(obss, "MetaData", "latitude", obs_lat)
+   else
+      call abor1_ftn('Variable latitude@MetaData does not exist, aborting')
+   endif
+endif
+if (.not. allocated(obs_lon)) then
+   variable_present = obsspace_has(obss, "MetaData", "longitude")
+   if (variable_present) then
+      call fckit_log%debug(' allocating obs_lon array')
+      allocate(obs_lon(nobs))
+      call obsspace_get_db(obss, "MetaData", "longitude", obs_lon)
+   else
+      call abor1_ftn('Variable longitude@MetaData does not exist, aborting')
+   endif
+endif
+
+! If needed, we can convert geopotential heights to geometric altitude
+! for full model vertical column using gnssro_mod_transform. We need
+! to get the latitude of observation to do this.
+
+idx_geop = -1
+idx_geop = index(trim(geovars_list(2)),'geopotential')
+model_level1 = model_geomz%vals(kbot,:)
+
+if (idx_geop.gt.0) then
+   write(err_msg,'(a)') 'ufo_sfccorrected:'//new_line('a')// &
+                        ' converting '//trim(geovars_list(2))// &
+                        ' variable to z-geometric'
+   call fckit_log%debug(err_msg)
+   if (.not. allocated(obs_lat)) then
+      variable_present = obsspace_has(obss, "MetaData", "latitude")
+      if (variable_present) then
+         call fckit_log%debug(' allocating obs_lat array')
+         allocate(obs_lat(nobs))
+         call obsspace_get_db(obss, "MetaData", "latitude", obs_lat)
+      else
+         call abor1_ftn('Variable latitude@MetaData does not exist, aborting')
+      endif
+   endif
+
+   if (trim(self%da_sfc_scheme) == "UKMO") allocate(H2000_geop(nobs))
+
+!---------------------------------------------------------------------
+   do iobs = 1, nlocs
+      if (obs_psfc(iobs).ne.missing) then
+         call geop2geometric(latitude=obs_lat(iobs),              &
+                        geopotentialH=model_geomz%vals(kbot,iobs),   &
+                        geometricZ=model_znew)
+         model_level1(iobs) = model_znew
+         if (trim(self%da_sfc_scheme) == "UKMO") then
+            call geometric2geop(latitude=obs_lat(iobs), &
+                           geometricZ=H2000, &
+                           geopotentialH=H2000_geop(iobs))
+         endif
+      else
+        if (trim(self%da_sfc_scheme) == "UKMO") H2000_geop(iobs) = missing
+      endif
+   enddo
+endif
+
+! Now do the same if needed for sfc geopotential height.
+idx_geop = -1
+idx_geop = index(trim(geovars_list(3)),'geopotential')
+model_zs = model_sfc_geomz%vals(1,:)
+if (idx_geop.gt.0) then
+   write(err_msg,'(a)') 'ufo_sfccorrected:'//new_line('a')//      &
+                        ' converting '//trim(geovars_list(3))//     &
+                        ' variable to z-sfc-geometric'
+   call fckit_log%debug(err_msg)
+   if (.not. allocated(obs_lat)) then
+      variable_present = obsspace_has(obss, "MetaData", "latitude")
+      if (variable_present) then
+         call fckit_log%debug(' allocating obs_lat array')
+         allocate(obs_lat(nobs))
+         call obsspace_get_db(obss, "MetaData", "latitude", obs_lat)
+      else
+         call abor1_ftn('Variable latitude@MetaData does not exist, aborting')
+      endif
+   endif
+   do iobs = 1, nlocs
+      if (obs_psfc(iobs).ne.missing) then
+         call geop2geometric(latitude=obs_lat(iobs),            &
+                   geopotentialH=model_sfc_geomz%vals(1,iobs),  &
+                   geometricZ=model_znew)
+         model_zs(iobs) = model_znew
+      endif
+   enddo
+endif
+
+!if (allocated(obs_lat)) deallocate(obs_lat)
+
+model_psfc = model_ps%vals(1,:)
+
+   ! get extra obs values
+   variable_present_t = .false.
+   variable_present_q = .false.
+
+   if (obsspace_has(obss, "ObsValue", "airTemperature")) then
+      variable_present_t = .true.
+      allocate(obs_t(nobs))
+      call obsspace_get_db(obss, "ObsValue", "airTemperature", obs_t)
+
+      variable_present_q = obsspace_has(obss, "ObsValue", "specificHumidity")
+      if (variable_present_q) then
+         allocate(obs_q(nobs))
+         call obsspace_get_db(obss, "ObsValue", "specificHumidity", obs_q)
+      end if
+   end if
+
+   allocate(model_ts(nobs))
+
+!--------------------------------------------
+! do terrain height correction, three options
+!--------------------------------------------
+
+select case (trim(self%da_sfc_scheme))
+!-------------
+case ("WRFDA")
+!-------------
+! Extrapolate from model lowest level (mid-layer) to model surface w constant lapse
+
+   model_ts = model_t%vals(kbot,:) + Lclr * ( model_level1 - model_zs )  !Lclr = 0.0065 K/m
+
+! get simulation at model surface or obs height
+   if (variable_present_t) then
+    call da_int(nobs, missing, cor_tsfc, obs_height, obs_t, model_zs, model_ts)
+   end if
+
+!------------
+case ("UKMO")
+!------------
+   allocate(model_p_2000(nobs))
+   allocate(model_t_2000(nobs))
+
+   do iobs = 1, nobs
+      ! vertical interpolation for getting model P and temp at 2000 m
+      if (allocated(H2000_geop)) then
+         call vert_interp_weights(model_geomz%nval, H2000_geop(iobs), &
+              model_geomz%vals(:,iobs), wi, wf)
+      else
+         call vert_interp_weights(model_geomz%nval, H2000, &
+              model_geomz%vals(:,iobs), wi, wf)
+      end if
+
+      call vert_interp_apply(model_p%nval, model_p%vals(:,iobs), model_p_2000(iobs), wi, wf)
+      call vert_interp_apply(model_t%nval, model_t%vals(:,iobs), model_t_2000(iobs), wi, wf)
+   end do
+   if (allocated(H2000_geop)) deallocate(H2000_geop)
+
+! get simulation at obs height or bring OBS to model surface height
+   call da_int_ukmo(nobs, missing, cor_tsfc, obs_height, obs_t, model_zs, model_psfc, model_t_2000, model_p_2000, model_ts)
+
+   deallocate(model_p_2000)
+   deallocate(model_t_2000)
+
+!----------------
+case ("GSL")
+!----------------
+
+   model_ts = model_t2m%vals(1,:)
+
+   allocate(lr(nobs))
+
+   if (self%lapse_rate_option.eq."Local") then
+
+      if (kbot == 1) then
+         ktop_lr = self%local_lapse_rate_level
+      else
+         ktop_lr = kbot - self%local_lapse_rate_level + 1
+      end if
+
+      ! Local lapse rate in K/m
+      lr = -1. * (model_t%vals(ktop_lr,:) - model_t%vals(kbot,:)) / &
+           (model_geomz%vals(ktop_lr,:) - model_geomz%vals(kbot,:))
+
+      call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+      write(filename, '(a, i4.4, a)') "local_lapse_rate_", rank, ".txt"
+      unit_lr = 100+rank
+      open(unit=unit_lr, file=filename, status='unknown')
+      do iobs = 1, nobs
+        if (model_p%vals(kbot,iobs) > 0 .and. model_p%vals(ktop_lr,iobs) > 0) then
+          write(unit_lr, '(i5, 9(f10.3))') &
+                iobs, obs_lat(iobs), obs_lon(iobs), model_p%vals(kbot,iobs)/100.0, &
+                model_p%vals(ktop_lr,iobs)/100.0, model_geomz%vals(ktop_lr,iobs), &
+                model_geomz%vals(kbot,iobs), &
+                (model_p%vals(kbot,iobs) - model_p%vals(ktop_lr,iobs)) / 100.0, &
+                model_geomz%vals(ktop_lr,iobs) - model_geomz%vals(kbot,iobs), &
+                lr(iobs) * 1000.0
+        end if
+      end do
+
+      if (self%threshold) then
+         lr = min(self%max_threshold, max(self%min_threshold, lr))
+      end if
+
+   else if (self%lapse_rate_option.eq."Constant") then
+
+      ! Local lapse rate in K/m
+      lr = self%lapse_rate
+
+   else
+
+      write(err_msg, '(a)') &
+           "No terrain adjustment applied to temperature observations."
+      call fckit_log%debug(err_msg)
+
+   endif
+
+   if (self%lapse_rate_option.eq."NoAdjustment") then
+      cor_tsfc = obs_t
+   else
+      call da_int_lr(nobs, missing, cor_tsfc, obs_height, obs_t, model_zs, lr)
+   end if
+
+!-----------
+case default
+!-----------
+   write(err_msg,*) "ufo_sfccorrected: da_sfc_scheme not recognized"
+   call fckit_log%debug(err_msg)
+   call abor1_ftn(err_msg)
+end select
+
+!----------------
+! update sfc temp
+!----------------
+do iobsvar = 1, size(self%obsvarindices)
+! Get index of row of hofx
+   ivar = self%obsvarindices(iobsvar)
+
+! cor_tsfc is corrected obs temp at model sfc
+!
+   do iobs = 1, nlocs
+     if (cor_tsfc(iobs) /= missing) then
+! for T_o2m, adjusted hofx - O = model_ts - T_o2m, OBS not adjusted.
+       hofx(ivar,iobs) = model_ts(iobs) + obs_t(iobs) - cor_tsfc(iobs)
+     else
+       hofx(ivar,iobs) = model_ts(iobs)
+     end if
+   enddo
+
+enddo
+
+deallocate(obs_height)
+if (allocated(obs_lat)) deallocate(obs_lat)
+if (allocated(obs_lon)) deallocate(obs_lon)
+if (variable_present_t) deallocate(obs_t)
+if (variable_present_q) deallocate(obs_q)
+
+deallocate(model_zs)
+deallocate(model_ts)
+deallocate(model_level1)
+deallocate(model_psfc)
+
+end subroutine ufo_sfccorrected_simobs
+
+! -----------------------------------------------------------
+!> \Conduct terrain height correction for sfc temp
+!!
+!! \Method: hydrosatic equation
+!!
+!!  P_o2m = P_o * exp [-grav/rd * (H_m-H_o) / (TV_m + TV_o)/2)
+!!
+!!  Where:
+!!  H_m   = model sfc height
+!!  H_o   = obs station height
+!!  T_m   = model temp at model sfc level from model 1st level mid-layer
+!!  T_o   = obs temp at station height
+!!  T_o2m = obs temp interpolated from station height to model sfc level
+!!  grav  = gravitational acceleration
+!!  rd    = gas constant per mole
+
+subroutine da_int(nobs, missing, cor_tsfc, H_o, T_o, H_m, T_m)
+implicit none
+integer,                          intent (in)  :: nobs
+real(c_double),                   intent (in)  :: missing
+real(kind_real), dimension(nobs), intent (in)  :: H_o
+real(kind_real), dimension(nobs), intent (in)  :: H_m, T_m
+real(kind_real), dimension(nobs), intent (in)  :: T_o
+real(kind_real), dimension(nobs), intent (out) :: cor_tsfc
+real(kind_real), dimension(nobs)               :: T_m2o, T_o2m
+integer i
+
+! T_o2m : obs temp interpolated to model sfc
+! T_m2o : model temp interpolated to obs station height
+
+! extrapolate temp from station height to model sfc
+! -------------------------------------------------
+where ( H_o /= missing .and. T_o /= missing )
+
+   T_o2m = T_o - Lclr * ( H_m - H_o)
+   T_m2o = T_m + Lclr * ( H_m - H_o)
+
+elsewhere
+   T_o2m = T_m   ! to give zero analysis increment
+   T_m2o = T_o   ! to give zero analysis increment
+end where
+
+   cor_tsfc = T_o2m
+!  cor_tsfc = T_m2o   ! for testing only
+
+end subroutine da_int
+
+! ------------------------------------------------------------------------------
+!> \Conduct terrain height correction for sfc temp
+!!
+!! \Reference: Ingleby,2013. UKMO Technical Report No: 582. Appendix 1.
+!!
+!! \Method: integrate hydrosatic equation dp/dz=-rho*g/RT to get P_m2o first, equation:
+!!
+!!  (P_m2o/P_m) = (T_m2o/T_m)** (grav/rd*L)
+!!
+!!  Where:
+!!  P_m2o : model sfc pressure at station height
+!!  P_m   : model sfc pressure
+!!  T_m   : temp at model sfc height; derived from T_2000
+!!  T_m2o : model sfc temp at station height
+!!  grav  : gravitational acceleration
+!!  rd    : gas constant per mole
+!!  Lclr  : constant lapse rate (0.0065 K/m)
+!!
+!!  To avoid dirunal/local variations, use T_2000 (2000 m above model sfc height) instead of direct T_m
+!!
+!!  T_m = T_2000 * (P_m / P_2000) ** (rd*L/grav)
+!!
+!! Where:
+!!  P_2000 : model pressure at 2000 m
+!!  T_2000 : model dry temp at 2000 m
+
+subroutine da_int_ukmo(nobs, missing, cor_tsfc, H_o, T_o, H_m, P_m, T_2000, P_2000, T_m)
+implicit none
+integer,                          intent (in)  :: nobs  ! total observation number
+real(c_double),                   intent (in)  :: missing
+real(kind_real), dimension(nobs), intent (in)  :: H_o, T_o  ! observed Height and temp
+real(kind_real), dimension(nobs), intent (in)  :: H_m, P_m, T_2000, P_2000 ! model Height, and TV/P at 2000 m
+
+real(kind_real), dimension(nobs), intent (out) :: T_m  ! model sfc temp from 2000m)
+
+real(kind_real), dimension(nobs), intent (out) :: cor_tsfc
+real(kind_real), dimension(nobs)               :: T_m2o, T_o2m ! model Temp at obs height; observed Temp at model sfc height
+real(kind_real)                                :: ind
+integer i
+
+! constant power exponent
+ind = rd * Lclr / grav
+
+where ( H_o /= missing .and. T_o /= missing )
+   ! T_m   : bg temp at model sfc
+   ! T_o2m : obs temp at model sfc
+   ! T_m2o : bg temp at obs station height
+
+   T_m = T_2000 * (P_m / P_2000) ** ind  ! P_2000 to model surface
+   T_o2m = T_o - Lclr * ( H_m - H_o)     ! OBS height to model surface
+   T_m2o = T_m + Lclr * ( H_m - H_o)     ! model surface to OBS height
+
+elsewhere
+   T_o2m = T_m
+   T_m2o = T_o
+end where
+
+   cor_tsfc = T_o2m
+!  cor_tsfc = T_m2o   ! for testing only
+
+end subroutine da_int_ukmo
+
+! -----------------------------------------------------------
+!> \Conduct terrain height correction for sfc temp
+!!
+!! \Method: Constant Lapse Rate (adiabatic by default)
+!!
+!!  Where:
+!!  H_m   = model sfc height
+!!  H_o   = obs station height
+!!  T_o   = obs temp at station height
+!!  T_lr  = temperature lapse rate
+!!  T_o2m = obs temp interpolated from station height to model sfc level
+
+subroutine da_int_lr(nobs, missing, cor_tsfc, H_o, T_o, H_m, T_lr)
+implicit none
+integer,                          intent (in)  :: nobs
+real(c_double),                   intent (in)  :: missing
+real(kind_real), dimension(nobs), intent (in)  :: H_o
+real(kind_real), dimension(nobs), intent (in)  :: H_m
+real(kind_real), dimension(nobs), intent (in)  :: T_o
+real(kind_real), dimension(nobs), intent (in)  :: T_lr
+real(kind_real), dimension(nobs), intent (out) :: cor_tsfc
+real(kind_real), dimension(nobs)               :: T_o2m, T_m2o
+integer i
+
+! T_o2m : obs temp interpolated to model sfc
+
+! Adjust temp from station height to model sfc based on lapse rate
+! -------------------------------------------------
+where ( H_o /= missing .and. T_o /= missing )
+
+   T_o2m = T_o - T_lr * ( H_m - H_o)
+
+elsewhere
+   T_o2m = T_o
+end where
+
+   cor_tsfc = T_o2m
+
+end subroutine da_int_lr
+
+! ------------------------------------------------------------------------------
+end module ufo_sfccorrected_mod

--- a/sorc/build.rdas
+++ b/sorc/build.rdas
@@ -12,6 +12,8 @@ EXEC2="${HOMErrfs}/sorc/RDASApp/build/bin/bufr2ioda.x"
 EXEC3="${HOMErrfs}/sorc/RDASApp/build/bin/mpasjedi_enkf.x"
 cd ${HOMErrfs}/sorc/RDASApp
 cp ../_workaround_/Registry.xml sorc/mpas/src/core_atmosphere
+cp ../_workaround_/CMakeLists.txt sorc/ufo/src/ufo
+cp -r ../_workaround_/sfccorrected sorc/ufo/src/ufo/operators
 if [[ "${MACHINE}" == "gaea" ]]; then
   cp ../_workaround_/TimeoffsetVariable.cpp sorc/iodaconv/src/bufr/BufrParser/Exports/Variables
 fi


### PR DESCRIPTION
This PR enables surface temperature data assimilation by using GSL's surface operator, which adjusts based on the local lapse rate.

example YAMLs:

for no adjustment:
```yaml
      obs operator:
        name: SfcCorrected
        da_sfc_scheme: GSL
        lapse_rate_option: NoAdjustment
        variables:
        - name: airTemperature
      linear obs operator:
        name: Identity
```

for adjustment using constant lapse rate
```yaml
      obs operator:
        name: SfcCorrected
        da_sfc_scheme: GSL
        lapse_rate_option: Constant
        lapse_rate: 6.5
        variables:
        - name: airTemperature
      linear obs operator:
        name: Identity
```

for adjustment using local lapse rate
```yaml
      obs operator:
        name: SfcCorrected
        da_sfc_scheme: GSL
        lapse_rate_option: Local
        local_lapse_rate_level: 10
        threshold: true
        min_threshold: 0.5
        max_threshold: 10.0
        variables:
        - name: airTemperature
      linear obs operator:
        name: Identity
```