### PR TITLE
[rrfs-mpas-jedi] Update RDASApp hash for JEDI submodule updates

### DIFF
--- a/parm/getkf_observer.yaml
+++ b/parm/getkf_observer.yaml
@@ -72,7 +72,7 @@ driver:
   update obs config with geometry info: false
 
 local ensemble DA:
-  solver: GETKF
+  solver: Deterministic GETKF
   use linear observer: true
   vertical localization: # current settings use 12 modulated members
     fraction of retained variance: 0.850

--- a/parm/getkf_solver.yaml
+++ b/parm/getkf_solver.yaml
@@ -75,7 +75,7 @@ driver:
   do posterior observer: false
 
 local ensemble DA:
-  solver: GETKF
+  solver: Deterministic GETKF
   use linear observer: true
   vertical localization: # current settings use 12 modulated members
     fraction of retained variance: 0.850


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR updates the RDASApp submodule to incorporate changes from [RDASApp PR #417](https://github.com/NOAA-EMC/RDASApp/pull/417), which synced all JEDI submodules with their upstream repositories. It also includes a CRTM update containing a bug fix to support a future transition to spack-stack 1.9.2.

The only required configuration change with this update is for the GETKF YAML files. These now refer to the solver as `Deterministic GETKF` instead of `GETKF`.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [x] Hercules

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
None

