### PR TITLE
Hotfix - add rho into stream_list.atmosphere.ensemble to solve the GETKF crash

### DIFF
--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.ensemble
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.ensemble
@@ -1,5 +1,6 @@
 pressure_base
 pressure_p
+rho
 scalars
 surface_pressure
 theta


### PR DESCRIPTION
See the issue https://github.com/NOAA-EMC/RDASApp/issues/309

Thanks @SamuelDegelia-NOAA @spanNOAA for debugging this issue and finding a final solution.