### PR TITLE
[rrfs-mpas-jedi] Add a new "south3.5km" MPAS domain

### DIFF
--- a/parm/namelist.mpassit
+++ b/parm/namelist.mpassit
@@ -13,8 +13,8 @@
     dx = @dx@
     dy = @dx@
     ref_lat = @ref_lat@
-    ref_lon = -97.5
+    ref_lon = @ref_lon@
     truelat1 = @ref_lat@
     truelat2 = @ref_lat@
-    stand_lon = -97.5
+    stand_lon = @ref_lon@
 /

--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -16,6 +16,10 @@ elif [[ ${MESH_NAME} == "conus3km" ]]; then
   dt=20
   substeps=4
   radt=15
+elif [[ ${MESH_NAME} == "south3.5km" ]]; then
+  dt=25
+  substeps=4
+  radt=15
 else
   echo "Unknown MESH_NAME, exit!"
   err_exit
@@ -68,6 +72,9 @@ if [[ "${MESH_NAME}" == "conus12km" ]]; then
 elif [[ "${MESH_NAME}" == "conus3km" ]]; then
   pio_num_iotasks=40
   pio_stride=20
+elif [[ "${MESH_NAME}" == "south3.5km" ]]; then
+  pio_num_iotasks=10
+  pio_stride=24
 fi
 file_content=$(< "${PARMrrfs}/${physics_suite}/namelist.atmosphere") # read in all content
 eval "echo \"${file_content}\"" > namelist.atmosphere

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -22,11 +22,19 @@ if [[ "${MESH_NAME}" == "conus12km" ]]; then
   ny=280
   dx=12000.0
   ref_lat=39.0
+  ref_lon=-97.5
 elif [[ "${MESH_NAME}" == "conus3km" ]]; then
   nx=1800
   ny=1060
   dx=3000.0
   ref_lat=38.5
+  ref_lon=-97.5
+elif [[ "${MESH_NAME}" == "south3.5km" ]]; then
+  nx=660
+  ny=440
+  dx=3500.0
+  ref_lat=34.0
+  ref_lon=-91.5
 fi
 #
 #
@@ -71,7 +79,7 @@ for (( ii=0; ii<"${num_fhrs}"; ii=ii+"${group_total_num}" )); do
 
       # generate the naemlist on fly
       sed -e "s/@timestr@/${timestr}/" -e "s/@nx@/${nx}/" -e "s/@ny@/${ny}/" -e "s/@dx@/${dx}/" \
-          -e "s/@ref_lat@/${ref_lat}/" "${PARMrrfs}/namelist.mpassit" > namelist.mpassit
+          -e "s/@ref_lat@/${ref_lat}/" -e "s/@ref_lon@/${ref_lon}/" "${PARMrrfs}/namelist.mpassit" > namelist.mpassit
 
       # run the executable
       source prep_step


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
This PR address https://github.com/NOAA-EMC/rrfs-workflow/issues/861, the need for a small convection-allowing MPAS domain for rapid development and testing of radar data assimilation.  Information about this new domain is added to two scripts.  In addition, stand_lon is now passed to the mpassit namelist rather than being a hard-coded number.

Quite a few fix files will accompany this PR, and I'll need some help making them available on all machines.  Currently, these files are available here on Jet:
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/meshes/south3.5km.grid.nc
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/meshes/south3.5km.invariant.nc_L60_GEFS
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/meshes/south3.5km.invariant.nc_L60_GFS
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/meshes/south3.5km.invariant.nc_L60_RAP
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/meshes/south3.5km.static.nc
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/meshes/south3.5km.ugwp_oro_data.nc
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info.part.120
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info.part.1200
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info.part.240
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info.part.360
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info.part.480
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/graphinfo/south3.5km.graph.info.part.600
/mnt/lfs5/BMC/wrfruc/ddowell/rrfs-workflow/fix/mpassit/geo_em.d01.nc_south3.5km

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
With theses changes and the fix files, I have tested hourly deterministic and ensemble cycling, without data assimilation, on Jet for the May 8, 2024 case.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- See discussion in https://github.com/NOAA-EMC/rrfs-workflow/issues/861

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

