### PR TITLE
move FCST_LENGTH from exp files to config.base to avoid confusions

### DIFF
--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -13,6 +13,7 @@ export CLUSTER=${CLUSTER:-""}
 export NATIVE=${NATIVE:-""}
 export MORE_XML_ENTITIES=${MORE_XML_ENTITIES:-false}
 export REALTIME_MONTHS=${REALTIME_MONTHS:-2}
+export FCST_LENGTH=1
 export DO_FCST=${DO_FCST:-true}
 export DO_POST=${DO_POST:-true}
 export DO_IC_LBC=${DO_IC_LBC:-true}

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -23,7 +23,6 @@ export HYB_ENS_PATH=""     # if empty, the workflow will try to find ensembles a
 
 export DO_CYC=true
 export CYC_INTERVAL=1
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="12"; done # 12hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -23,7 +23,6 @@ export HYB_ENS_PATH=""     # if empty, the workflow will try to find ensembles a
 
 export DO_CYC=true
 export CYC_INTERVAL=1
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="12"; done # 12hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -25,7 +25,6 @@ export DO_RECENTER=false
 
 export DO_CYC=true
 export CYC_INTERVAL=1
-export FCST_LENGTH=1
 for i in {0..23};    do arr[$i]="01"; done # 1hr fcst
 for i in {0..23..6}; do arr[$i]="01"; done # 1hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -26,7 +26,6 @@ export DO_RECENTER=false
 
 export DO_CYC=true
 export CYC_INTERVAL=6
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/rt_jet/exp.rt_jet_conus12km
+++ b/workflow/exp/rt_jet/exp.rt_jet_conus12km
@@ -25,7 +25,6 @@ export HYB_ENS_PATH=""     # if empty, the workflow will try to find ensembles a
 
 export DO_CYC=true
 export CYC_INTERVAL=1
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="12"; done # 12hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/rt_jet/exp.rt_jet_conus3km
+++ b/workflow/exp/rt_jet/exp.rt_jet_conus3km
@@ -25,7 +25,6 @@ export HYB_ENS_PATH=""     # if empty, the workflow will try to find ensembles a
 
 export DO_CYC=true
 export CYC_INTERVAL=1
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/rt_jet/exp.rt_jet_ens_conus12km
+++ b/workflow/exp/rt_jet/exp.rt_jet_ens_conus12km
@@ -27,7 +27,6 @@ export DO_RECENTER=false
 
 export DO_CYC=true
 export CYC_INTERVAL=3
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="06"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"

--- a/workflow/exp/rt_jet/exp.rt_jet_ens_conus3km
+++ b/workflow/exp/rt_jet/exp.rt_jet_ens_conus3km
@@ -28,7 +28,6 @@ export DO_RECENTER=false
 
 export DO_CYC=true
 export CYC_INTERVAL=6
-export FCST_LENGTH=3
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"


### PR DESCRIPTION
`FCST_LENGH` was introduced in the very early stage of the rrfs-workflow(v2), and it has been replaced by `FCST_LEN_HRS_CYCLES` a long time ago. The latter has a big advantage to be able to set different forecast hours for different cycles, such as 12 hrs forecasts at 00/12z, while 3hrs forecasts at other cycle:
`FCST_LEN_HRS_CYCLES="12 03 03 03 03 03 12 03 03 03 03 03 12 03 03 03 03 03 12 03 03 03 03 03"`

Now users are only expected to set `FCST_LEN_HRS_CYCLES` as follows:
```
for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
for i in {0..23..6}; do arr[$i]="12"; done # 12hr fcst every 6hrs
export FCST_LEN_HRS_CYCLES="${arr[*]}"
```

A few users provided feedback that the extra `FCST_LENGH` in the exp setup files brought confusion.
At the same time, `FCST_LENGH` still serves as a last resort to safeguard the workflow.

So this PR moves `FCST_LENGH`  from exp.setup files to config.base to hide it from most users.