### PR TITLE
update the rocoto workflow <log> path to match task logs

### DIFF
--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -54,7 +54,7 @@ def setup_xml(HOMErrfs, expdir):
     header_entities(xmlFile,expdir)
     header_end(xmlFile)
     wflow_begin(xmlFile)
-    log_fpath=f'&LOGROOT;/rrfs&WGF;.@Y@m@d/@H/rrfs&WGF;_{TAG}.log'
+    log_fpath=f'&LOGROOT;/&RUN;.@Y@m@d/@H/&WGF;/&RUN;.log'
     wflow_log(xmlFile,log_fpath)
     wflow_cycledefs(xmlFile,dcCycledef)
     


### PR DESCRIPTION
We have changed the com/ and log/ directory structure to match the latest rrfs.v1 (ie. `RUN.PDY/cyc/WGF`) but forgot to update the rocoto workflow `<log>` element accordingly. This PR addresses this glitch.