### PR TITLE
Fix masked longitude data in `offline_ioda_tweak.py`

### DIFF
--- a/ush/offline_ioda_tweak.py
+++ b/ush/offline_ioda_tweak.py
@@ -86,7 +86,10 @@ for group in groups:
           np_invar[(np_invar < 0) | (np_invar > 15)] = 15
           g.variables[var][:] = np_invar.astype(invar.dtype)
         else:
-          g.variables[var][:] = invar[:][:]
+          if var in ['latitude', 'longitude']:
+            g.variables[var][:] = invar[:][:].data
+          else:
+            g.variables[var][:] = invar[:][:]
         # Copy attributes for this variable
         for attr in invar.ncattrs():
             if '_FillValue' in attr: continue


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR follows [RDASApp #342](https://github.com/NOAA-EMC/RDASApp/pull/342). The offline utility for adding the `latitude_longitude_pressure` variable was having issues with outputting masked longitude data for the ZTD obs when converted from (-180,180) to (0,360). This PR now outputs the unmasked location data but still leaves other variables masked if the data are bad.

Before the fix: 

```
ncdump -g MetaData -v longitude ioda_ztd_llp_orig.nc
   longitude = 4.59495, _, _, 7.66128, 4.83611, _, _, 1.60283, _, _, 0.96189,
      _, 5.81914, _, 0.98814, _, 5.83403, _, 5.18686, 4.31558, _, _, _,
      3.20022, _, _, _, _, _, _, _, _, _, _, _, 6.93336, _, _, 0.97647,
      0.11644, _, 3.56469, 3.27506, 3.96925, _, _, _, 4.21644, _, _, 3.86953,
      3.70917, 3.88306, _, _, _, 1.73194, _, 4.84033, 0.33567, 4.04311,
      4.90044, _, _, 5.37422, _, 2.85906, _, 3.37172, _, _, _, _, _, _, _, _,
      _, _, 4.25417, _, _, _, _, _, _, 5.75067, 5.73928, _, 5.29747, 0.48344,
      _, 4.51061, 1.38289, 5.44408, 5.192, 5.11706, 4.86064, _, 0.41528,
      4.15092, 4.30475, _, 4.62783, 4.84506, 3.80203, 3.61797, _, _, _, _, _,
...
```

After this fix:

```
ncdump -g MetaData -v longitude ioda_ztd_llp.nc
   longitude = 4.59495, 353.0697, 334.3372, 7.66128, 4.83611, 355.4287,
      355.2587, 1.60283, 359.4407, 355.8004, 0.96189, 354.1505, 5.81914,
      356.5199, 0.98814, 352.4995, 5.83403, 352.6359, 5.18686, 4.31558,
      358.2503, 356.965, 356.6044, 3.20022, 358.9834, 357.0385, 358.0801,
      354.6727, 354.3981, 356.8932, 357.0617, 358.5617, 358.6685, 357.6057,
      357.3595, 6.93336, 357.8021, 356.2639, 0.97647, 0.11644, 356.6559,
      3.56469, 3.27506, 3.96925, 356.7931, 356.5899, 355.3115, 4.21644,
      357.9973, 358.5187, 3.86953, 3.70917, 3.88306, 357.6912, 355.1424,
      355.7035, 1.73194, 359.4713, 4.84033, 0.33567, 4.04311, 4.90044,
      355.3579, 358.6203, 5.37422, 358.4861, 2.85906, 355.7808, 3.37172,
      357.5599, 358.9219, 355.6793, 354.9477, 357.6713, 355.9526, 357.0985,
...
```

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

I tested these changes by running `offline_ioda_tweak.py` on a sample set of ZTD obs. 

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
None


