### PR TITLE
Hotfix: KEEPDATA needs uppercase YES/NO

### DIFF
--- a/jobs/JRRFS_FCST
+++ b/jobs/JRRFS_FCST
@@ -65,7 +65,9 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+# [[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+# we cannot remove fcst DATA here since save_fcst lags behind and still needs to access them
+# instead, let save_fcst remove fcst DATA
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/jobs/JRRFS_SAVE_FCST
+++ b/jobs/JRRFS_SAVE_FCST
@@ -56,6 +56,14 @@ if [[ -e "${pgmout}" ]]; then
   cat "${pgmout}"
 fi
 #
+#----------------------------------------
+# Remove the Temporary working directory and UMBRELLA_FCST_DATA
+#----------------------------------------
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_FCST_DATA}"
+fi
+#
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"
 exit 0

--- a/workflow/rocoto_funcs/base.py
+++ b/workflow/rocoto_funcs/base.py
@@ -66,7 +66,7 @@ def header_entities(xmlFile, expdir):
     partition = os.getenv('PARTITION', 'hera')
     reservation = os.getenv('RESERVATION', '')
     mesh_name = os.getenv('MESH_NAME', 'na3km')
-    keepdata = os.getenv('KEEPDATA', 'YES').upper()
+    keepdata = os.getenv('KEEPDATA', 'YES').strip().upper()
     mpi_run_cmd = os.getenv('MPI_RUN_CMD', 'srun')
     wgf = os.getenv('WGF', 'det')
     cyc_interval = os.getenv('CYC_INTERVAL', '3')

--- a/workflow/rocoto_funcs/base.py
+++ b/workflow/rocoto_funcs/base.py
@@ -66,7 +66,7 @@ def header_entities(xmlFile, expdir):
     partition = os.getenv('PARTITION', 'hera')
     reservation = os.getenv('RESERVATION', '')
     mesh_name = os.getenv('MESH_NAME', 'na3km')
-    keepdata = os.getenv('KEEPDATA', 'yes')
+    keepdata = os.getenv('KEEPDATA', 'YES').upper()
     mpi_run_cmd = os.getenv('MPI_RUN_CMD', 'srun')
     wgf = os.getenv('WGF', 'det')
     cyc_interval = os.getenv('CYC_INTERVAL', '3')


### PR DESCRIPTION
In j-jobs, `KEEPDATA` is compared to `NO` instead of `no`
```
[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
```

However, current exp.setup files all use lowercase `no` so we don't clean up temporary `DATA` directories as expected.

This PR applies a hotfix to make sure only uppercase `YES/NO` will be passed into each task.
