### PR TITLE
enable running conus3km JEDI 3DEnVar on Gaea C6

### DIFF
--- a/workflow/ush/gaea_patch
+++ b/workflow/ush/gaea_patch
@@ -73,6 +73,19 @@ changesets = {
 }
 modify(myfile, changesets)
 
+# tweak 4 ----------------------------------------------------------
+myfile = "scripts/exrrfs_jedivar.sh"
+changesets = {
+    'echo "INFO: No DA at the cold start cycle"':
+    '''echo "INFO: No DA at the cold start cycle"
+  # move ${DATA} from ${HOME} to ${UMBRELLA_JEDIVAR_DATA}
+  cd "${UMBRELLA_JEDIVAR_DATA}"
+  rm -rf "${DATA}"
+  mv "${HOME}/rrfstmp_${PDY}${cyc}" "${DATA}"
+  cd "${DATA}" || exit 1'''
+}
+modify(myfile, changesets)
+
 # remove 11 lines from scripts/exrrfs_jedivar.sh
 file = "scripts/exrrfs_jedivar.sh"
 shutil.copy(file, ".tmpfile")  # this can preserve the file permission


### PR DESCRIPTION
This has bothered us for a few months, i.e. conus3km JEDI 3DEnVar crashes on Gaea due to a `cxil_map: write error`.
The error detail is documented at https://github.com/orgs/JCSDA-internal/discussions/181
A helpdesk ticket has been submitted to the Gaea admin and the ticket has been forwarded to ORNL for further examination.

Currently, we don't have a final solution on this. 
But Nrushad from ORNL found that he can successfully ran my crash case under the home directory (which is a NFS system) (as a reference, `/gpfs/f6` is a IBM General Parallel File System). 

Although we still cannot run high resolution conus3km in `/gpfs/f6`, we can run it from our HOME directory.

This PR provides a solution to run JEDI in one's home directory and then copy results back to /gpfs at each cycle.
This enables us to run some high resolution experiments on Gaea C6 where we have lots of computing resources.

One will need to follow these extra steps in order to run conus3km 3DEnVar on Gaea:
1. Make sure the HOME directory has at least 20G free spaces. 
The HOME directory has a quota of 50G on GaeaC6.
2. run `workflow/ush/gaea_patch` to patch the jedivar j-job, scripts and YAML files.
3. After `rrfs.xml` is generated, change `cyclethrottle="3"` to an appropriate value depending on the available free space in the HOME directory. One 3DEnVar cycle usually needs 12G, so you may run 3 cycles concurrently if your HOME directory has more than 40G free disk space.
