### PR TITLE
[rrfs-mpas-jedi] Update MPAS-Model submodule to ufs-community repo 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
         ignore = all
 [submodule "sorc/MPAS-Model"]
 	path = sorc/MPAS-Model
-	url = https://github.com/RRFSx/MPAS-Model
+	url = https://github.com/ufs-community/MPAS-Model
         branch = gsl/develop
         ignore = all
 [submodule "sorc/RDASApp"]


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR updates the MPAS-Model submodule to point to the official `ufs-community/MPAS-Model` repository, replacing the temporary fork at `RRFSx/MPAS-Model`.

We had previously used the `RRFSx` fork to incorporate necessary fixes related to the `da_state` stream which improved the accuracy of model restarts. These fixes have since been merged upstream (https://github.com/ufs-community/MPAS-Model/pull/137), making it possible to return to the community-maintained repository.

In addition to the `da_state` stream updates, this submodule bump includes other changes introduced upstream. These additional updates may impact our retros and thus should be validated through additional testing.

## TESTS CONDUCTED: 
None

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

