### PR TITLE
hotfix - checkDA should be able to check any directory specified

### DIFF
--- a/workflow/ush/qrocoto/checkDA
+++ b/workflow/ush/qrocoto/checkDA
@@ -8,8 +8,12 @@ import re
 def get_value(line):
     return re.search(r'<value>(.*?)</value>', line).group(1)
 
-rundir = os.path.dirname(os.path.abspath(__file__))
-expdir = os.path.dirname(rundir)
+args = sys.argv
+nargs = len(args) - 1
+if nargs < 1:
+    print(f"{os.path.basename(sys.argv[0])} <.|dir_name>")
+    exit()
+expdir = args[1]
 
 # check exp.setup
 getkf = False


### PR DESCRIPTION
Currently, when one `source qrocoto/load_qorocot.sh` under `expdir1`, the `checkDA` utility under `qrocoto` can only check the DA settings for `expdir1`. When one changes to another directory, for example `expdir2`, in the same terminal, `checkDA` still check `expdir1`. This is not expected and is a bug.  `checkDA` should be able to check any directory specified.

This PR fixes this issue.