### PR TITLE
Adding sfcrunoff to stream_list.atmosphere.output

### DIFF
--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.output
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.output
@@ -115,6 +115,7 @@ tslb
 soilt1
 rhosnf
 snowfallac
+sfcrunoff
 acrunoff
 grdflx
 ivgtyp


### PR DESCRIPTION
Tanya requested surface runoff (sfcrunoff) be added to the MPAS history files for real-time MPAS runs.  This PR accomplishes that.

## DESCRIPTION OF CHANGES: 
Add 'sfcrunoff" to stream_list.atmosphere.output

## TESTS CONDUCTED: 
Tested in the real-time MPAS_physics_dev1 system on Jet.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others: MPAS_physics_dev1

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

