### PR TITLE
[main] Redesign RRFS forecast RESTART capability to work with bit-identical executable

### DIFF
--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -374,7 +374,7 @@ else
   if [ ${BKTYPE} -eq 1 ]; then
     target="sfc_data.tile${TILE_RGNL}.halo${NH0}.nc"
     symlink="sfc_data.nc"
-    #### Additional logic to exam if sfc_data.nc already exist
+    # Additional logic to exam if sfc_data.nc already exist
     if [ ! -s sfc_data.nc ]; then
       if [ -f "${target}" ]; then
         ln -sf ${relative_or_null} $target $symlink
@@ -400,11 +400,6 @@ if [ "${DO_SMOKE_DUST}" = "TRUE" ]; then
   ln -snf  ${FIX_SMOKE_DUST}/${PREDEF_GRID_NAME}/emi_data.nc      ${DATA}/INPUT/emi_data.nc
   yyyymmddhh=${CDATE:0:10}
   echo ${yyyymmddhh}
-  #### if [ ${CYCLE_TYPE} = "spinup" ]; then
-  ####   smokefile=${COMrrfs}/RAVE_INTP/SMOKE_RRFS_data_${yyyymmddhh}00_spinup.nc
-  #### else
-  ####   smokefile=${COMrrfs}/RAVE_INTP/SMOKE_RRFS_data_${yyyymmddhh}00.nc
-  #### fi
   smokefile=${COMrrfs}/RAVE_INTP/SMOKE_RRFS_data_${yyyymmddhh}00.nc
   echo "try to use smoke file=",${smokefile}
   if [ -f ${smokefile} ]; then
@@ -462,17 +457,6 @@ ln -sf ${relative_or_null} ${FIXam}/aeroclim.m??.nc ${DATA}
 #
 #-----------------------------------------------------------------------
 #
-# If running this cycle/ensemble member combination more than once (e.g.
-# using rocotoboot), remove any time stamp file that may exist from the
-# previous attempt.
-#
-#-----------------------------------------------------------------------
-#
-cd ${DATA}
-rm -f time_stamp.out
-#
-#-----------------------------------------------------------------------
-#
 # Create links in the current run directory to cycle-independent (and
 # ensemble-member-independent) model input files in the main experiment
 # directory.
@@ -507,7 +491,7 @@ if [ ${BKTYPE} -eq 0 ]; then
   # cycling, using namelist for cycling forecast
   if [ "${STOCH}" = "TRUE" ]; then
     cpreq -p ${FV3_NML_RESTART_STOCH_FP} ${DATA}/${FV3_NML_FN}
-   else
+  else
     cpreq -p ${FV3_NML_RESTART_FP} ${DATA}/${FV3_NML_FN}
   fi
 else
@@ -529,7 +513,6 @@ if [ "${STOCH}" = "TRUE" ]; then
     ensmem_num=$(echo "${ENSMEM_INDX}" | awk '{print $1+0}')
     cpreq -p ${FV3_NML_RESTART_STOCH_FP}_ensphy${ensmem_num} ${DATA}/${FV3_NML_FN}_base 
     rm -fr ${DATA}/field_table
-    #### cpreq -p ${PARMrrfs}/field_table.rrfsens_phy${ENSMEM_INDX} ${DATA}/field_table
     cpreq -p ${PARMrrfs}/field_table.rrfsens_phy0${ENSMEM_INDX} ${DATA}/field_table
   else
     cpreq -p ${DATA}/${FV3_NML_FN} ${DATA}/${FV3_NML_FN}_base
@@ -574,9 +557,6 @@ else
   FCST_LEN_HRS=${FCST_LEN_HRS_CYCLES[$cyc]}
 fi
 
-#### dev overwrite
-#### FCST_LEN_HRS=60
-#### export FCST_LEN_HRS_SPINUP=60
 #
 #-----------------------------------------------------------------------
 #
@@ -657,21 +637,9 @@ flag_fcst_restart="FALSE"
 coupler_res_ct=0
 DO_FCST_RESTART=${DO_FCST_RESTART:-"TRUE"}
 
-#if [ ${CYCLE_TYPE} = "spinup" ]; then
-#  FCST_LEN_HRS=${FCST_LEN_HRS_SPINUP}
-#else
-#  FCST_LEN_HRS=${FCST_LEN_HRS_CYCLES[$cyc]}
-#fi
-
-##### dev overwrite
-#FCST_LEN_HRS=60
-#export FCST_LEN_HRS_SPINUP=60
-
-
 # Get the current restart set count from shared restart location in the Umbrella Data
 if [ -d ${shared_forecast_restart_data} ]; then
-  set +eu
-  coupler_res_ct=$(eval ls -A ${shared_forecast_restart_data}/*.coupler.res|wc -l)
+  coupler_res_ct=$(find ${shared_forecast_restart_data} -type f -name "*.coupler.res"|wc -l)
 fi
 
 # make symbolic links to write forecast RESTART files directly to shared forecast RESTART location
@@ -683,8 +651,10 @@ if [ ${CYCLE_TYPE} = "spinup" ]; then
 fi
 if [ $FCST_LEN_HRS -gt 0 ]; then
   cd ${DATA}/RESTART
-  #### [[ -e ${umbrella_forecast_data}/forecast_clean.flag ]] && rm -f ${umbrella_forecast_data}/forecast_clean.flag
-  file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
+  file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "fv_diag.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
+  if [ ${WGF} = "firewx" ]; then
+    file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
+  fi
   num_file_ids=${#file_ids[*]}
   read -a restart_hrs <<< "${RESTART_HRS}"
   num_restart_hrs=${#restart_hrs[*]}
@@ -720,7 +690,10 @@ if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN
     err_exit "FATAL ERROR: function to update the FV3 input.nml file for RESTART capability"
   fi
   # Check that restart files exist at restart_interval
-  file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
+  file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "fv_diag.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
+  if [ ${WGF} = "firewx" ]; then
+    file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
+  fi
   num_file_ids=${#file_ids[*]}
   IFS=' '
   read -a restart_hrs <<< "${RESTART_HRS}"
@@ -737,6 +710,8 @@ if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN
     done
     if [ "${num_rst_files}" = "${num_file_ids}" ]; then
       FHROT="${restart_hrs[ih_rst]}"
+      urange_ih_rst=$((ih_rst+1))
+      FHROT_UPPER_RANGE="${restart_hrs[urange_ih_rst]}"
       restart_set_found="YES"
       break
     fi
@@ -750,14 +725,36 @@ if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN
       fi
       target="${umbrella_forecast_data}/RESTART/${rst_yyyymmdd}.${rst_hh}0000.${file_id}"
       symlink="${file_id}"
-      create_symlink_to_file target="$target" symlink="$symlink" relative="${relative_link_flag}"
+      create_symlink_to_file target="$target" symlink="$symlink" relative="FALSE"
     done
     cd ${DATA}
   fi
+  # Clean up old forecast output file in shared output location in Umbrella DATA
+  if [ ${restart_set_found} == "YES" ]; then
+    cd $shared_forecast_output_data
+    [[ -f output_file_backup.sh ]]&& rm -f output_file_backup.sh
+    [[ ! -d OLD ]]&& mkdir OLD
+    for (( fhr_to_remove=${FHROT_UPPER_RANGE}; fhr_to_remove>=${FHROT}; fhr_to_remove-- )); do
+      fhr_to_remove3d=$( printf "%03d" "${fhr_to_remove}" )
+      if [ $fhr_to_remove -eq $FHROT ]; then
+        $(find -type f -name "log.atm.f*${fhr_to_remove3d}*" | grep -v "00-00" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        $(find -type f -name "dynf*${fhr_to_remove3d}*" | grep -v "00-00" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        $(find -type f -name "phyf*${fhr_to_remove3d}*" | grep -v "00-00" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        sed -i "/log\.atm\.f${fhr_to_remove3d}/d" output_file_backup.sh
+        sed -i "/dynf${fhr_to_remove3d}\.nc/d" output_file_backup.sh
+        sed -i "/phyf${fhr_to_remove3d}\.nc/d" output_file_backup.sh
+      else
+        $(find -type f -name "log.atm.f*${fhr_to_remove3d}*" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        $(find -type f -name "dynf*${fhr_to_remove3d}*" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        $(find -type f -name "phyf*${fhr_to_remove3d}*" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        $(find -name "phyf*${fhr_to_remove3d}.nc" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+        $(find -name "dynf*${fhr_to_remove3d}.nc" | awk '{print "mv",$1,"./OLD"}' >> output_file_backup.sh)
+      fi
+    done
+    [[ -s output_file_backup.sh ]]&& sh output_file_backup.sh
+    cd ${DATA}
+  fi
 fi
-
-
-
 #
 #-----------------------------------------------------------------------
 #
@@ -803,7 +800,6 @@ fi
 # copy over diag_table for multiphysics ensemble
 if [ "${STOCH}" = "TRUE" ] && [ ${BKTYPE} -eq 0 ] && [ ${DO_ENSFCST_MULPHY} = "TRUE" ]; then
   rm -fr ${DATA}/diag_table
-  #### cpreq -p ${PARMrrfs}/diag_table.rrfsens_phy${ENSMEM_INDX} ${DATA}/diag_table
   cpreq -p ${PARMrrfs}/diag_table.rrfsens_phy0${ENSMEM_INDX} ${DATA}/diag_table
 fi
 
@@ -858,6 +854,18 @@ fi
 #-----------------------------------------------------------------------
 #
 module list
+
+# Ensure acsnow is in sfc_data.nc
+cd INPUT
+[[ ! -f sfc_data.nc ]]&& exit 4
+acsnow_ct=$(ncdump -h sfc_data.nc|grep acsnow|wc -l)
+if [ $acsnow_ct -eq 0 ] && [ ! ${WGF} = "firewx" ]; then
+  echo "Run DATA sfc_data.nc surge for acsnow"
+  ncks -A ${FIXrrfs}/acsnow/acsnow.nc sfc_data.nc
+  export err=$?; err_chk
+fi
+cd ..
+#
 
 export pgm="ufs_model"
 cpreq -p ${FV3_EXEC_FP} ${DATA}/$pgm

--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -374,7 +374,7 @@ else
   if [ ${BKTYPE} -eq 1 ]; then
     target="sfc_data.tile${TILE_RGNL}.halo${NH0}.nc"
     symlink="sfc_data.nc"
-    # Additional logic to exam if sfc_data.nc already exist
+    # Additional logic to examine if sfc_data.nc already exist
     if [ ! -s sfc_data.nc ]; then
       if [ -f "${target}" ]; then
         ln -sf ${relative_or_null} $target $symlink

--- a/scripts/exrrfs_fsm.sh
+++ b/scripts/exrrfs_fsm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -x
 #-----------------------------------------------------------------------
 # This is RRFS file server management job for ecflow workflow
 # Scan and set ecflow trigger event for file level dependency

--- a/scripts/exrrfs_save_restart.sh
+++ b/scripts/exrrfs_save_restart.sh
@@ -142,7 +142,7 @@ if [ -r "${shared_forecast_restart_data}/${restart_prefix}.coupler.res" ]; then
   #
   #-----------------------------------------------------------------------
   #
-  for restart_source_file in phy_data.nc fv_tracer.res.tile1.nc fv_core.res.tile1.nc sfc_data.nc fv_srf_wnd.res.tile1.nc fv_core.res.nc coupler.res; do
+  for restart_source_file in phy_data.nc fv_tracer.res.tile1.nc fv_core.res.tile1.nc fv_diag.res.tile1.nc sfc_data.nc fv_srf_wnd.res.tile1.nc fv_core.res.nc coupler.res; do
     cpreq ${shared_forecast_restart_data}/${restart_prefix}.${restart_source_file} ${COMOUT}/RESTART
   done
   echo " ${fhr} forecast from ${yyyymmdd}${hh} is ready " #> ${COMOUT}/RESTART/restart_done_f${fhr}
@@ -174,6 +174,7 @@ if [ "${if_save_input}" = TRUE ]; then
   if [ "${DO_SAVE_INPUT}" = TRUE ]; then
     if [ -r ${umbrella_forecast_data}/INPUT/coupler.res ]; then  # warm start
       if [ "${IO_LAYOUT_Y}" = "1" ]; then
+        [[ -f ${umbrella_forecast_data}/INPUT/fv_diag.res.tile1.nc ]]&& cp ${umbrella_forecast_data}/INPUT/fv_diag.res.tile1.nc ${COMOUT}/INPUT
         for file in ${filelistn}; do
           cp ${umbrella_forecast_data}/INPUT/${file} ${COMOUT}/INPUT/${file}
         done

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -10,10 +10,12 @@ required = True
 
 [ufs-weather-model]
 protocol = git
-repo_url = https://github.com/ufs-community/ufs-weather-model
+#### repo_url = https://github.com/ufs-community/ufs-weather-model
+repo_url = https://github.com/DusanJovic-NOAA/ufs-weather-model.git
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 970fa85
+#### hash = 970fa85
+hash = 3411cb
 local_path = ufs-weather-model
 required = True
 

--- a/ush/update_input_nml.py
+++ b/ush/update_input_nml.py
@@ -67,6 +67,10 @@ def update_input_nml(run_dir):
             "warm_start": True,
         }
 
+        settings["gfs_physics_nml"] = {
+           "sigmab_coldstart": False,
+        }
+
         # settings["gfs_physics_nml"] = {
         #    "nstf_name": [2, 0, 0, 0, 0],
         #}


### PR DESCRIPTION
Using an updated version of the model forecast executable. The ensemble forecast RESTART capability from this version of the executable is not bit identical. The det and firewx RESTART cab produce bit identical results.
Redesign RRFS forecast RESTART capability by adopting new RESTART set generated from the bit identical version of the executable.
Add data surgery capability in forecast job for acsnow to allow the executable to process hailcast data.

## TESTS CONDUCTED: 
- WCOSS2
  - [X] Cactus/Dogwood

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [X] Engineering tests
    - [X] Parallel
- [X] RRFS fire weather