### PR TITLE
add more granularity for generating selective workflow tasks

### DIFF
--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -13,6 +13,9 @@ export CLUSTER=${CLUSTER:-""}
 export NATIVE=${NATIVE:-""}
 export MORE_XML_ENTITIES=${MORE_XML_ENTITIES:-false}
 export REALTIME_MONTHS=${REALTIME_MONTHS:-2}
+export DO_FCST=${DO_FCST:-true}
+export DO_POST=${DO_POST:-true}
+export DO_IC_LBC=${DO_IC_LBC:-true}
 
 # ioda_bufr
 export NODES_IODA_BUFR=${NODES_IODA_BUFR:-"<nodes>1:ppn=1</nodes>"}

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -101,7 +101,9 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
 
 # overwrite dependencies if no cycling (forecst-only)
     if os.getenv('DO_CYC', 'FALSE').upper() == "FALSE":
-        dependencies = f'''
+        dependencies = ""
+        if os.getenv('DO_IC_LBC', 'TRUE').upper() == "TRUE":
+            dependencies = f'''
   <dependency>
   <and>{timedep}
    <taskdep task="ic{ensindexstr}"/>

--- a/workflow/rocoto_funcs/prep_lbc.py
+++ b/workflow/rocoto_funcs/prep_lbc.py
@@ -2,7 +2,7 @@
 import os
 from rocoto_funcs.base import xml_task, get_cascade_env
 
-# begin of fcst --------------------------------------------------------
+# begin of prep_lbc --------------------------------------------------------
 
 
 def prep_lbc(xmlFile, expdir, do_ensemble=False):
@@ -58,7 +58,9 @@ def prep_lbc(xmlFile, expdir, do_ensemble=False):
     for hr in range(0, 12):
         taskdep = taskdep + f'\n     <metataskdep metatask="lbc{ensindexstr}" cycle_offset="-{hr}:00:00" />'
 
-    dependencies = f'''
+    dependencies = ""
+    if os.getenv('DO_IC_LBC', 'TRUE').upper() == "TRUE":
+        dependencies = f'''
   <dependency>
   <and>{timedep}
    <or>{taskdep}
@@ -68,4 +70,4 @@ def prep_lbc(xmlFile, expdir, do_ensemble=False):
     #
     xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies,
              metatask, meta_id, meta_bgn, meta_end, "PREP_LBC")
-# end of fcst --------------------------------------------------------
+# end of prep_lbc  --------------------------------------------------------

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -63,10 +63,12 @@ def setup_xml(HOMErrfs, expdir):
             if os.getenv("DO_IODA", "FALSE").upper() == "TRUE":
                 ioda_bufr(xmlFile, expdir)
             #
-            ungrib_ic(xmlFile, expdir)
-            ungrib_lbc(xmlFile, expdir)
-            ic(xmlFile, expdir)
-            lbc(xmlFile, expdir)
+            if os.getenv("DO_IC_LBC", "TRUE").upper() == "TRUE":
+                ungrib_ic(xmlFile, expdir)
+                ungrib_lbc(xmlFile, expdir)
+                ic(xmlFile, expdir)
+                lbc(xmlFile, expdir)
+            #
             if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
                 prep_lbc(xmlFile, expdir)
                 # spin up line
@@ -78,7 +80,7 @@ def setup_xml(HOMErrfs, expdir):
                 jedivar(xmlFile, expdir)
                 fcst(xmlFile, expdir)
                 save_fcst(xmlFile, expdir)
-            else:
+            elif os.getenv("DO_FCST", "TRUE").upper() == "TRUE":
                 prep_ic(xmlFile, expdir)
                 prep_lbc(xmlFile, expdir)
                 if os.getenv("DO_JEDI", "FALSE").upper() == "TRUE":
@@ -86,8 +88,9 @@ def setup_xml(HOMErrfs, expdir):
                 fcst(xmlFile, expdir)
                 save_fcst(xmlFile, expdir)
             #
-            mpassit(xmlFile, expdir)
-            upp(xmlFile, expdir)
+            if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
+                mpassit(xmlFile, expdir)
+                upp(xmlFile, expdir)
 
 # ---------------------------------------------------------------------------
 # assemble tasks for an ensemble experiment


### PR DESCRIPTION
@barlage brought up a good workflow use scenario:

One may want to run the ioda/ic/lbc tasks only once and then use that same copy for multiple retro experiments.   
This happened to me when I did some retro experiments on Gaea using the same set of ioda observation files. At that time, I manually did it. 

Now, Model or Physics developers would like to run 20+ experiments on the same IC/LBC but with different physics.

This PR is to add more granularity for generating selective workflow tasks so as to meet the above needs.

By default, `DO_IC_LBC`, `DO_FCST`and `DO_POST` all take values of `true`, so this PR does not affect any existing workflow capabilities.

If one defines the following variables in the exp setup files, 
```
export DO_IODA=false
export DO_JEDI=false
export DO_POST=false
export DO_SPINUP=false
export DO_FCST=false
export DO_CYC=false
```
one will only run the IC/LBC tasks. The associated workflow may only need to run once to generate the needed IC/LBC data

One can then define the following variables in the exp setup files to only run the forecast related tasks (`prep_ic`, `prep_lbc`, `fcst`, `save_fcst`):
```
export DO_IODA=false
export DO_JEDI=false
export DO_POST=false
export DO_SPINUP=false
export DO_IC_LBC=false
export DO_CYC=false
```
