### PR TITLE
change default KEEPDATA to no

### DIFF
--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -67,7 +67,7 @@ export WALLTIME_MPASSIT="1:00:00"
 export WALLTIME_UPP="1:00:00"
 export WALLTIME_JEDIVAR="00:30:00"
 #
-export KEEPDATA=yes
+export KEEPDATA=no
 export MPI_RUN_CMD=srun
 #
 # local.setup: setup some local options specific to a platform or an experiment

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -67,7 +67,7 @@ export WALLTIME_MPASSIT="2:00:00"
 export WALLTIME_UPP="2:00:00"
 export WALLTIME_JEDIVAR="00:30:00"
 #
-export KEEPDATA=yes
+export KEEPDATA=no
 export MPI_RUN_CMD=srun
 #
 # local.setup: setup some local options specific to a platform or an experiment

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -57,7 +57,7 @@ export WALLTIME_MPASSIT="1:00:00"
 export WALLTIME_UPP="1:00:00"
 export WALLTIME_GETKF="00:30:00"
 #
-export KEEPDATA=yes
+export KEEPDATA=no
 export MPI_RUN_CMD=srun
 export RETRO_TASKTHROTTLE=60
 #

--- a/workflow/exp/rt_jet/exp.rt_jet_conus12km
+++ b/workflow/exp/rt_jet/exp.rt_jet_conus12km
@@ -69,7 +69,7 @@ export WALLTIME_MPASSIT="1:00:00"
 export WALLTIME_UPP="1:00:00"
 export WALLTIME_JEDIVAR="00:30:00"
 #
-export KEEPDATA=yes
+export KEEPDATA=no
 export MPI_RUN_CMD=srun
 #
 # local.setup: setup some local options specific to a platform or an experiment

--- a/workflow/exp/rt_jet/exp.rt_jet_ens_conus12km
+++ b/workflow/exp/rt_jet/exp.rt_jet_ens_conus12km
@@ -59,7 +59,7 @@ export WALLTIME_MPASSIT="1:00:00"
 export WALLTIME_UPP="1:00:00"
 export WALLTIME_GETKF="00:30:00"
 #
-export KEEPDATA=yes
+export KEEPDATA=no
 export MPI_RUN_CMD=srun
 export RETRO_TASKTHROTTLE=60
 #


### PR DESCRIPTION
At this stage, all data/results needed by downstream offline applications have been transferred out of the temporary `DATA` directories, so set the default value of `KEEPDATA` to `no`. This can save quite a lot of disk space.

If we need any other data from `DATA`, we should update the workflow to transfer it out.