### PR TITLE
Add three utilities to use the `Herbie` Python package to download gfs/gefs/rap data from AWS

### DIFF
--- a/modulefiles/BOKEH/gaeaC6.lua
+++ b/modulefiles/BOKEH/gaeaC6.lua
@@ -1,0 +1,19 @@
+help([[
+Load environment for running BOKEH.
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+prepend_path("MODULEPATH", '/gpfs/f6/bil-fire10-oar/world-shared/gge/Miniforge3/modulefiles')
+
+load("Miniforge3/24.11.3-2")
+load("bokeh/3.7.0")
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: BOKEH")
+whatis("Description: Load all libraries needed for BOKEH")

--- a/modulefiles/BOKEH/hera.lua
+++ b/modulefiles/BOKEH/hera.lua
@@ -1,0 +1,19 @@
+help([[
+Load environment for running BOKEH.
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+prepend_path("MODULEPATH", '/scratch1/BMC/wrfruc/gge/Miniforge3/modulefiles')
+
+load("Miniforge3/24.11.3-2")
+load("bokeh/3.7.0")
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: BOKEH")
+whatis("Description: Load all libraries needed for BOKEH")

--- a/modulefiles/BOKEH/hercules.lua
+++ b/modulefiles/BOKEH/hercules.lua
@@ -1,0 +1,19 @@
+help([[
+Load environment for running BOKEH.
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+prepend_path("MODULEPATH", '/work/noaa/zrtrr/gge/hercules/Miniforge3/modulefiles')
+
+load("Miniforge3/24.11.3-2")
+load("bokeh/3.7.0")
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: BOKEH")
+whatis("Description: Load all libraries needed for BOKEH")

--- a/modulefiles/BOKEH/jet.lua
+++ b/modulefiles/BOKEH/jet.lua
@@ -1,0 +1,19 @@
+help([[
+Load environment for running BOKEH.
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+prepend_path("MODULEPATH", '/lfs6/BMC/wrfruc/gge/Miniforge3/modulefiles')
+
+load("Miniforge3/24.11.3-2")
+load("bokeh/3.7.0")
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: BOKEH")
+whatis("Description: Load all libraries needed for BOKEH")

--- a/modulefiles/BOKEH/orion.lua
+++ b/modulefiles/BOKEH/orion.lua
@@ -1,0 +1,19 @@
+help([[
+Load environment for running BOKEH
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+prepend_path("MODULEPATH", '/work/noaa/zrtrr/gge/Miniforge3/modulefiles')
+
+load("Miniforge3/24.11.3-2")
+load("bokeh/3.7.0")
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: BOKEH")
+whatis("Description: Load all libraries needed for BOKEH")

--- a/workflow/ush/herbie_get_GEFS_from_aws
+++ b/workflow/ush/herbie_get_GEFS_from_aws
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import os
 import shutil
 import sys
+import time
 
 args = sys.argv
 nargs = len(args) - 1
@@ -30,35 +31,41 @@ date2 += timedelta(hours=23)
 cur_date = date1
 fhrs = fhr_range.split("-")
 dcProduct = {"atmos.5": "pgrb2ap5", "atmos.5b": "pgrb2bp5"}
+ens_size = 30
 
 while cur_date <= date2:
-    sdate0 = datetime.strftime(cur_date, "%Y%m%d%M")
+    sdate0 = datetime.strftime(cur_date, "%Y%m%d%H")
     for product in ["atmos.5", "atmos.5b"]:
-        final_dest = f'{dest_path}/{model.upper()}/{model}.{sdate0[:8]}/{sdate0[-2:]}'
-        if os.path.exists(f'{final_dest}/{dcProduct[product]}'):
-            print(f"'{final_dest}/{dcProduct[product]}' already exists, please rename or remove it first")
-            exit()
-        if os.path.exists(f'./tmp/{model}/{sdate0[:8]}'):
-            shutil.rmtree(f'./tmp/{model}/{sdate0[:8]}')  # remove temporary directory to avoid contamination
+        final_dest = f'{dest_path}/{model.upper()}/{model}.{sdate0[:8]}/{sdate0[-2:]}/{dcProduct[product]}'
+        tmp_dir = f'./tmp/{model}/{sdate0[:8]}'
+        if os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir)  # remove temporary directory to avoid contamination
         for fhr in range(int(fhrs[0]), int(fhrs[1]) + 1, fhr_interval):
-            for member in [f"p{str(i).zfill(2)}" for i in range(1, 31)]:
+            for member in [f"p{str(i).zfill(2)}" for i in range(1, ens_size + 1)]:
                 sdate = datetime.strftime(cur_date, "%Y-%m-%d %H:%M")
-                try:
-                    HB = Herbie(
-                        sdate,
-                        model=model,
-                        product=product,
-                        member=member,
-                        fxx=fhr,
-                        save_dir="./tmp",
-                        overwrite=True,
-                        verbose=False,
-                    )
-                    HB.download()
-                except Exception as e:
-                    print(f"Warning: Could not download {model},'{sdate}','{product}','{member}','f{fhr:03d}' : {e}")
+                HB = Herbie(
+                    sdate,
+                    model=model,
+                    product=product,
+                    member=member,
+                    fxx=fhr,
+                    save_dir="./tmp",
+                    overwrite=True,
+                    verbose=False,
+                )
+                for attempt in range(5):
+                    try:
+                        HB.download()
+                        time.sleep(3)  # avoid AWS throttling (too many downloads too fast)
+                        break  # success, exit the loop
+                    except Exception as e:
+                        print(f"attempt {attempt+1}/5: could not download {model},'{sdate}','{product}','{member}','f{fhr:03d}' : {e}")
+                        time.sleep(3)
         # ~~~~~~~~~~~
         os.makedirs(final_dest, exist_ok=True)
-        shutil.move(f'./tmp/{model}/{sdate0[:8]}', f'{final_dest}/{dcProduct[product]}')
-
+        for file in os.listdir(tmp_dir):
+            if os.path.exists(f'{final_dest}/{file}'):
+                os.remove(f'{final_dest}/{file}')
+            shutil.move(f'{tmp_dir}/{file}', f'{final_dest}')
+    # ~~~~~~~~~~~~
     cur_date += timedelta(hours=cyc_interval)

--- a/workflow/ush/herbie_get_GEFS_from_aws
+++ b/workflow/ush/herbie_get_GEFS_from_aws
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#  User the Python package Herbie to download gfs/rap/gefs data from AWS, which is more reliable
+#
+from herbie import Herbie
+from datetime import datetime, timedelta
+import os
+import shutil
+import sys
+
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 2:
+    print(f"{args[0]} YYYYMMDD-YYYYMMDD [0-70]\n")
+    print(f'  the first parameter specifies the date range to download')
+    print(f'  the second parameter specifies the fhr range to download, default to 0-70')
+    exit()
+
+date_range = args[1]
+fhr_range = args[2]
+
+model = "gefs"  # gfs, rap
+dest_path = "./downloads"
+fhr_interval = 3
+cyc_interval = 6
+
+two_dates = date_range.split("-")
+date1 = datetime.strptime(two_dates[0], "%Y%m%d")
+date2 = datetime.strptime(two_dates[1], "%Y%m%d")
+date2 += timedelta(hours=23)
+cur_date = date1
+fhrs = fhr_range.split("-")
+dcProduct = {"atmos.5": "pgrb2ap5", "atmos.5b": "pgrb2bp5"}
+
+while cur_date <= date2:
+    sdate0 = datetime.strftime(cur_date, "%Y%m%d%M")
+    for product in ["atmos.5", "atmos.5b"]:
+        final_dest = f'{dest_path}/{model.upper()}/{model}.{sdate0[:8]}/{sdate0[-2:]}'
+        if os.path.exists(f'{final_dest}/{dcProduct[product]}'):
+            print(f"'{final_dest}/{dcProduct[product]}' already exists, please rename or remove it first")
+            exit()
+        if os.path.exists(f'./tmp/{model}/{sdate0[:8]}'):
+            shutil.rmtree(f'./tmp/{model}/{sdate0[:8]}')  # remove temporary directory to avoid contamination
+        for fhr in range(int(fhrs[0]), int(fhrs[1]) + 1, fhr_interval):
+            for member in [f"p{str(i).zfill(2)}" for i in range(1, 31)]:
+                sdate = datetime.strftime(cur_date, "%Y-%m-%d %H:%M")
+                try:
+                    HB = Herbie(
+                        sdate,
+                        model=model,
+                        product=product,
+                        member=member,
+                        fxx=fhr,
+                        save_dir="./tmp",
+                        overwrite=True,
+                        verbose=False,
+                    )
+                    HB.download()
+                except Exception as e:
+                    print(f"Warning: Could not download {model},'{sdate}','{product}','{member}','f{fhr:03d}' : {e}")
+        # ~~~~~~~~~~~
+        os.makedirs(final_dest, exist_ok=True)
+        shutil.move(f'./tmp/{model}/{sdate0[:8]}', f'{final_dest}/{dcProduct[product]}')
+
+    cur_date += timedelta(hours=cyc_interval)

--- a/workflow/ush/herbie_get_GFS_from_aws
+++ b/workflow/ush/herbie_get_GFS_from_aws
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#  User the Python package Herbie to download gfs/rap/gefs data from AWS, which is more reliable
+#
+from herbie import Herbie
+from datetime import datetime, timedelta
+import os
+import shutil
+import sys
+import time
+
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 2:
+    print(f"{args[0]} YYYYMMDD-YYYYMMDD [0-70]\n")
+    print(f'  the first parameter specifies the date range to download')
+    print(f'  the second parameter specifies the fhr range to download, default to 0-70')
+    exit()
+
+date_range = args[1]
+fhr_range = args[2]
+
+model = "gfs"  # gfs, rap
+dest_path = "./downloads"
+fhr_interval = 1
+cyc_interval = 6
+
+two_dates = date_range.split("-")
+date1 = datetime.strptime(two_dates[0], "%Y%m%d")
+date2 = datetime.strptime(two_dates[1], "%Y%m%d")
+date2 += timedelta(hours=23)
+cur_date = date1
+fhrs = fhr_range.split("-")
+
+while cur_date <= date2:
+    sdate0 = datetime.strftime(cur_date, "%Y%m%d%H")
+    final_dest = f'{dest_path}/{model.upper()}/{model}.{sdate0[:8]}/{sdate0[-2:]}'
+    tmp_dir = f'./tmp/{model}/{sdate0[:8]}'
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)  # remove temporary directory to avoid contamination
+    for product in ["pgrb2.0p25", "pgrb2b.0p25"]:
+        for fhr in range(int(fhrs[0]), int(fhrs[1]) + 1, fhr_interval):
+            sdate = datetime.strftime(cur_date, "%Y-%m-%d %H:%M")
+            HB = Herbie(
+                sdate,
+                model=model,
+                product=product,
+                fxx=fhr,
+                save_dir="./tmp",
+                overwrite=True,
+                verbose=False,
+            )
+            for attempt in range(5):
+                try:
+                    HB.download()
+                    time.sleep(3)  # avoid AWS throttling (too many downloads too fast)
+                    break  # success, exit the loop
+                except Exception as e:
+                    print(f"attempt {attempt+1}/5: could not download {model},'{sdate}','{product}','f{fhr:03d}' : {e}")
+                    time.sleep(3)
+    # ~~~~~~~~~~~
+    os.makedirs(final_dest, exist_ok=True)
+    for file in os.listdir(tmp_dir):
+        if os.path.exists(f'{final_dest}/{file}'):
+            os.remove(f'{final_dest}/{file}')
+        shutil.move(f'{tmp_dir}/{file}', f'{final_dest}')
+    # ~~~~~~~~~~
+    cur_date += timedelta(hours=cyc_interval)

--- a/workflow/ush/herbie_get_RAP_from_aws
+++ b/workflow/ush/herbie_get_RAP_from_aws
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#  User the Python package Herbie to download gfs/rap/gefs data from AWS, which is more reliable
+#
+from herbie import Herbie
+from datetime import datetime, timedelta
+import os
+import shutil
+import sys
+import time
+
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 2:
+    print(f"{args[0]} YYYYMMDD-YYYYMMDD [0-70]\n")
+    print(f'  the first parameter specifies the date range to download')
+    print(f'  the second parameter specifies the fhr range to download, default to 0-70')
+    exit()
+
+date_range = args[1]
+fhr_range = args[2]
+
+model = "rap"  # gfs, rap
+dest_path = "./downloads"
+fhr_interval = 1
+cyc_interval = 1
+
+two_dates = date_range.split("-")
+date1 = datetime.strptime(two_dates[0], "%Y%m%d")
+date2 = datetime.strptime(two_dates[1], "%Y%m%d")
+date2 += timedelta(hours=3) # 23 gge.debug
+cur_date = date1
+fhrs = fhr_range.split("-")
+fhr_at_cyc = {}
+for i in range(0,24):
+    fhr_at_cyc[i] = min(int(fhrs[1]), 21)  # 21 hours for standard cycles
+for i in [3, 9, 15, 21]:
+    fhr_at_cyc[i] = min(int(fhrs[1]), 51)  # 51 hours at 03, 09, 15, 21 cycles
+
+while cur_date <= date2:
+    sdate0 = datetime.strftime(cur_date, "%Y%m%d%H")
+    final_dest = f'{dest_path}/{model.upper()}/{model}.{sdate0[:8]}'
+    tmp_dir = f'./tmp/{model}/{sdate0[:8]}'
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)  # remove temporary directory to avoid contamination
+    for product in ["wrfnat"]:
+        cur_fhr = fhr_at_cyc[int(sdate0[-2:])]
+        for fhr in range(int(fhrs[0]), cur_fhr + 1, fhr_interval):
+            sdate = datetime.strftime(cur_date, "%Y-%m-%d %H:%M")
+            HB = Herbie(
+                sdate,
+                model=model,
+                product=product,
+                fxx=fhr,
+                save_dir="./tmp",
+                overwrite=True,
+                verbose=False,
+            )
+            for attempt in range(5):
+                try:
+                    HB.download()
+                    time.sleep(3)  # avoid AWS throttling (too many downloads too fast)
+                    break  # success, exit the loop
+                except Exception as e:
+                    print(f"attempt {attempt+1}/5: could not download {model},'{sdate}','{product}','f{fhr:03d}' : {e}")
+                    time.sleep(3)
+    # ~~~~~~~~~~~
+    os.makedirs(final_dest, exist_ok=True)
+    for file in os.listdir(tmp_dir):
+        if os.path.exists(f'{final_dest}/{file}'):
+            os.remove(f'{final_dest}/{file}')
+        shutil.move(f'{tmp_dir}/{file}', f'{final_dest}')
+    # ~~~~~~~~~~
+    cur_date += timedelta(hours=cyc_interval)

--- a/workflow/ush/herbie_get_RAP_from_aws
+++ b/workflow/ush/herbie_get_RAP_from_aws
@@ -27,11 +27,11 @@ cyc_interval = 1
 two_dates = date_range.split("-")
 date1 = datetime.strptime(two_dates[0], "%Y%m%d")
 date2 = datetime.strptime(two_dates[1], "%Y%m%d")
-date2 += timedelta(hours=3) # 23 gge.debug
+date2 += timedelta(hours=23)
 cur_date = date1
 fhrs = fhr_range.split("-")
 fhr_at_cyc = {}
-for i in range(0,24):
+for i in range(0, 24):
     fhr_at_cyc[i] = min(int(fhrs[1]), 21)  # 21 hours for standard cycles
 for i in [3, 9, 15, 21]:
     fhr_at_cyc[i] = min(int(fhrs[1]), 51)  # 51 hours at 03, 09, 15, 21 cycles

--- a/workflow/ush/load_bokeh.sh
+++ b/workflow/ush/load_bokeh.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Check if the script is sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Usage: source ${0}"
+  exit 1
+fi
+
+### scripts continues here...
+ushdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck disable=SC1091
+source "${ushdir}/detect_machine.sh"
+
+module purge
+module use "${ushdir}/../../modulefiles"
+if [[ "${MACHINE}" == "gaea" ]]; then
+  if [[ -d /gpfs/f5 ]]; then
+    module load "BOKEH/${MACHINE}C5"
+  elif [[ -d /gpfs/f6 ]]; then
+    module load "BOKEH/${MACHINE}C6"
+  else
+    echo "not supported gaea cluster: ${MACHINE}"
+  fi
+else
+  module load "BOKEH/${MACHINE}"
+fi


### PR DESCRIPTION
Previously, we used `wget` to download gfs/gefs/rap data from AWS. It turned out that we got quite a few sporadic, bad, incomplete files, and they crashed the model forecasts. It took non-trivial effort to sort out all the bad files.

[Herbie](https://herbie.readthedocs.io/en/stable/) is a popular Python package for downloading NWP model data from AWS. It is more reliable in terms of downloading a complete copy of grib2 files.

This PR is to add three utilities to use the `Herbie` Python package to download gfs/gefs/rap data from AWS.

Example:
```
source workflow/ush/load_bokeh.sh
cd workflow/ush
herbie_get_GFS_from_aws  20240501-20240501  0-3
```