### PR TITLE
Turn off REFS native level output

### DIFF
--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -462,7 +462,10 @@ fi
 #-----------------------------------------------------------------------
 #
 cpreq -p ${prslev} ${COMOUT}
-cpreq -p ${natlev} ${COMOUT}
+# Native level output has been turned off for ensemble forecasts
+if [ ${WGF} != "ensf" ]; then
+  cpreq -p ${natlev} ${COMOUT}
+fi
 # Only one latlons_corners file per cycle is needed in COMOUT - make this change later
 if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
   cpreq -p latlons_corners.txt.f${fhr} ${COMOUT}

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = 8a5363f
+hash = bdb080f
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the native level (NATLEV) output is turned off in the REFS in order to reduce the amount of data written to COMOUT.  This change would reduce COM storage by about ~2.3 TB/long cycle (00/06/12/18Z). The NATLEV section has been removed from the REFS UPP control files (see UPP PR [#1259](https://github.com/NOAA-EMC/UPP/pull/1259) to release/rrfs_v1 for those changes, as the fix/upp directory is no longer included in rrfs-workflow).

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
A single cycle of REFS output was created on Cactus and is available in this directory:
/lfs/h3/emc/lam/noscrub/ecflow/ptmp/emc.lam/ecflow_rrfs/para/com/rrfs/v1.0/refs.20250709/00/

This change was tested alongside the switch to g2tmpl/1.15.0 (#839 ).  Confirmed that natlev files were not generated, and the generating process ID for REFS is 136.

@MatthewPyle-NOAA , @lgannoaa , and @ShunLiu-NOAA if the changes look good to you, I can implement this in the real-time parallel today.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Resolves issue #841 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

