### PR TITLE
update build.mpas based on the MPAS-Model changes, where new build options were added for WCOSS2 and Ursa

### DIFF
--- a/sorc/build.mpas
+++ b/sorc/build.mpas
@@ -17,17 +17,11 @@ if [[ "${MACHINE}" == "wcoss2" ]]; then
   if [[ -f "${BUILD_VERSION_FILE}" ]]; then
     source "${BUILD_VERSION_FILE}"
   fi
-  compiler_str="ftn"
-  export FFLAGS_PROMOTION="-real-size 64"
-  export FFLAGS_OPT="-O3 -convert big_endian -free -align array64byte"
-  export CFLAGS_OPT="-O3"
-  export CXXFLAGS_OPT="-O3"
-  export LDFLAGS_OPT="-O3"
+  compiler_str="ftn-wcoss2"
 elif [[ "${MACHINE}" == "gaea" ]]; then
   compiler_str="ifort"
 elif [[ "${MACHINE}" == "ursa" ]]; then
-  export CC_SERIAL=icx
-  export CXX_SERIAL=icpx
+  compiler_str="intel-mpi-ursa"
 fi
 
 module purge                      


### PR DESCRIPTION
We discussed the best way to move forward for the changes to MPAS-Model/Makefile in https://github.com/ufs-community/MPAS-Model/pull/141 with the model experts and it has been determined that adding new build sections is preferred as this make it much easier to sync our MPAS-Model code with the NCAR one.

This PR is to make changes needed on the workflow side to accomodate the above changes.