### PR TITLE
[hotfix] Turn off hofx_scaling for uv287

### DIFF
--- a/parm/jedivar.yaml
+++ b/parm/jedivar.yaml
@@ -3039,9 +3039,6 @@ cost function:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData


### PR DESCRIPTION
This PR disables hofx scaling for uv287, which was causing unreasonable fit ratios for METAR observations. The change specifically affects only METAR wind observations. Further investigation is still required for other types of surface wind observations.