### PR TITLE
Updates for the Hera /scratch[1,2] -> /scratch[3,4] transition

### DIFF
--- a/modulefiles/BOKEH/hera.lua
+++ b/modulefiles/BOKEH/hera.lua
@@ -8,7 +8,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-prepend_path("MODULEPATH", '/scratch1/BMC/wrfruc/gge/Miniforge3/modulefiles')
+prepend_path("MODULEPATH", '/scratch3/BMC/wrfruc/hera/Miniforge3/modulefiles')
 
 load("Miniforge3/24.11.3-2")
 load("bokeh/3.7.0")

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -7,7 +7,7 @@ export WGF="det"   # working group function = "det", "enkf", "ens", "firewx"
 export EXP_NAME=hrly_12km
 export VERSION=$(cat ./VERSION)
 export TAG=d12km
-export OPSROOT=/scratch1/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
+export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
 export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=yes
@@ -84,10 +84,10 @@ export LBC_EXTRN_MDL_NAME_PATTERN=${IC_EXTRN_MDL_NAME_PATTERN}
 export LBC_EXTRN_MDL_NAME_PATTERN_B=${IC_EXTRN_MDL_NAME_PATTERN_B}
 case ${MACHINE} in
   "hera")
-    export IC_EXTRN_MDL_BASEDIR="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GFS"
+    export IC_EXTRN_MDL_BASEDIR="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSIAC="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="wrfruc"
     export QUEUE="batch"
     export PARTITION="hera"

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -7,7 +7,7 @@ export WGF="det"   # working group function = "det", "enkf", "ens", "firewx"
 export EXP_NAME=hrly_3km
 export VERSION=$(cat ./VERSION)
 export TAG=d3km
-export OPSROOT=/scratch1/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
+export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
 export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=yes
@@ -83,10 +83,10 @@ export LBC_EXTRN_MDL_NAME_PATTERN=${IC_EXTRN_MDL_NAME_PATTERN}
 export LBC_EXTRN_MDL_NAME_PATTERN_B=${IC_EXTRN_MDL_NAME_PATTERN_B}
 case ${MACHINE} in
   "hera")
-    export IC_EXTRN_MDL_BASEDIR="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GFS"
+    export IC_EXTRN_MDL_BASEDIR="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSIAC="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="wrfruc"
     export QUEUE="batch"
     export PARTITION="hera"

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -7,7 +7,7 @@ export WGF="enkf"   # working group function = "det", "enkf", "ens", "firewx"
 export EXP_NAME=hrly_12km
 export VERSION=$(cat ./VERSION)
 export TAG=e12km
-export OPSROOT=/scratch1/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
+export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
 export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=yes
@@ -77,10 +77,10 @@ export LBC_EXTRN_MDL_NAME_PATTERN=${IC_EXTRN_MDL_NAME_PATTERN}
 export LBC_EXTRN_MDL_NAME_PATTERN_B=${IC_EXTRN_MDL_NAME_PATTERN_B}
 case ${MACHINE} in
   "hera")
-    export IC_EXTRN_MDL_BASEDIR="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GEFS"
+    export IC_EXTRN_MDL_BASEDIR="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSIAC="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="wrfruc"
     export QUEUE="batch"
     export PARTITION="hera"

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -8,7 +8,7 @@ export WGF="enkf"   # working group function = "det", "enkf", "ens", "firewx"
 export EXP_NAME=hrly_3km
 export VERSION=$(cat ./VERSION)
 export TAG=e3km
-export OPSROOT=/scratch1/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
+export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
 export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=yes
@@ -78,10 +78,10 @@ export LBC_EXTRN_MDL_NAME_PATTERN=${IC_EXTRN_MDL_NAME_PATTERN}
 export LBC_EXTRN_MDL_NAME_PATTERN_B=${IC_EXTRN_MDL_NAME_PATTERN_B}
 case ${MACHINE} in
   "hera")
-    export IC_EXTRN_MDL_BASEDIR="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GEFS"
+    export IC_EXTRN_MDL_BASEDIR="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/scratch2/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSIAC="/scratch4/BMC/rtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="wrfruc"
     export QUEUE="batch"
     export PARTITION="hera"

--- a/workflow/ush/init.sh
+++ b/workflow/ush/init.sh
@@ -10,7 +10,7 @@ case ${MACHINE} in
     FIX_RRFS_LOCATION=/lfs/h2/emc/da/noscrub/samuel.degelia/FIX_RRFS2
     ;;
   hera)
-    FIX_RRFS_LOCATION=/scratch2/BMC/rtrr/FIX_RRFS2
+    FIX_RRFS_LOCATION=/scratch4/BMC/rtrr/FIX_RRFS2
     ;;
   ursa)
     FIX_RRFS_LOCATION=/scratch4/BMC/rtrr/FIX_RRFS2

--- a/workflow/ush/linter_pythoncheck.sh
+++ b/workflow/ush/linter_pythoncheck.sh
@@ -8,7 +8,7 @@ case ${MACHINE} in
     EXEC_DIR=/to/be/added
     ;;
   hera)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/hera/Miniforge3/envs/bokeh/bin
     ;;
   ursa)
     EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin

--- a/workflow/ush/linter_pythonmodify.sh
+++ b/workflow/ush/linter_pythonmodify.sh
@@ -8,7 +8,7 @@ case ${MACHINE} in
     EXEC_DIR=/to/be/added
     ;;
   hera)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/hera/Miniforge3/envs/bokeh/bin
     ;;
   ursa)
     EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin

--- a/workflow/ush/linter_shellcheck.sh
+++ b/workflow/ush/linter_shellcheck.sh
@@ -8,10 +8,10 @@ case ${MACHINE} in
     EXEC_DIR=/to/be/added
     ;;
   hera)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/hera/Miniforge3/envs/bokeh/bin
     ;;
   ursa)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;
   jet)
     EXEC_DIR=/lfs6/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin

--- a/workflow/ush/linter_shellcheck_all.sh
+++ b/workflow/ush/linter_shellcheck_all.sh
@@ -9,10 +9,10 @@ case ${MACHINE} in
     EXEC_DIR=/to/be/added
     ;;
   hera)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/hera/Miniforge3/envs/bokeh/bin
     ;;
   ursa)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;
   jet)
     EXEC_DIR=/lfs6/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin

--- a/workflow/ush/linter_yamlcheck.sh
+++ b/workflow/ush/linter_yamlcheck.sh
@@ -8,7 +8,7 @@ case ${MACHINE} in
     EXEC_DIR=/to/be/added
     ;;
   hera)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    EXEC_DIR=/scratch3/BMC/wrfruc/hera/Miniforge3/envs/bokeh/bin
     ;;
   ursa)
     EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin


### PR DESCRIPTION
From the Hera system admin:
- /scratch[1,2] will be set to read only on 7/15/25, plan to complete migrating your data to /scratch[3,4] by 7/31/25.
- /scratch[1,2] is planned to be decommissioned (unmounted) at the ~8/5/25 NESCC maintenance downtime.

This PR gets the rrfs-workflow ready for this transition.