### PR TITLE
Hotfixes for incorrect file processing in MPASSIT and UPP

### DIFF
--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -39,7 +39,7 @@ echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
 #
 # loop through forecast history files for this group
 #
-fhr_string=$( seq 0 $((10#${HISTORY_INTERVAL})) $((10#${fcst_len_hrs_thiscyc} )) )
+fhr_string=$( seq 0 $((10#${HISTORY_INTERVAL})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ' )
 read -ra fhr_all <<< "${fhr_string}"  # convert fhr_string to an array
 num_fhrs=${#fhr_all[@]}
 group_total_num=$((10#${GROUP_TOTAL_NUM}))

--- a/scripts/exrrfs_upp.sh
+++ b/scripts/exrrfs_upp.sh
@@ -41,7 +41,7 @@ echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
 #
 # loop through forecast history files for this group
 #
-fhr_string=$( seq 0 $((10#${HISTORY_INTERVAL})) $((10#${fcst_len_hrs_thiscyc} )) )
+fhr_string=$( seq 0 $((10#${HISTORY_INTERVAL})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ' )
 read -ra fhr_all <<< "${fhr_string}"  # convert fhr_string to an array
 num_fhrs=${#fhr_all[@]}
 group_total_num=$((10#${GROUP_TOTAL_NUM}))


### PR DESCRIPTION
After PR#[711](https://github.com/NOAA-EMC/rrfs-workflow/pull/711), both MPASSIT and UPP were limited to processing only the 0-hour forecast. This PR resolves issues related to incorrect file handling in these tasks, ensuring that MPASSIT and UPP now process all available forecast outputs.