### PR TITLE
implement `HYB_ENS_PATH` to rrfs ensembles so as to be able to use external ensembles

### DIFF
--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -64,7 +64,11 @@ if [[ "${HYB_WGT_ENS}" != "0" ]] && [[ "${HYB_WGT_ENS}" != "0.0" ]]; then # usin
     mpasout_file=mpasout.${timestr}.nc
     for (( ii=0; ii<4; ii=ii+1 )); do
        CDATEp=$(${NDATE} "-${ii}" "${CDATE}" )
-       ensdir=${COMINrrfs}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
+       if [[ "${HYB_ENS_PATH}" == "" ]]; then
+         ensdir=${COMINrrfs}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
+       else
+         ensdir=${HYB_ENS_PATH}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
+       fi
        ensdir_m001=${ensdir}/fcst/enkf/mem001
        if [[ -s "${ensdir_m001}/${mpasout_file}" ]]; then
          for (( iii=1; iii<31; iii=iii+1 )); do

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -46,12 +46,14 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     HYB_WGT_ENS = os.getenv("HYB_WGT_ENS", "0.85")
     ens_dep = ""
     if HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "1":  # rrfsens
+        if HYB_ENS_PATH == "":
+            HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
         RUN = 'rrfs'
         ens_dep = f'''
     <or>
-      <datadep age="00:05:00"><cyclestr offset="-1:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/fcst/enkf/mem030/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-2:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/fcst/enkf/mem030/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
-      <datadep age="00:05:00"><cyclestr offset="-3:00:00">&COMROOT;/{NET}/{VERSION}/{RUN}.@Y@m@d/@H/fcst/enkf/mem030/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-1:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/fcst/enkf/mem030/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-2:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/fcst/enkf/mem030/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
+      <datadep age="00:05:00"><cyclestr offset="-3:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/fcst/enkf/mem030/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
     </or>'''
 
     elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "2":  # interpolated GDAS/GEFS

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -44,10 +44,11 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     VERSION = os.getenv("VERSION", "VERSION_NOT_DEFINED")
     HYB_ENS_TYPE = os.getenv("HYB_ENS_TYPE", "0")
     HYB_WGT_ENS = os.getenv("HYB_WGT_ENS", "0.85")
+    HYB_ENS_PATH = os.getenv("HYB_ENS_PATH", "")
+    if HYB_ENS_PATH == "":
+        HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
     ens_dep = ""
     if HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "1":  # rrfsens
-        if HYB_ENS_PATH == "":
-            HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
         RUN = 'rrfs'
         ens_dep = f'''
     <or>
@@ -57,9 +58,6 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     </or>'''
 
     elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "2":  # interpolated GDAS/GEFS
-        HYB_ENS_PATH = os.getenv("HYB_ENS_PATH", "")
-        if HYB_ENS_PATH == "":
-            HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
         RUN = 'rrfs'
         ens_dep = f'''
     <or>


### PR DESCRIPTION
PR #764 implemented `HYB_ENS_PATH` for interpolated GEFS/GDAS ensembles.
This PR extends that to rrfs ensembles so that we can use one copy of external rrfs ensembles for multiple retros.