### PR TITLE
[rrfs-mpas-jedi] Enable ADPUPA 120 surface pressure assimilation

### DIFF
--- a/parm/baseline_jedi_yamls/jedivar_b001_3denvar.yaml
+++ b/parm/baseline_jedi_yamls/jedivar_b001_3denvar.yaml
@@ -662,6 +662,279 @@ cost function:
          #- filter: GOMsaver
          #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
+         name: adpupa_stationPressure_120
+         distribution:
+           name: "RoundRobin"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_adpupa.nc"
+             missing file action: "warn"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_adpupa_stationPressure_120.nc
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [stationPressure]
+         simulated variables: [stationPressure]
+
+       obs operator:
+         name: SfcPCorrected
+         da_psfc_scheme: GSI
+         geovar_sfc_geomz: geopotential_height_at_surface
+         geovar_geomz: geopotential_height
+       linear obs operator:
+         name: Identity
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # stationPressure (120)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: passivate # accept, reject, passivate
+
+         # Reject all obs with QualityMarker > 3
+         - filter: RejectList
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 4-15
+             value: is_not_valid
+           where operator: or
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           filter variables:
+           - name: stationPressure
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: '@analysisDate@'
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online regional domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 120
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [68.115, 68.115, 68.115, 71.307, 74.576, 77.845, 79.791, 81.737, 83.684, 92.441, 101.2, 108.99, 117.75, 128.44, 144.99, 158.58, 182.93, 247.16, 269.54, 315.28, 383.38, 489.46, 577.03, 577.03, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11]
+
+         # Error inflation based on pressure check (setupps.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 120
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorSfcPressure
+               options:
+                 geovar_geomz: geopotential_height
+                 geovar_sfc_geomz: geopotential_height_at_surface
+
+#         # Error inflation based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: stationPressure
+#           where:
+#           - variable: ObsType/stationPressure
+#             is_in: 120
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [stationPressure]
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+
+         # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 10000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  ObsErrorData/stationPressure
+           minvalue: 0.0
+           maxvalue: 1000
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           minvalue: 20000.0
+           maxvalue: 120000.0
+           action:
+             name: reduce obs space
+
+         # Create temporary ObsErrorData
+         - filter: Variable Assignment
+           apply at iterations: 0,1
+           assignments:
+           - name: TempObsErrorData/stationPressure
+             type: float
+             function:
+               name: ObsFunction/Arithmetic
+               options:
+                 variables:
+                 - name: ObsErrorData/stationPressure
+           defer to post: true
+
+         # Set ObsError set "error parameter" if < "max value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 100.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             maxvalue: 100.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Set ObsError set "error parameter" if > "min value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 300.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             minvalue: 300.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Gross Error Check
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 4.0
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_not_in: 3
+           defer to post: true
+
+         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 2.8
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+           defer to post: true
+
+         # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error function: TempObsErrorData/stationPressure
+           where:
+           - variable:
+               name: TempObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
+     - obs space:
          name: adpupa_winds_220
          distribution:
            name: "RoundRobin"

--- a/parm/baseline_jedi_yamls/jedivar_b001_3denvar_sat.yaml
+++ b/parm/baseline_jedi_yamls/jedivar_b001_3denvar_sat.yaml
@@ -662,6 +662,279 @@ cost function:
          #- filter: GOMsaver
          #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
+         name: adpupa_stationPressure_120
+         distribution:
+           name: "RoundRobin"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_adpupa.nc"
+             missing file action: "warn"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_adpupa_stationPressure_120.nc
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [stationPressure]
+         simulated variables: [stationPressure]
+
+       obs operator:
+         name: SfcPCorrected
+         da_psfc_scheme: GSI
+         geovar_sfc_geomz: geopotential_height_at_surface
+         geovar_geomz: geopotential_height
+       linear obs operator:
+         name: Identity
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # stationPressure (120)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: passivate # accept, reject, passivate
+
+         # Reject all obs with QualityMarker > 3
+         - filter: RejectList
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 4-15
+             value: is_not_valid
+           where operator: or
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           filter variables:
+           - name: stationPressure
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: '@analysisDate@'
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online regional domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 120
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [68.115, 68.115, 68.115, 71.307, 74.576, 77.845, 79.791, 81.737, 83.684, 92.441, 101.2, 108.99, 117.75, 128.44, 144.99, 158.58, 182.93, 247.16, 269.54, 315.28, 383.38, 489.46, 577.03, 577.03, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11]
+
+         # Error inflation based on pressure check (setupps.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 120
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorSfcPressure
+               options:
+                 geovar_geomz: geopotential_height
+                 geovar_sfc_geomz: geopotential_height_at_surface
+
+#         # Error inflation based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: stationPressure
+#           where:
+#           - variable: ObsType/stationPressure
+#             is_in: 120
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [stationPressure]
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+
+         # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 10000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  ObsErrorData/stationPressure
+           minvalue: 0.0
+           maxvalue: 1000
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           minvalue: 20000.0
+           maxvalue: 120000.0
+           action:
+             name: reduce obs space
+
+         # Create temporary ObsErrorData
+         - filter: Variable Assignment
+           apply at iterations: 0,1
+           assignments:
+           - name: TempObsErrorData/stationPressure
+             type: float
+             function:
+               name: ObsFunction/Arithmetic
+               options:
+                 variables:
+                 - name: ObsErrorData/stationPressure
+           defer to post: true
+
+         # Set ObsError set "error parameter" if < "max value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 100.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             maxvalue: 100.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Set ObsError set "error parameter" if > "min value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 300.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             minvalue: 300.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Gross Error Check
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 4.0
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_not_in: 3
+           defer to post: true
+
+         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 2.8
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+           defer to post: true
+
+         # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error function: TempObsErrorData/stationPressure
+           where:
+           - variable:
+               name: TempObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
+     - obs space:
          name: adpupa_winds_220
          distribution:
            name: "RoundRobin"

--- a/parm/baseline_jedi_yamls/jedivar_b001_3dvar.yaml
+++ b/parm/baseline_jedi_yamls/jedivar_b001_3dvar.yaml
@@ -683,6 +683,279 @@ cost function:
          #- filter: GOMsaver
          #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
+         name: adpupa_stationPressure_120
+         distribution:
+           name: "RoundRobin"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_adpupa.nc"
+             missing file action: "warn"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_adpupa_stationPressure_120.nc
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [stationPressure]
+         simulated variables: [stationPressure]
+
+       obs operator:
+         name: SfcPCorrected
+         da_psfc_scheme: GSI
+         geovar_sfc_geomz: geopotential_height_at_surface
+         geovar_geomz: geopotential_height
+       linear obs operator:
+         name: Identity
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # stationPressure (120)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: passivate # accept, reject, passivate
+
+         # Reject all obs with QualityMarker > 3
+         - filter: RejectList
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 4-15
+             value: is_not_valid
+           where operator: or
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           filter variables:
+           - name: stationPressure
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: '@analysisDate@'
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online regional domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 120
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [68.115, 68.115, 68.115, 71.307, 74.576, 77.845, 79.791, 81.737, 83.684, 92.441, 101.2, 108.99, 117.75, 128.44, 144.99, 158.58, 182.93, 247.16, 269.54, 315.28, 383.38, 489.46, 577.03, 577.03, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11]
+
+         # Error inflation based on pressure check (setupps.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 120
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorSfcPressure
+               options:
+                 geovar_geomz: geopotential_height
+                 geovar_sfc_geomz: geopotential_height_at_surface
+
+#         # Error inflation based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: stationPressure
+#           where:
+#           - variable: ObsType/stationPressure
+#             is_in: 120
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [stationPressure]
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+
+         # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 10000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  ObsErrorData/stationPressure
+           minvalue: 0.0
+           maxvalue: 1000
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           minvalue: 20000.0
+           maxvalue: 120000.0
+           action:
+             name: reduce obs space
+
+         # Create temporary ObsErrorData
+         - filter: Variable Assignment
+           apply at iterations: 0,1
+           assignments:
+           - name: TempObsErrorData/stationPressure
+             type: float
+             function:
+               name: ObsFunction/Arithmetic
+               options:
+                 variables:
+                 - name: ObsErrorData/stationPressure
+           defer to post: true
+
+         # Set ObsError set "error parameter" if < "max value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 100.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             maxvalue: 100.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Set ObsError set "error parameter" if > "min value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 300.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             minvalue: 300.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Gross Error Check
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 4.0
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_not_in: 3
+           defer to post: true
+
+         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 2.8
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+           defer to post: true
+
+         # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error function: TempObsErrorData/stationPressure
+           where:
+           - variable:
+               name: TempObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
+     - obs space:
          name: adpupa_winds_220
          distribution:
            name: "RoundRobin"

--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -17,7 +17,7 @@ ${cpreq} "${EXECrrfs}"/bufr2ioda.x .
 REFERENCE_TIME="${CDATE:0:4}-${CDATE:4:2}-${CDATE:6:2}T${CDATE:8:2}:00:00Z"
 yaml_list=(
 "prepbufr_adpsfc.yaml"
-"prepbufr_adpupa.yaml"
+#"prepbufr_adpupa.yaml"
 "prepbufr_aircar.yaml"
 "prepbufr_aircft.yaml"
 "prepbufr_ascatw.yaml"
@@ -32,7 +32,7 @@ if (( ${YAML_GEN_METHOD:-1} == 2 )); then
   # For YAML_GEN_METHOD=2 we can use all obs. vadwnd not yet ready.
   yaml_list=(
   "prepbufr_adpsfc.yaml"
-  "prepbufr_adpupa.yaml"
+  #"prepbufr_adpupa.yaml"
   "prepbufr_aircar.yaml"
   "prepbufr_aircft.yaml"
   "prepbufr_ascatw.yaml"
@@ -73,6 +73,8 @@ done
 # run python bufr2ioda tool for ZTD and AMV bufr obs
 # --------------------------------------------------
 HOMErdasapp=${HOMErrfs}/sorc/RDASApp/
+${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.json .
+${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.py .
 ${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/bufr2ioda_ztd.py .
 #${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/bufr2ioda_satwnd.py .
 ${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/bufr2ioda.json .
@@ -85,13 +87,20 @@ PYIODALIB=$(echo "$HOMErdasapp"/build/lib/python3.*)
 WXFLOWLIB=${USHrrfs}/wxflow/src
 export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYTHONPATH}"
 
-# generate a JSON w CDATE from the template
+# generate a JSON w CDATE from the template and convert to IODA
 ${cpreq} "${HOMErdasapp}"/rrfs-test/IODA/python/gen_bufr2ioda_json.py .
-./gen_bufr2ioda_json.py -t bufr2ioda.json -o bufr2ioda_0.json
+# ADPUPA
+./gen_bufr2ioda_json.py -t bufr2ioda_adpupa_prepbufr.json -o bufr2ioda_adpupa_prepbufr_0.json
+./bufr2ioda_adpupa_prepbufr.py -c bufr2ioda_adpupa_prepbufr_0.json
 
+# ZTD
+./gen_bufr2ioda_json.py -t bufr2ioda.json -o bufr2ioda_0.json
 ./bufr2ioda_ztd.py -c bufr2ioda_0.json
+
+# SATWND
 #./bufr2ioda_satwnd.py -c bufr2ioda_0.json
-#convert abi gsrcsr bufr to ioda
+
+# GSRCSR
 ln -sf abibufr "rap.t${cyc}z.gsrcsr.tm00.bufr_d"
 ./run_bufr2ioda_gsrcsr.sh "${CDATE}" rap "${DATA}" "${DATA}" "${DATA}" "${HOMErdasapp}"
 cp "rap.t${cyc}z.abi_g16.tm00.nc" "ioda_abi_g16.nc"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Switched to using the python converter for generating all adpupa observations (the only way to get the surface pressure obs is to use the python version).
- [Won't change results] Updated the baseline yamls and passivated adpupa 120 surface pressure.

## TESTS CONDUCTED: 
Tested a few cycles on Hera with the baseline retro.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- [Fixes the issue(s) mentioned in #9999](https://github.com/NOAA-EMC/RDASApp/pull/409/files)


