### PR TITLE
[main] Restore REFS f00 native level output

### DIFF
--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -462,8 +462,8 @@ fi
 #-----------------------------------------------------------------------
 #
 cpreq -p ${prslev} ${COMOUT}
-# Native level output has been turned off for ensemble forecasts
-if [ ${WGF} != "ensf" ]; then
+# Native level output is disabled for ensemble forecasts after f00
+if [[ -f ${natlev} ]]; then
   cpreq -p ${natlev} ${COMOUT}
 fi
 # Only one latlons_corners file per cycle is needed in COMOUT - make this change later

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = bdb080f
+hash = 86079d3
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The REFS native level output was turned off last week with PR #847 .  Matt and Jacob requested that the f00 native level (NATLEV) output be restored, so the f00 UPP control file for REFS is reverted back to its previous version.
- The following files were also updated in the `rrfs/para/packages/e701e12` and `rrfs/para/packages/d754653` on Cactus (exec and fix directories are not included on Github):
   - `exec/upp.x` (re-compiled with #86079d3 of the release/rrfs_v1 branch of UPP)
   - `fix/upp/postxconfig-NT-refs_f00.txt`
   - `fix/upp/refs_postcntrl_f00.xml`

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Two standalone UPP tests were successfully completed on WCOSS2; one for f00 with the NATLEV file generated, and another for f18 with no NATLEV file. The output directories are located here on Cactus:
```
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_refs_2025071411_f00
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_refs_2025040112_f18
```

The rrfs-workflow changes herein will be tested on Cactus before promotion to the real-time parallel on Dogwood.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others: Standalone UPP tests.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #850 