### PR TITLE
[main] Updates to use the latest BUFRSND station list

### DIFF
--- a/scripts/exrrfs_bufrsnd.sh
+++ b/scripts/exrrfs_bufrsnd.sh
@@ -111,7 +111,9 @@ cyc=$hh
 mkdir -p $DATA/bufrpost
 cd $DATA/bufrpost
 
-cpreq -p ${FIX_BUFRSND}/${PREDEF_GRID_NAME}/rrfs_profdat regional_profdat
+NSTAT=1950
+
+cpreq -p ${FIX_BUFRSND}/${PREDEF_GRID_NAME}/rrfs_profdat.${NSTAT} regional_profdat
 
 OUTTYP=netcdf
 
@@ -223,7 +225,6 @@ do
     err_exit "ABORTING due to bad model selection for this script."
   fi
 
-  NSTAT=1850
   datestr=`date`
   echo top of loop after found needed log file for $fhr at $datestr
 
@@ -240,10 +241,6 @@ $NSTAT
 $OUTFILDYN
 $OUTFILPHYS
 EOF
-
-#  export FORT19="$DATA/bufrpost/regional_profdat"
-#  export FORT79="$DATA/bufrpost/profilm.c1.${tmmark}"
-#  export FORT11="./itag"
 
 ln -sf $DATA/bufrpost/regional_profdat     fort.19
 ln -sf $DATA/bufrpost/profilm.c1.${tmmark} fort.79
@@ -287,11 +284,6 @@ ln -sf $DATA/regional_sndp.parm.mono fort.11
 ln -sf $DATA/regional_bufr.tbl       fort.32
 ln -sf $DATA/profilm.c1.${tmmark}    fort.66
 ln -sf $DATA/class1.bufr             fort.78
-
-# export FORT11="$DATA/regional_sndp.parm.mono"
-# export FORT32="$DATA/regional_bufr.tbl"
-# export FORT66="$DATA/profilm.c1.${tmmark}"
-# export FORT78="$DATA/class1.bufr"
 
 echo here model $model
 
@@ -373,7 +365,7 @@ SNOUTF   = ${outfilbase}.snd
 SFOUTF   = ${outfilbase}.sfc+
 SNPRMF   = snrrfs.prm
 SFPRMF   = sfrrfs.prm
-TIMSTN   = 85/1850
+TIMSTN   = 85/$NSTAT
 r
 
 exit


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Switches to the "1950" version of the BUFRSND profdat file that includes the most recent additions.
- Cleans out some legacy commented out lines.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:  Have tested it offline, and gave it a final test within the real-time RRFS system starting with the 20250408/18Z cycle (and from 20250408/12Z REFS cycle as well)
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #595 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

