### PR TITLE
Add a few supplementary non-runtime changes

### DIFF
--- a/jobs/JRRFS_GETKF
+++ b/jobs/JRRFS_GETKF
@@ -17,12 +17,6 @@ export USHrrfs=${USHrrfs:-${HOMErrfs}/ush}
 # Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
 #
-# source the config cascade
-#source ${EXPDIR}/exp.setup
-#source ${EXPDIR}/config/config.${MACHINE}
-#source ${EXPDIR}/config/config.base
-#[[ -s ${EXPDIR}/config/config.da ]] && source ${EXPDIR}/config/config.da
-#
 export UMBRELLA_PREP_IC_DATA=${UMBRELLA_PREP_IC_DATA:-${DATAROOT}/${RUN}_prep_ic_${cyc}_${rrfs_ver}/${WGF}}
 export UMBRELLA_GETKF_DATA=${UMBRELLA_GETKF_DATA:-${DATAROOT}/${RUN}_getkf_${TYPE}_${cyc}_${rrfs_ver}/${WGF}}
 export UMBRELLA_GETKF_OBSERVER_DATA=${UMBRELLA_GETKF_OBSERVER_DATA:-${DATAROOT}/${RUN}_getkf_observer_${cyc}_${rrfs_ver}/${WGF}}

--- a/jobs/JRRFS_JEDIVAR
+++ b/jobs/JRRFS_JEDIVAR
@@ -17,12 +17,6 @@ export USHrrfs=${USHrrfs:-${HOMErrfs}/ush}
 # Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
 #
-# source the config cascade
-#source ${EXPDIR}/exp.setup
-#source ${EXPDIR}/config/config.${MACHINE}
-#source ${EXPDIR}/config/config.base
-#[[ -s ${EXPDIR}/config/config.da ]] && source ${EXPDIR}/config/config.da
-#
 if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
   export UMBRELLA_PREP_IC_DATA=${UMBRELLA_PREP_IC_DATA:-${DATAROOT}/${RUN}_prep_ic_spinup_${cyc}_${rrfs_ver}/${WGF}}
   export UMBRELLA_JEDIVAR_DATA=${UMBRELLA_JEDIVAR_DATA:-${DATAROOT}/${RUN}_jedivar_spinup_${cyc}_${rrfs_ver}/${WGF}}

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -17,7 +17,7 @@ export FCST_LENGTH=1
 export DO_FCST=${DO_FCST:-true}
 export DO_POST=${DO_POST:-true}
 export DO_IC_LBC=${DO_IC_LBC:-true}
-export USE_THE_LATEST_SATBIAS=${USE_THE_LATEST_SATBIAS:-true} # whether DA tasks use the latest satbias from the previous cycle
+export USE_THE_LATEST_SATBIAS=${USE_THE_LATEST_SATBIAS:-false} # whether DA tasks use the latest satbias from the previous cycle
 
 # PREP_LBC_LOOK_BACK_HRS
 if ${REALTIME:-false}; then

--- a/workflow/rocoto_funcs/base.py
+++ b/workflow/rocoto_funcs/base.py
@@ -32,6 +32,16 @@ def source(bash_file, optional=False):
     os.environ.update(env_vars)
 # end of source(bash_file)
 
+# run_git_command
+
+
+def run_git_command(cmd):
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    else:
+        raise RuntimeError(f"Git command failed: {' '.join(cmd)}\n{result.stderr.strip()}")
+
 # head_begin
 
 

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -30,6 +30,9 @@ from rocoto_funcs.misc import misc
 def setup_xml(HOMErrfs, expdir):
     # source the config cascade
     source(f'{expdir}/exp.setup')
+    if os.path.exists(f"{expdir}/config/satinfo") and os.getenv("USE_THE_LATEST_SATBIAS") is None:
+        env_vars = {'USE_THE_LATEST_SATBIAS': 'true'}
+        os.environ.update(env_vars)
     machine = os.getenv('MACHINE').lower()
     do_deterministic = os.getenv('DO_DETERMINISTIC', 'true').upper()
     do_ensemble = os.getenv('DO_ENSEMBLE', 'false').upper()

--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -125,13 +125,6 @@ with open(EXPin, 'r') as infile, open(EXPout, 'w') as outfile:
 
 setup_xml(HOMErrfs, expdir)
 
-if os.getenv("DO_JEDI", 'false').upper() == "TRUE":
-    print('\nIf doing satellite radiance data assimilation, run the following commands to prepare the initial satbias files:')
-    print(f'    cd  {expdir}')
-    print(f'    source qrocoto/load_qrocoto.sh')
-    print(f'    prep_satbias.sh YYYYMMDDHH [satbias_path]')
-    print(f'check https://github.com/NOAA-EMC/rrfs-workflow/wiki for more details')
-
 if os.getenv('YAML_GEN_METHOD', '1') == '1':
     # copy qrocoto utilities to expdir/qrocoto
     srcdir = f'{HOMErrfs}/workflow/ush/qrocoto'
@@ -139,8 +132,15 @@ if os.getenv('YAML_GEN_METHOD', '1') == '1':
     if os.path.exists(dstdir):
         shutil.rmtree(dstdir)
     shutil.copytree(srcdir, dstdir)
+    if os.getenv("DO_JEDI", 'false').upper() == "TRUE" and os.path.exists('satinfo'):
+        print(f'''\nRun the following commands to prepare the initial satbias files:
+  cd  {expdir}
+  source qrocoto/load_qrocoto.sh
+  prep_satbias.sh YYYYMMDDHH [satbias_path]
+check https://github.com/NOAA-EMC/rrfs-workflow/wiki for more details''')
 
 elif os.getenv('YAML_GEN_METHOD', '1') == '2':
+    print("If doing radiance DA, run `prep_satbias.sh` to prepare the initial stabias files")
     # Copy files from HOMErrfs/workflow/ush to expdir
     shutil.copy2(f'{HOMErrfs}/workflow/ush/qrocoto/prep_satbias.sh', expdir)
     source_dir = os.path.join(HOMErrfs, 'workflow', 'ush')

--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -98,7 +98,7 @@ diff_results += run_git_command(['git', 'diff', '--cached'])
 with open(f'{expdir}/config/snapshot_git_diff.txt', 'w') as outfile:
     outfile.write(diff_results)
 text = f'''#=== Auto-generation of HOMErrfs, MACHINE, etc
-# current branch: {branch};  remote: {remote_url};  the latest log:
+# {remote_url} -b {branch};  the latest log:
 #  {latest_log}
 export HOMErrfs={HOMErrfs}
 export MACHINE={machine}

--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -110,17 +110,7 @@ with open(EXPin, 'r') as infile, open(EXPout, 'w') as outfile:
                 outfile.write(text)
                 outfile.write(line)
         else:
-            rm_list = ('REALTIME=', 'RETRO_CYCLETHROTTLE=',
-                       'RETRO_TASKTHROTTLE=', 'ACCOUNT', 'QUEUE', 'PARTITION', 'RESERVATION', 'STARTTIME', 'NODES', 'WALLTIME',
-                       'CYC_INTERVAL', 'DO_DETERMINISTIC', 'DO_ENSEMBLE',
-                       )
-            found = False
-            for rmstr in rm_list:
-                if rmstr in line:
-                    found = True
-                    break
-            if not found:
-                outfile.write(line)
+            outfile.write(line)
     # ~~~~~~~~~~~~
 
 setup_xml(HOMErrfs, expdir)

--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import os
 from rocoto_funcs.setup_xml import setup_xml
-from rocoto_funcs.base import source, get_required_env
+from rocoto_funcs.base import source, get_required_env, run_git_command
 print('Aloha!')
 #
 
@@ -88,8 +88,18 @@ if os.getenv("DO_JEDI", 'false').upper() == "TRUE":
 # copyover the VERSION file
 shutil.copy(f'{HOMErrfs}/workflow/VERSION', f'{expdir}/VERSION')
 
-# generate exp.setup under $expdir
-text = f'''#=== Auto-generation of HOMErrfs, MACHINE
+# generate exp.setup, snapshot_git_diff.txt under $expdir
+latest_log = run_git_command(['git', 'log', '--oneline', '--no-decorate', '-1'])
+branch = run_git_command(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+remote = run_git_command(['git', 'config', f'branch.{branch}.remote'])
+remote_url = run_git_command(['git', 'remote', 'get-url', remote])
+diff_results = run_git_command(['git', 'diff'])
+diff_results += run_git_command(['git', 'diff', '--cached'])
+with open(f'{expdir}/config/snapshot_git_diff.txt', 'w') as outfile:
+    outfile.write(diff_results)
+text = f'''#=== Auto-generation of HOMErrfs, MACHINE, etc
+# current branch: {branch};  remote: {remote_url};  the latest log:
+#  {latest_log}
 export HOMErrfs={HOMErrfs}
 export MACHINE={machine}
 #===

--- a/workflow/ush/qrocoto/rstat.all
+++ b/workflow/ush/qrocoto/rstat.all
@@ -1,0 +1,65 @@
+#!/bin/bash
+# shellcheck disable=all
+# a wrapper to rocotostat
+# by Guoqing Ge, 2019/04
+#
+fulltasks="yes"
+module load rocoto
+#known major xml files for different systems
+xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
+# rstat [xmlfile] [offset] [cycles] [tasks] [-m=metatasks]
+get_parm_type(){
+  local str=$1
+  if [[ "${str##*.}" == "xml" ]]; then
+    xmlfile=${str%.*}
+  elif [[ "${str}" == "-m="*  ]]; then
+    metatasks=${str:3}
+  elif [[ "${str}" == "-v10"  ]]; then
+    verbose="-v 10"
+  elif [[ "${str:0:1}" == "-" ]] || [[ "${str:0:1}" == "+" ]]; then
+    offset="${str}"
+  elif [[ "${str}" =~ ^[0-9]+$ ]] ; then # all digits
+    if (( 10#${str} < 9999 )); then
+      offset="${str}"
+    else
+      cycles="${str}"
+    fi
+  elif [[ "${str:0:12}" =~ ^[0-9]+$ ]] && [[ "${str:13:12}" =~ ^[0-9]+$ ]]; then
+    cycles="${str}"
+  elif [[ ! -z ${str} ]]; then
+    tasks="${str}"
+  #else # if $1 is empty, do nothing
+  fi
+}
+
+get_parm_type "$1"
+get_parm_type "$2"
+get_parm_type "$3"
+get_parm_type "$4"
+
+# if xmlfile is not specified
+if [[ -z ${xmlfile} ]]; then
+# find if there exists major xml files under current directory
+  for s in ${xmlarray[@]}; do
+    if [ -f $s ]; then
+      xmlfile=${s%.*};found=true;break
+    fi
+  done
+  if [ ! $found ]; then # check other xml files under current directory
+    arr=(*.xml)
+    len=${#arr[@]}
+    if [ "${arr[0]}" == "*.xml" ]; then
+      echo "No xml file under current directory"; exit
+    elif [ $len -eq 1 ]; then
+      xmlfile=${arr[0]}; xmlfile=${xmlfile%.*}
+    else
+      echo "specify which xml file to use"; ls -1 *.xml; exit
+    fi
+  fi
+elif [[ ! -e "${xmlfile}.xml" ]]; then
+  echo "${xmlfile}.xml: no such file"
+  exit
+fi
+echo "ok, work on ${xmlfile}.xml..."
+
+rocotostat ${verbose} -w ${xmlfile}.xml -d ${xmlfile}.db

--- a/workflow/ush/qrocoto/satinfo_keep_sis
+++ b/workflow/ush/qrocoto/satinfo_keep_sis
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+import sys
+import os
+
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 2:
+    print(f"{sys.argv[0]} <satinfo_filename> <sis_str>")
+    print(f'  eg: {args[0]} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
+    exit()
+
+yfile = args[1]
+yfile2 = yfile + "_old001"
+sis_list = [mysis.strip() for mysis in args[2].strip().split(',')]
+#
+# find an available file name to backup the old yaml file
+if os.path.exists(yfile2):
+    knt = 1
+    yfile2 = f'{yfile}_old{knt:03}'
+    while os.path.exists(yfile2):
+        knt += 1
+        yfile2 = f'{yfile}_old{knt:03}'
+#
+os.replace(yfile, yfile2)
+with open(yfile2, 'r') as infile, open(yfile, 'w') as outfile:
+    for line in infile:
+        if line.strip().startswith("!"):
+            outfile.write(line)
+        else:
+            found = False
+            for sis in sis_list:
+                if sis in line:
+                    found = True
+                    break
+            if found:
+                outfile.write(line)

--- a/workflow/ush/qrocoto/satinfo_list_sis
+++ b/workflow/ush/qrocoto/satinfo_list_sis
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#
+import yaml
+import sys
+
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 1:
+    print(f"{sys.argv[0]} <satinfo_filename>")
+    exit()
+
+dcSatInfo = {}
+with open(args[1], 'r') as sfile:
+	for line in sfile:
+		if not line.strip().startswith("!"):
+			fields = line.split()
+			if len(fields) == 11:
+				sis = fields[0]  # sensor/instr/sat
+				if sis in dcSatInfo:
+					dcSIS = dcSatInfo[sis]
+				else:
+					dcSIS = {'channels': [], 'use_flag': [], 'error': [], 'error_cld': [], 'obserr_bound_max': [],
+							 'var_b': [], 'var_pg': [], 'use_flag_clddet': [], 'icloud': [], 'iaerosol': [],
+							 }
+				#
+				dcSIS['channels'].append(fields[1])
+				dcSIS['use_flag'].append(fields[2])
+				dcSIS['error'].append(fields[3])
+				dcSIS['error_cld'].append(fields[4])
+				dcSIS['obserr_bound_max'].append(fields[5])
+				dcSIS['var_b'].append(fields[6])
+				dcSIS['var_pg'].append(fields[7])
+				dcSIS['use_flag_clddet'].append(fields[8])
+				dcSIS['icloud'].append(fields[9])
+				dcSIS['iaerosol'].append(fields[10])
+				dcSatInfo[sis] = dcSIS
+			else:
+				print(f"read_satinfo warning: expected 11 fields\n{line}")
+
+print(f'Total number of SIS: {len(dcSatInfo)}')
+print(', '.join(dcSatInfo.keys()))

--- a/workflow/ush/qrocoto/satinfo_list_sis
+++ b/workflow/ush/qrocoto/satinfo_list_sis
@@ -11,31 +11,31 @@ if nargs < 1:
 
 dcSatInfo = {}
 with open(args[1], 'r') as sfile:
-	for line in sfile:
-		if not line.strip().startswith("!"):
-			fields = line.split()
-			if len(fields) == 11:
-				sis = fields[0]  # sensor/instr/sat
-				if sis in dcSatInfo:
-					dcSIS = dcSatInfo[sis]
-				else:
-					dcSIS = {'channels': [], 'use_flag': [], 'error': [], 'error_cld': [], 'obserr_bound_max': [],
-							 'var_b': [], 'var_pg': [], 'use_flag_clddet': [], 'icloud': [], 'iaerosol': [],
-							 }
-				#
-				dcSIS['channels'].append(fields[1])
-				dcSIS['use_flag'].append(fields[2])
-				dcSIS['error'].append(fields[3])
-				dcSIS['error_cld'].append(fields[4])
-				dcSIS['obserr_bound_max'].append(fields[5])
-				dcSIS['var_b'].append(fields[6])
-				dcSIS['var_pg'].append(fields[7])
-				dcSIS['use_flag_clddet'].append(fields[8])
-				dcSIS['icloud'].append(fields[9])
-				dcSIS['iaerosol'].append(fields[10])
-				dcSatInfo[sis] = dcSIS
-			else:
-				print(f"read_satinfo warning: expected 11 fields\n{line}")
+    for line in sfile:
+        if not line.strip().startswith("!"):
+            fields = line.split()
+            if len(fields) == 11:
+                sis = fields[0]  # sensor/instr/sat
+                if sis in dcSatInfo:
+                    dcSIS = dcSatInfo[sis]
+                else:
+                    dcSIS = {'channels': [], 'use_flag': [], 'error': [], 'error_cld': [], 'obserr_bound_max': [],
+                             'var_b': [], 'var_pg': [], 'use_flag_clddet': [], 'icloud': [], 'iaerosol': [],
+                             }
+                #
+                dcSIS['channels'].append(fields[1])
+                dcSIS['use_flag'].append(fields[2])
+                dcSIS['error'].append(fields[3])
+                dcSIS['error_cld'].append(fields[4])
+                dcSIS['obserr_bound_max'].append(fields[5])
+                dcSIS['var_b'].append(fields[6])
+                dcSIS['var_pg'].append(fields[7])
+                dcSIS['use_flag_clddet'].append(fields[8])
+                dcSIS['icloud'].append(fields[9])
+                dcSIS['iaerosol'].append(fields[10])
+                dcSatInfo[sis] = dcSIS
+            else:
+                print(f"read_satinfo warning: expected 11 fields\n{line}")
 
 print(f'Total number of SIS: {len(dcSatInfo)}')
 print(', '.join(dcSatInfo.keys()))

--- a/workflow/ush/qrocoto/satinfo_remove_sis
+++ b/workflow/ush/qrocoto/satinfo_remove_sis
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+import sys
+import os
+
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 2:
+    print(f"{sys.argv[0]} <satinfo_filename> <sis_str>")
+    print(f'  eg: {args[0]} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
+    exit()
+
+yfile = args[1]
+yfile2 = yfile + "_old001"
+sis_list = [mysis.strip() for mysis in args[2].strip().split(',')]
+#
+# find an available file name to backup the old yaml file
+if os.path.exists(yfile2):
+    knt = 1
+    yfile2 = f'{yfile}_old{knt:03}'
+    while os.path.exists(yfile2):
+        knt += 1
+        yfile2 = f'{yfile}_old{knt:03}'
+#
+os.replace(yfile, yfile2)
+with open(yfile2, 'r') as infile, open(yfile, 'w') as outfile:
+    for line in infile:
+        if line.strip().startswith("!"):
+            outfile.write(line)
+        else:
+            found = False
+            for sis in sis_list:
+                if sis in line:
+                    found = True
+                    break
+            if not found:
+                outfile.write(line)


### PR DESCRIPTION
This PR adds a few supplementary non-runtime changes:
1. In the early stage, `exp.setup` was sourced inside j-job scripts and hence we want to remove many resource-related environmental variables to keep only runtime-needed envs. However, this has been changed a long time ago. We now pass all runtime envs through job cards and no longer source the `exp.setup` file. This PR cleans up relevant outdated code snippets and comments.
2. `setup_rocoto.py` now saves a snapshot of the rrfs-workflow repo status to `expdir`. The branch/remote information and the latest one-line log will be added to `exp.setup`, and if there are any local disk changes, `expdir/config/snapshot_git_diff.txt` will save those changes. This enables us to get a full awareness of what version is used and what changes have been made for a given experiment.
3. Add three utilities to facilitate users in checking the available satellite SIS (sensor/instrument/satellite) in `satinfo` and easily modifying it.
4. Some developers want a quick command similar to `rstat`, but listing all Rocoto tasks in all cycles. This PR adds a new utility `rstat.all` to address this request.
5. Set the default value of `USE_THE_LATEST_SATBIAS` to `false`. If a user does not do satellite radiance DA, he/she does not need to deal with `USE_THE_LATEST_SATBIAS`