### PR TITLE
hotfix - getkf uses the background stream to read background state variables

### DIFF
--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.ensemble
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.ensemble
@@ -1,6 +1,5 @@
 pressure_base
 pressure_p
-rho
 scalars
 surface_pressure
 theta

--- a/parm/getkf_observer.yaml
+++ b/parm/getkf_observer.yaml
@@ -1,7 +1,7 @@
 _member: &memberConfig
   date: &analysisDate '@analysisDate@'
   state variables: [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal,theta,rho,u,qv,pressure,landmask,xice,snowc,skintemp,ivgtyp,isltyp,snowh,vegfra,u10,v10,lai,smois,tslb,pressure_p,qc,qi,qg,qr,qs,cldfrac]
-  stream name: ensemble
+  stream name: background
 
 increment variables: [temperature, spechum, uReconstructZonal, uReconstructMeridional, surface_pressure]
 

--- a/parm/getkf_solver.yaml
+++ b/parm/getkf_solver.yaml
@@ -1,7 +1,7 @@
 _member: &memberConfig
   date: &analysisDate '@analysisDate@'
   state variables: [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal,theta,rho,u,qv,pressure,landmask,xice,snowc,skintemp,ivgtyp,isltyp,snowh,vegfra,u10,v10,lai,smois,tslb,pressure_p,qc,qi,qg,qr,qs,cldfrac]
-  stream name: ensemble
+  stream name: background
 
 increment variables: [temperature, spechum, uReconstructZonal, uReconstructMeridional, surface_pressure]
 

--- a/parm/streams.atmosphere.getkf
+++ b/parm/streams.atmosphere.getkf
@@ -27,17 +27,6 @@
         <file name="stream_list/stream_list.atmosphere.analysis"/>
 </stream>
 
-<stream name="ensemble"
-        type="input;output"
-        precision="single"
-        io_type="pnetcdf,cdf5"
-        filename_template="foo3.nc"
-        input_interval="none"
-        output_interval="none"
-        clobber_mode="overwrite">
-        <file name="stream_list/stream_list.atmosphere.ensemble"/>
-</stream>
-
 <stream name="control"
         type="input;output"
         precision="single"


### PR DESCRIPTION
This is a further hotfix for the GETKF crash issue which has been "temporarily" fixed by PR #686 

To summarize, GETKF needs to read more state variables from the background ensembles besides `rho`.