### PR TITLE
[rrfs-mpas-jedi] Update modules loaded for offline domain check in ioda_bufr task

### DIFF
--- a/ush/offline_domain_check.py
+++ b/ush/offline_domain_check.py
@@ -55,7 +55,7 @@ def alpha_shape(points, alpha, only_outer=True):
     edges = set()
     # Loop over triangles:
     # ia, ib, ic = indices of corner points of the triangle
-    for ia, ib, ic in tri.vertices:
+    for ia, ib, ic in tri.simplices:
         pa = points[ia]
         pb = points[ib]
         pc = points[ic]

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -31,7 +31,7 @@ case ${task_id} in
     module purge
     module use "${HOMErrfs}/sorc/RDASApp/modulefiles"
     module load "RDAS/${MACHINE}.intel"
-    module load "EVA/${MACHINE}"
+    module load py-matplotlib py-cartopy py-netcdf4
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOMErrfs}/sorc/RDASApp/build/lib64
     ;;
   ungrib)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

When #728 was opened to add the offline domain check to rrfs-mpas-jedi, I chose to load the EVA modules to access the necessary python libraries. But it turns out that this unfortunately only works on Orion. When running the workflow on Hera, EVA is not able to be loaded due to a conflict between the python and miniconda versions. So the offline domain check does not run. 

**Note that this does not cause issues with any other task except running the GETKF with the posterior observer enabled. The JEDIVAR task still completes just fine despite the offline domain check code not working.** 

To solve this problem, we can instead load the needed python modules from spack-stack which is sourced through `RDAS/${MACHINE}.intel`. Loading these modules uses a slightly different version of scipy so one line in the python code also needed to change. This change has been confirmed to work on Hera/Jet/Orion/Hercules/Gaea. 

## TESTS CONDUCTED: 
Ran `ioda_bufr` task on Hera to make sure it works. Then did standalone tests of running `offline_domain_check.py` on all other machines after loading the modules as defined in `launch.sh`. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [x] Jet
  - [x] Orion
  - [x] Hercules
  - [x] Gaea


### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None


