### PR TITLE
Enforce using the same MPAS-Model for the workflow and RDASApp by default

### DIFF
--- a/sorc/build.rdas
+++ b/sorc/build.rdas
@@ -8,6 +8,27 @@ HOMErrfs="$(dirname "$rundir")"
 source "${HOMErrfs}/workflow/ush/detect_machine.sh"
 source "${HOMErrfs}/workflow/ush/init.sh"
 
+# get a clean copy of the same MPAS-Model as in the workflow
+# if RDASApp has a different version from the workflow
+# and users don't specify 'different_mpas' at the command line
+if [[ "$1" == "different_mpas" ]]; then
+  use_same_mpas=no
+else
+  use_same_mpas=yes
+fi
+cd "${HOMErrfs}/sorc/MPAS-Model" || exit 1
+hash_workflow=$(git rev-parse HEAD)
+cd "${HOMErrfs}/sorc/RDASApp/sorc/mpas" || exit 1
+hash_rdasapp=$(git rev-parse HEAD)
+if [[ "${hash_workflow}" != "${hash_rdasapp}" ]] && [[ "${use_same_mpas}" == "yes" ]]; then
+  cd "${HOMErrfs}/sorc/RDASApp/sorc" || exit 1
+  mv mpas "mpas.$(date +%s)" # save a copy of current RDASApp mpas
+  git clone https://github.com/NOAA-GSL/MPAS-Model.git mpas
+  cd "${HOMErrfs}/sorc/RDASApp/sorc/mpas" || exit 1
+  git checkout "${hash_workflow}"
+  git submodule update --init --recursive
+fi
+
 EXEC="${HOMErrfs}/sorc/RDASApp/build/bin/mpasjedi_variational.x"
 EXEC2="${HOMErrfs}/sorc/RDASApp/build/bin/bufr2ioda.x"
 EXEC3="${HOMErrfs}/sorc/RDASApp/build/bin/mpasjedi_enkf.x"


### PR DESCRIPTION
The MPAS-Model is very sensitive to the metadata in NetCDF files. If we use different versions of MPAS (hence different metadata) between the workflow and the RDASApp, most time we will get a crash even if the actual MPAS differences don't matter to DA at all. 

The crash information does not tell us this is because of the mismatch of metadata and we will take time to examine it until finally we find it is due to the mismatch of the MPAS-Model. I have experienced this a few times, and it took me quite a while to figure that out. 

Now that a few other developers have also experienced a similar situation. It is good to add a safeguard to ensure we use the same MPAS-Model commit for both the workflow and the RDASApp unless users want to explicitly use different MPAS versions for some testing (in which case, they can run `build.rdas  different_mpas` or build manually).

This is just a safeguard, and one still needs to make PRs to both rrfs-workflow and RDASApp when updating the MPAS-Model.
