### PR TITLE
allow creating and copying ZTD and satellite ioda files in all RDHPCS platforms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,7 @@
 	path = sorc/RRFS_UTILS
 	url = https://github.com/hu5970/RRFS_UTILS.git
         ignore = all
+[submodule "ush/wxflow"]
+	path = ush/wxflow
+	url = https://github.com/NOAA-EMC/wxflow.git
+        ignore = all

--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -82,7 +82,8 @@ ${cpreq} "${USHrrfs}"/run_bufr2ioda_gsrcsr.sh .
 
 # pyioda libraries
 PYIODALIB=$(echo "$HOMErdasapp"/build/lib/python3.*)
-export PYTHONPATH=${PYIODALIB}:${PYTHONPATH}
+WXFLOWLIB=${USHrrfs}/wxflow/src
+export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYTHONPATH}"
 
 # generate a JSON w CDATE from the template
 ${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/gen_bufr2ioda_json.py .

--- a/ush/copy_obs.sh
+++ b/ush/copy_obs.sh
@@ -25,6 +25,10 @@ mappings["ioda_proflr.nc"]="${obspath}/ioda_proflr.nc"
 mappings["ioda_rassda.nc"]="${obspath}/ioda_rassda.nc"
 mappings["ioda_sfcshp.nc"]="${obspath}/ioda_sfcshp.nc"
 mappings["ioda_vadwnd.nc"]="${obspath}/ioda_vadwnd.nc"
+mappings["ioda_gnss_ztd.nc"]="${obspath}/ioda_gnss_ztd.nc"
+# satellite observations
+mappings["ioda_abi_g16.nc"]="${obspath}/ioda_abi_g16.nc"
+mappings["ioda_abi_g18.nc"]="${obspath}/ioda_abi_g18.nc"
 
 if [[ "${DO_ENVAR_RADAR_REF}" == "true" ]] && ${jedivar}; then
   obspath="${COMOUT}/ioda_mrms_refl/${WGF}"


### PR DESCRIPTION
The Python-based ioda converters for ZTD and satellite observations use functions from the [`wxflow`](https://github.com/NOAA-EMC/wxflow) package.
This PR includes the wxflow package as a submodule so that we can generate ZTD and satellite ioda files on all supported RDHPCS platforms.

This PR also adds ZTD, abi_g16, and abi_g18 into `ush/copy_obs.sh`.

