### PR TITLE
[rrfs-mpas-jedi] Disable `config_do_DAcycling` for GETKF to prevent MPAS error

### DIFF
--- a/parm/streams.atmosphere.getkf
+++ b/parm/streams.atmosphere.getkf
@@ -6,11 +6,23 @@
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
+<stream name="da_state"
+        type="input;output"
+        precision="single"
+        clobber_mode="truncate"
+        filename_template="foo.nc"
+        packages="jedi_da"
+        io_type="pnetcdf,cdf5"
+        input_interval="initial_only"
+        output_interval="1:00:00" >
+        <file name="stream_list/stream_list.atmosphere.da_state"/>
+</stream>
+
 <stream name="background"
         type="input;output"
         precision="single"
         io_type="pnetcdf,cdf5"
-        filename_template="foo.nc"
+        filename_template="foo1.nc"
         input_interval="none"
         output_interval="none"
         clobber_mode="overwrite">

--- a/scripts/exrrfs_getkf.sh
+++ b/scripts/exrrfs_getkf.sh
@@ -37,14 +37,13 @@ fi
 #
 # determine whether to begin new cycles and link correct ensembles
 #
+do_DAcycling='false'
 if [[ -r "${UMBRELLA_PREP_IC_DATA}/mem001/init.nc" ]]; then
   start_type='cold'
-  do_DAcycling='false'
   initial_file='init.nc'
   mkdir -p ana
 else
   start_type='warm'
-  do_DAcycling='true'
   initial_file='mpasin.nc'
 fi
 # link ensembles to data/ens/


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR addresses changes introduced in #819 which updated MPAS-Model to read the `da_state` stream if `config_do_DAcycling = true`. The `da_state` stream is not used by GETKF but the current MPAS code still throws an error if this stream is not defined for the GETKF tasks. 

To avoid reading the `da_state` stream, this PR explicitly sets `config_do_DAcycling = false` for the GETKF tasks. However, we still include the `da_state` stream in `streams.atmosphere.getkf` to suppress warning messages from MPAS-Model when it makes calls that expect the stream to be defined.

Note: this is likely a temporary fix until we can update MPAS for a permanent solution. 

## TESTS CONDUCTED: 

This change was tested with the GETKF observer task which completed successfully and produced identical `jdiag` files to those generated prior to #819.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
#848 

