### PR TITLE
cosmetic changes to some qrocoto utilities

### DIFF
--- a/workflow/ush/qrocoto/convinfo_keep_obs
+++ b/workflow/ush/qrocoto/convinfo_keep_obs
@@ -7,8 +7,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <convinfo_filename> <obs_str>")
-    print(f'  eg: {args[0]} convinfo "t133,q133"')
+    print(f"{os.path.basename(sys.argv[0])} <convinfo_filename> <obs_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} convinfo "t133,q133"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/convinfo_list_obs
+++ b/workflow/ush/qrocoto/convinfo_list_obs
@@ -2,11 +2,12 @@
 #
 import yaml
 import sys
+import os
 
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 1:
-    print(f"{sys.argv[0]} <convinfo_filename>")
+    print(f"{os.path.basename(sys.argv[0])} <convinfo_filename>")
     exit()
 
 dcConvInfo = {}

--- a/workflow/ush/qrocoto/convinfo_monitor_obs
+++ b/workflow/ush/qrocoto/convinfo_monitor_obs
@@ -7,8 +7,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <convinfo_filename> <obs_str>")
-    print(f'  eg: {args[0]} convinfo "t133,q133"')
+    print(f"{os.path.basename(sys.argv[0])} <convinfo_filename> <obs_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} convinfo "t133,q133"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/convinfo_remove_obs
+++ b/workflow/ush/qrocoto/convinfo_remove_obs
@@ -7,8 +7,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <convinfo_filename> <obs_str>")
-    print(f'  eg: {args[0]} convinfo "t133,q133"')
+    print(f"{os.path.basename(sys.argv[0])} <convinfo_filename> <obs_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} convinfo "t133,q133"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/convinfo_unuse_obs
+++ b/workflow/ush/qrocoto/convinfo_unuse_obs
@@ -7,8 +7,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <convinfo_filename> <obs_str>")
-    print(f'  eg: {args[0]} convinfo "t133,q133"')
+    print(f"{os.path.basename(sys.argv[0])} <convinfo_filename> <obs_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} convinfo "t133,q133"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/convinfo_use_obs
+++ b/workflow/ush/qrocoto/convinfo_use_obs
@@ -7,8 +7,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <convinfo_filename> <obs_str>")
-    print(f'  eg: {args[0]} convinfo "t133,q133"')
+    print(f"{os.path.basename(sys.argv[0])} <convinfo_filename> <obs_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} convinfo "t133,q133"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/satinfo_keep_sis
+++ b/workflow/ush/qrocoto/satinfo_keep_sis
@@ -6,8 +6,8 @@ import os
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <satinfo_filename> <sis_str>")
-    print(f'  eg: {args[0]} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
+    print(f"{os.path.basename(sys.argv[0])} <satinfo_filename> <sis_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/satinfo_list_sis
+++ b/workflow/ush/qrocoto/satinfo_list_sis
@@ -2,11 +2,12 @@
 #
 import yaml
 import sys
+import os
 
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 1:
-    print(f"{sys.argv[0]} <satinfo_filename>")
+    print(f"{os.path.basename(sys.argv[0])} <satinfo_filename>")
     exit()
 
 dcSatInfo = {}

--- a/workflow/ush/qrocoto/satinfo_remove_sis
+++ b/workflow/ush/qrocoto/satinfo_remove_sis
@@ -6,8 +6,8 @@ import os
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{sys.argv[0]} <satinfo_filename> <sis_str>")
-    print(f'  eg: {args[0]} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
+    print(f"{os.path.basename(sys.argv[0])} <satinfo_filename> <sis_str>")
+    print(f'  eg: {os.path.basename(sys.argv[0])} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
     exit()
 
 yfile = args[1]

--- a/workflow/ush/qrocoto/yaml_keep_obs
+++ b/workflow/ush/qrocoto/yaml_keep_obs
@@ -9,8 +9,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{args[0]} <yaml_file> <obs_str>\n")
-    print(f'  eg: {args[0]} jedivar.yaml "t120,q120,ps120,uv220"')
+    print(f"{os.path.basename(sys.argv[0])} <yaml_file> <obs_str>\n")
+    print(f'  eg: {os.path.basename(sys.argv[0])} jedivar.yaml "t120,q120,ps120,uv220"')
     exit()
 yfile = args[1]
 basename = yfile.rstrip(".yaml")

--- a/workflow/ush/qrocoto/yaml_list_obs
+++ b/workflow/ush/qrocoto/yaml_list_obs
@@ -2,11 +2,12 @@
 #
 import yaml
 import sys
+import os
 
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 1:
-    print(f"{sys.argv[0]} <yamlfile_name>")
+    print(f"{os.path.basename(sys.argv[0])} <yamlfile_name>")
     exit()
 
 yfile = open(args[1], 'r')

--- a/workflow/ush/qrocoto/yaml_remove_obs
+++ b/workflow/ush/qrocoto/yaml_remove_obs
@@ -9,8 +9,8 @@ import re
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{args[0]} <yaml_file> <obs_str>\n")
-    print(f'  eg: {args[0]} jedivar.yaml "t120,q120,ps120,uv220"')
+    print(f"{os.path.basename(sys.argv[0])} <yaml_file> <obs_str>\n")
+    print(f'  eg: {os.path.basename(sys.argv[0])} jedivar.yaml "t120,q120,ps120,uv220"')
     exit()
 yfile = args[1]
 basename = yfile.rstrip(".yaml")


### PR DESCRIPTION
Currently, if one runs `satinfo_remove_sis` without specifying any command line parameters, it will output the help information as follows:
```
/gpfs/f6/bil-pmp/world-shared/gge/OPSROOT/133q133uv233gefs3/exp/rrfsdet/qrocoto/satinfo_remove_sis <satinfo_filename> <sis_str>
  eg: /gpfs/f6/bil-pmp/world-shared/gge/OPSROOT/133q133uv233gefs3/exp/rrfsdet/qrocoto/satinfo_remove_sis satinfo "abi_g16,abi_g18,cris-fsr_n21"
```
This output is too verbose and NOT what we expect. it is because `sys.argv[0]` is used directly:
```
if nargs < 2:
    print(f"{sys.argv[0]} <satinfo_filename> <sis_str>")
    print(f'  eg: {args[0]} satinfo "abi_g16,abi_g18,cris-fsr_n21"')
    exit()
```
Changing it to `os.path.basename(sys.argv[0])` will give us concise and enough help information as follows:
```
satinfo_remove_sis <satinfo_filename> <sis_str>
  eg: satinfo_remove_sis satinfo "abi_g16,abi_g18,cris-fsr_n21"
```
This PR applies these cosmetic changes to affected qrocoto utilties.