### PR TITLE
[rrfs-mpas-jedi] Also load the contrib module on Orion/Hercules

### DIFF
--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -121,7 +121,8 @@ def setup_xml(HOMErrfs, expdir):
 
     fPath = f"{expdir}/run_rocoto.sh"
     extra_modules = ""
-    if machine in ['orion', 'hercules']: extra_modules = "contrib"
+    if machine in ['orion', 'hercules']: 
+        extra_modules = "contrib"
     with open(fPath, 'w') as rocotoFile:
         text = \
             f'''#!/usr/bin/env bash

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -120,13 +120,11 @@ def setup_xml(HOMErrfs, expdir):
 # ---------------------------------------------------------------------------
 
     fPath = f"{expdir}/run_rocoto.sh"
-    extra_modules = ""
-    if machine in ['orion', 'hercules']: extra_modules = "contrib"
     with open(fPath, 'w') as rocotoFile:
         text = \
             f'''#!/usr/bin/env bash
 source /etc/profile
-module load {extra_modules} rocoto
+module load rocoto
 cd {expdir}
 rocotorun -w rrfs.xml -d rrfs.db
 '''

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -120,11 +120,13 @@ def setup_xml(HOMErrfs, expdir):
 # ---------------------------------------------------------------------------
 
     fPath = f"{expdir}/run_rocoto.sh"
+    extra_modules = ""
+    if machine in ['orion', 'hercules']: extra_modules = "contrib"
     with open(fPath, 'w') as rocotoFile:
         text = \
             f'''#!/usr/bin/env bash
 source /etc/profile
-module load rocoto
+module load {extra_modules} rocoto
 cd {expdir}
 rocotorun -w rrfs.xml -d rrfs.db
 '''

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -121,7 +121,7 @@ def setup_xml(HOMErrfs, expdir):
 
     fPath = f"{expdir}/run_rocoto.sh"
     extra_modules = ""
-    if machine in ['orion', 'hercules']: 
+    if machine in ['orion', 'hercules']:
         extra_modules = "contrib"
     with open(fPath, 'w') as rocotoFile:
         text = \


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

The contrib module needs to be loaded on MSU HPCs before loading rocoto. This small PR modifies `setup_xml.py` to also load contrib on Orion/Hercules in `run_rocoto.sh`. After this change, `run_rocoto.sh` can be successfully run through the crontab. 

## TESTS CONDUCTED: 
Tested running `run_rocoto.sh` through the Cron on Orion. Also tested to make sure that the contrib module does not get added on Hera. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [x] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
- Fixes the issue(s) mentioned in #723


