### PR TITLE
[v2.1.1-1.2] Save `log.atmosphere.0000.out` to com/ directory

### DIFF
--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -89,6 +89,7 @@ for fhr in ${history_all}; do
     ln -snf "${DATA}/history.${timestr}.nc" "${UMBRELLA_FCST_DATA}"
     ln -snf "${DATA}/diag.${timestr}.nc" "${UMBRELLA_FCST_DATA}"
     ln -snf "${DATA}/mpasout.${timestr}.nc" "${UMBRELLA_FCST_DATA}"
+    ln -snf "${DATA}/log.atmosphere.0000.out" "${UMBRELLA_FCST_DATA}"
   fi
 done
 
@@ -106,11 +107,12 @@ if (( "${num_err_log}" > 0 )) ; then
   echo "FATAL ERROR: MPAS model run failed"
   err_exit
 else
-  # spinup cycles copy mpasout to com/ directly, don't need the save_fcst task
+  # spinup cycles copy mpasout and log file to com/ directly, don't need the save_fcst task
   if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
     CDATEp=$( ${NDATE} 1 "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
     ${cpreq} "${DATA}/mpasout.${timestr}.nc" "${COMOUT}/fcst_spinup/${WGF}${MEMDIR}"
+    ${cpreq} "${DATA}/log.atmosphere.0000.out" "${COMOUT}/fcst_spinup/${WGF}${MEMDIR}"
   fi
   exit 0
 fi

--- a/scripts/exrrfs_save_fcst.sh
+++ b/scripts/exrrfs_save_fcst.sh
@@ -31,6 +31,7 @@ for fhr in ${history_all}; do
     history_file=${UMBRELLA_FCST_DATA}/history.${timestr}.nc
     diag_file=${UMBRELLA_FCST_DATA}/diag.${timestr}.nc
     mpasout_file=${UMBRELLA_FCST_DATA}/mpasout.${timestr}.nc
+    log_file=${UMBRELLA_FCST_DATA}/log.atmosphere.0000.out
 
     # wait for file available for 20 min
     for (( j=0; j < 20; j=j+1)); do
@@ -49,7 +50,9 @@ for fhr in ${history_all}; do
       # save to com
       if (( ii <= cyc_interval )) && (( ii > 0 )); then
         mpasout_path=$(realpath "${mpasout_file}")
+        log_path=$(realpath "${log_file}")
         ${cpreq} "${mpasout_path}" "${COMOUT}/fcst/${WGF}${MEMDIR}/."
+        ${cpreq} "${log_path}" "${COMOUT}/fcst/${WGF}${MEMDIR}/."
       fi
     else
       echo "ERROR, diag.${timestr}.nc or history.${timestr}.nc missing"


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR modifies `exrrfs_fcst.sh` and `exrrfs_save_fcst.sh` to now save `log.atmosphere.0000.out` to the `com/` directory. This log file contains information about the maximum wind and tracer values at each model time step. It is useful for diagnosing potential instability issues in MPAS. 

## TESTS CONDUCTED: 
Ran one cycle of both deterministic and ensemble DA to confirm that the log files are copied into `com/`. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [x] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None


