### PR TITLE
[rrfs-mpas-jedi] Update RDASApp submodule and use new `-t` option for building 

### DIFF
--- a/sorc/build.rdas
+++ b/sorc/build.rdas
@@ -50,7 +50,7 @@ if [[ "${MACHINE}" == "gaea" ]]; then
 fi
 
 rm -rf build/
-./build.sh -m MPAS
+./build.sh -m MPAS -t NO
 
 mkdir -p "${HOMErrfs}/exec"
 echo "copy ${EXEC} to ../exec/mpasjedi_variational.x"


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

Previously, RDASApp would fail to build if the ctest data were not available. This was resolved in [RDASApp #384](https://github.com/NOAA-EMC/RDASApp/pull/384) that added a build option to skip linking/generating the test data. 

This PR updates the RDASApp hash to use this new build option. We now build RDASApp with `./build.sh -m MPAS -t NO` to skip linking the test data. This is useful for rrfs-workflow since the test data are not needed. This is also useful for testing rrfs-workflow on machines where we have not staged this test data. 


## TESTS CONDUCTED: 
Tested building RDASApp on Orion with the new hash. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [x] Orion
  - [ ] Hercules

## ISSUE: 
None

