### PR TITLE
Update UPP hash in real-time parallel

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = 17b4d1d
+hash = 891786a
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the UPP hash is updated to #891786a to match what is now being used in the real-time parallel starting with the 6/23 12Z cycle.  The other UPP updates were already added to the main branch of rrfs-workflow as part of PR #800 and a summary of the post changes is included here for reference:
   - Encode the REFS grib2 output with product definition template 4.1
   - Remove hardcoded bucket accumulation time interval of 6 hours for ensemble products
   - Update the grib2 precision for two cloud ceiling height fields
   - Remove an experimental cloud ceiling diagnostic field (CEIL:cloud base)
   - Remove 2-m potential temperature
   - Time labeling fix for 1-hr averaged PM2.5 and PM10 products - labeled as “Total Aerosol” instead of “Missing.”
   - Re-add PMTF and PMTC at all 65 hybrid levels to natlev files (change was lost when switching to ecflow)
   - Re-add SNOWC to prslev and natlev files (change was lost when switching to ecflow)
   - Re-remove hydrometeor-based VIL from prslev and natlev files (change was lost when switching to ecflow)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
The post changes were tested on the development machine several weeks ago, and they were promoted to the real-time parallel on Cactus today.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others: