### PR TITLE
Updating MPASSIT to enable building and running on Ursa

### DIFF
--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -77,7 +77,11 @@ case ${task_id} in
   mpassit)
     module purge
     module use "${HOMErrfs}/sorc/MPASSIT/modulefiles"
-    module load "build.${MACHINE}.intel"
+    if [[ ${MACHINE} == "ursa" ]]; then
+      module load "build.${MACHINE}.intel-llvm"
+    else
+      module load "build.${MACHINE}.intel"
+    fi
     ;;
   upp)
     module purge


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
-Updating MPASSIT to the latest version which compiles and runs on Ursa
- Updating launch.sh to load intel-llvm modules (instead of intel) when we are on Ursa

## TESTS CONDUCTED: 
Code was tested on Ursa in the context of the rrfs-mpas-jedi branch of rrfs-workflow

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules
  - [x] Ursa

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #856 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

