### PR TITLE
[rrfs-mpas-jedi] Add a dummy variable for `ObsError/specificHumidity` to prevent empty observation errors during the GETKF solver

### DIFF
--- a/parm/prepbufr_adpsfc.yaml
+++ b/parm/prepbufr_adpsfc.yaml
@@ -71,6 +71,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -425,6 +432,12 @@ observations:
           source: variables/stationPressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_adpupa.yaml
+++ b/parm/prepbufr_adpupa.yaml
@@ -85,6 +85,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -311,6 +318,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_aircar.yaml
+++ b/parm/prepbufr_aircar.yaml
@@ -71,6 +71,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -308,6 +315,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_aircft.yaml
+++ b/parm/prepbufr_aircft.yaml
@@ -71,6 +71,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/PRSLEVLA{1}/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -308,6 +315,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_msonet.yaml
+++ b/parm/prepbufr_msonet.yaml
@@ -74,6 +74,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -355,6 +362,12 @@ observations:
           source: variables/stationPressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_proflr.yaml
+++ b/parm/prepbufr_proflr.yaml
@@ -66,6 +66,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -293,6 +300,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_rassda.yaml
+++ b/parm/prepbufr_rassda.yaml
@@ -66,6 +66,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -322,6 +329,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_satwnd.yaml
+++ b/parm/prepbufr_satwnd.yaml
@@ -68,6 +68,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -304,6 +311,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_sfcshp.yaml
+++ b/parm/prepbufr_sfcshp.yaml
@@ -71,6 +71,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -425,6 +432,12 @@ observations:
           source: variables/stationPressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/parm/prepbufr_vadwnd.yaml
+++ b/parm/prepbufr_vadwnd.yaml
@@ -66,6 +66,13 @@ observations:
             type: float
             transforms:
               - scale: 0.000001
+          # Assign fake Q errors
+          specificHumidityError:
+            query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+            type: float
+            transforms:
+              - scale: 0.0
+              - offset: 999
           specificHumidityQualityMarker:
             query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
           relativeHumidityError:
@@ -293,6 +300,12 @@ observations:
           source: variables/pressureError
           longName: "Pressure Observation Error"
           units: "Pa"
+
+        - name: "ObsError/specificHumidity"
+          coordinates: "longitude latitude"
+          source: variables/specificHumidityError
+          longName: "Specific Humidity Error"
+          units: "kg kg-1"
 
         - name: "ObsError/relativeHumidity"
           coordinates: "longitude latitude"

--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -81,7 +81,7 @@ if os.getenv("DO_JEDI", 'false').upper() == "TRUE":
     # copy jedivar.yaml or getkf yamls to exp_configdir
     if os.getenv('DO_ENSEMBLE', 'FALSE').upper() == "TRUE":
         shutil.copy(f'{HOMErrfs}/parm/getkf_observer.yaml', f'{exp_configdir}/getkf_observer.yaml')
-        shutil.copy(f'{HOMErrfs}/parm/getkf_solver.yaml', f'{exp_configdir}/getkf_observer.yaml')
+        shutil.copy(f'{HOMErrfs}/parm/getkf_solver.yaml', f'{exp_configdir}/getkf_solver.yaml')
     else:
         shutil.copy(f'{HOMErrfs}/parm/jedivar.yaml', f'{exp_configdir}/jedivar.yaml')
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

Note: This is a companion PR to https://github.com/NOAA-EMC/RDASApp/pull/369 . 

Here, we update the bufr2ioda yamls to add a dummy variable for `ObsError/specificHumidity`. This prevents an empty `DerivedObsError/specificHumidity` variable from being output in the jdiag files during the GETKF observer. This empty variable was taking priority during the solver which led to zero increments when assimilating moisture obs. 

This PR also includes a quick bugfix to `workflow/setup_rocoto.py`. 

Moisture obs are now being assimilated by the GETKF after this fix. Here is a figure of the ensemble mean qvapor increments from assimilating only q133 obs. This is plotted from rrfs-workflow using `exp.ens_conus12km` for the 2024050600 cold start cycle.  

Qv increments: 
<img src="https://github.com/user-attachments/assets/7666a330-3969-48e7-88f0-2bc8abcecc2d" width="80%" height="60%">

## TESTS CONDUCTED: 
Ran rrfs-workflow for the 2024050600 retro using `exp.ens_conus12km`. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [x] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

