### PR TITLE
Implement `HYB_ENS_PATH`, allow specifying an external path for BEC ensembles

### DIFF
--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -72,7 +72,11 @@ if [[ "${HYB_WGT_ENS}" != "0" ]] && [[ "${HYB_WGT_ENS}" != "0.0" ]]; then # usin
     init_file=init.nc
     for (( ii=0; ii<7; ii=ii+1 )); do
        CDATEp=$(${NDATE} "-${ii}" "${CDATE}" )
-       ensdir=${COMINrrfs}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
+       if [[ "${HYB_ENS_PATH}" == "" ]]; then
+         ensdir=${COMINrrfs}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
+       else
+         ensdir=${HYB_ENS_PATH}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
+       fi
        ensdir_m001=${ensdir}/ic/enkf/mem001
        if [[ -s "${ensdir_m001}/${init_file}" ]]; then
          for (( iii=1; iii<31; iii=iii+1 )); do

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -55,16 +55,19 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     </or>'''
 
     elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "2":  # interpolated GDAS/GEFS
+        HYB_ENS_PATH = os.getenv("HYB_ENS_PATH", "")
+        if HYB_ENS_PATH == "":
+            HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
         RUN = 'rrfs'
         ens_dep = f'''
     <or>
-      <datadep age="00:05:00"><cyclestr  offset="0:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-1:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-2:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-3:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-4:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-5:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-6:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr  offset="0:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-1:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-2:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-3:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-4:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-5:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-6:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
     </or>'''
 
     # ~~~~


### PR DESCRIPTION
This PR implements the long-awaited `HYB_ENS_PATH`, which allows specifying an external path for BEC ensembles and hence different retros can use the same ensemble BEC for fair comparisons.