### PR TITLE
set umask to 022 before calling j-jobs

### DIFF
--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -57,6 +57,7 @@ if [[ "${NDATE}" == "" ]]; then
   exit 1
 fi
 
+umask 022
 # run J-job or sideload non-NCO tasks
 case ${task_id} in
   clean)


### PR DESCRIPTION
In this issue: https://github.com/NOAA-EMC/rrfs-workflow/issues/692#issuecomment-2749124719:
@TingLei-NOAA found that he couldn't access my rundir `/work2/noaa/wrfruc/gge/orion/OPSROOT/c12km/stmp` on orion.
I checked my rundir and found that they are not open to others outside of my projects:
```
drwxr-s--- 3 gge wrfruc 4.0K Mar  8 20:28 com/
drwxr-s--- 3 gge wrfruc 4.0K Mar 26 20:08 stmp/
```
To address this issue and facilitate future collaborations, `umask 022` is added just before calling j-jobs.
