### PR TITLE
hotfix - add module purge into build.mpassit to solve the compiling failure on Gaea

### DIFF
--- a/sorc/build.mpassit
+++ b/sorc/build.mpassit
@@ -4,6 +4,7 @@ date
 rundir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 HOMErrfs="$(dirname "$rundir")"
 
+module purge
 source ${HOMErrfs}/workflow/ush/detect_machine.sh
 source ${HOMErrfs}/workflow/ush/init.sh
 


### PR DESCRIPTION
build.mpassit failed on Gaea with an Intel internal error.
It was found that it was due to a conflict with some loaded modules in the users' current shell environment.
`module purge` solved this issue.