### PR TITLE
Purge DATA and UMBRELLA_DATA in time to save disk space

### DIFF
--- a/jobs/JRRFS_FCST
+++ b/jobs/JRRFS_FCST
@@ -65,7 +65,11 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+if [[ "${KEEPDATA}" == "NO" ]];
+  # rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_PREP_LBC_DATA}"
+  rm -rf "${UMBRELLA_PREP_IC_DATA}"
+fi
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/jobs/JRRFS_FCST
+++ b/jobs/JRRFS_FCST
@@ -65,7 +65,7 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-if [[ "${KEEPDATA}" == "NO" ]];
+if [[ "${KEEPDATA}" == "NO" ]]; then
   # rm -rf "${DATA}"
   rm -rf "${UMBRELLA_PREP_LBC_DATA}"
   rm -rf "${UMBRELLA_PREP_IC_DATA}"

--- a/jobs/JRRFS_IC
+++ b/jobs/JRRFS_IC
@@ -57,7 +57,10 @@ fi
 # Remove the Temporary working directory
 #----------------------------------------
 #
-[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_UNGRIB_DATA}"
+fi
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/jobs/JRRFS_IC
+++ b/jobs/JRRFS_IC
@@ -23,7 +23,7 @@ if [[ -z "${ENS_INDEX}" ]]; then
 else
   export MEMDIR="/mem${ENS_INDEX}"
 fi
-export UMBRELLA_UNGRIB_DATA=${UMBRELLA_UNGRIB_DATA:-${DATAROOT}/${RUN}_ungrib_ic_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
+export UMBRELLA_UNGRIB_IC_DATA=${UMBRELLA_UNGRIB_IC_DATA:-${DATAROOT}/${RUN}_ungrib_ic_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
 export jobid=${jobid:-ic_${cyc}}
 export UMBRELLA_IC_DATA=${UMBRELLA_IC_DATA:-${DATAROOT}/${RUN}_ic_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
 export DATA=${DATA:-${UMBRELLA_IC_DATA}/${jobid}}
@@ -59,7 +59,7 @@ fi
 #
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_UNGRIB_DATA}"
+  rm -rf "${UMBRELLA_UNGRIB_IC_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_LBC
+++ b/jobs/JRRFS_LBC
@@ -66,7 +66,10 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_UNGRIB_DATA}"
+fi
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/jobs/JRRFS_LBC
+++ b/jobs/JRRFS_LBC
@@ -34,7 +34,7 @@ if [[ -z "${ENS_INDEX}" ]]; then
 else
   export MEMDIR="/mem${ENS_INDEX}"
 fi
-export UMBRELLA_UNGRIB_DATA=${UMBRELLA_UNGRIB_DATA:-${DATAROOT}/${RUN}_ungrib_lbc_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
+export UMBRELLA_UNGRIB_LBC_DATA=${UMBRELLA_UNGRIB_LBC_DATA:-${DATAROOT}/${RUN}_ungrib_lbc_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
 export jobid=${jobid:-lbc_g${GROUP_INDEX}_${cyc}}
 export UMBRELLA_LBC_DATA=${UMBRELLA_LBC_DATA:-${DATAROOT}/${RUN}_lbc_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
 export DATA=${DATA:-${UMBRELLA_LBC_DATA}/${jobid}}
@@ -68,7 +68,7 @@ fi
 #----------------------------------------
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_UNGRIB_DATA}"
+  rm -rf "${UMBRELLA_UNGRIB_LBC_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_MPASSIT
+++ b/jobs/JRRFS_MPASSIT
@@ -63,7 +63,10 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_SAVE_FCST_DATA}"
+fi
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/jobs/JRRFS_SAVE_FCST
+++ b/jobs/JRRFS_SAVE_FCST
@@ -48,16 +48,20 @@ fi
 #----------------------------------------
 # Execute the script.
 #----------------------------------------
-if [[ "${KEEPDATA}" == "NO" ]]; then
-  rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_FCST_DATA}"
-fi
 export pgmout="${DATA}/OUTPUT.$$"
 "${HOMErrfs}"/scripts/exrrfs_save_fcst.sh
 export err=$?; err_chk
 
 if [[ -e "${pgmout}" ]]; then
   cat "${pgmout}"
+fi
+#
+#----------------------------------------
+# Remove the Temporary working directory
+#----------------------------------------
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_FCST_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_SAVE_FCST
+++ b/jobs/JRRFS_SAVE_FCST
@@ -48,6 +48,10 @@ fi
 #----------------------------------------
 # Execute the script.
 #----------------------------------------
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_FCST_DATA}"
+fi
 export pgmout="${DATA}/OUTPUT.$$"
 "${HOMErrfs}"/scripts/exrrfs_save_fcst.sh
 export err=$?; err_chk

--- a/jobs/JRRFS_UPP
+++ b/jobs/JRRFS_UPP
@@ -62,7 +62,10 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+if [[ "${KEEPDATA}" == "NO" ]]; then
+  rm -rf "${DATA}"
+  rm -rf "${UMBRELLA_MPASSIT_DATA}"
+fi
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/scripts/exrrfs_ic.sh
+++ b/scripts/exrrfs_ic.sh
@@ -49,7 +49,7 @@ sed -e "s/@input_stream@/static.nc/" -e "s/@output_stream@/init.nc/" \
 #
 #prepare fix files and ungrib files for init_atmosphere
 #
-ln -snf "${UMBRELLA_UNGRIB_DATA}/${prefix}:${start_time:0:13}" .
+ln -snf "${UMBRELLA_UNGRIB_IC_DATA}/${prefix}:${start_time:0:13}" .
 ${cpreq} "${FIXrrfs}/meshes/${MESH_NAME}.static.nc" static.nc
 ${cpreq} "${FIXrrfs}/graphinfo/${MESH_NAME}.graph.info.part.${NTASKS}" .
 ln -snf "${FIXrrfs}/physics/${PHYSICS_SUITE}/QNWFA_QNIFA_SIGMA_MONTHLY.dat" .

--- a/scripts/exrrfs_lbc.sh
+++ b/scripts/exrrfs_lbc.sh
@@ -68,7 +68,7 @@ sed -e "s/@input_stream@/invariant.nc/" -e "s/@output_stream@/foo.nc/" \
 for fhr in  ${fhr_all}; do
   EDATE=$(${NDATE} "${fhr}" "${CDATEin}")
   timestring=$(date -d "${EDATE:0:8} ${EDATE:8:2}" +%Y-%m-%d_%H:%M:%S)
-  ln -snf "${UMBRELLA_UNGRIB_DATA}/${prefix}:${timestring:0:13}" .
+  ln -snf "${UMBRELLA_UNGRIB_LBC_DATA}/${prefix}:${timestring:0:13}" .
 done
 zeta_levels=${EXPDIR}/config/ZETA_LEVELS.txt
 nlevel=$(wc -l < "${zeta_levels}")

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -123,7 +123,7 @@ umask 022
 case ${task_id} in
   clean)
     case ${MACHINE} in
-      gaea|orion|hercules)
+      ursa|gaea|orion|hercules)
         set +x
         module load python
         set -x


### PR DESCRIPTION
When running conus3km, one day will consume `15T` disk space (details below),
and this is only 12h fcst twice a day and 3h fcst for other cycles. When we run a full functional RRFS.v2 experiments, especially with an ensemble system, the disk consumption will be huge.

Since `DATA` and `UMBRELLA_DATA` are all temporary, they can be removed once itself and all tasks depending on it complete. Based on this, this PR applies the following cascading purge strategy:

- `ic` removes umbrella `ungrib_ic`
- `lbc` removes umbrella `ungrib_lbc`
- `fcst` removes umbrella `prep_ic` and `prep_lbc`
- `save_fcst` removes umbrella `fcst`
- `massit` removes umbrella `save_fcst`
- `upp` removes umbrella `mpassit`

```
stmp/
du -sh  *_{00,01}_v2.1.1

2.8T at cold start cycles (12h fcst)
688G    rrfs_fcst_00_v2.1.1
1.1T    rrfs_ic_00_v2.1.1
407M    rrfs_ioda_bufr_00_v2.1.1
299M    rrfs_jedivar_00_v2.1.1
265G    rrfs_lbc_00_v2.1.1
162G    rrfs_mpassit_00_v2.1.1
30G     rrfs_prep_ic_00_v2.1.1
145G    rrfs_prep_lbc_00_v2.1.1
404G    rrfs_save_fcst_00_v2.1.1
11G     rrfs_ungrib_ic_00_v2.1.1
28G     rrfs_ungrib_lbc_00_v2.1.1
17G     rrfs_upp_00_v2.1.1

442G at warm start cycles (3h fcst)
172G    rrfs_fcst_01_v2.1.1
247M    rrfs_ioda_bufr_01_v2.1.1
344M    rrfs_jedivar_01_v2.1.1
52G     rrfs_mpassit_01_v2.1.1
53G     rrfs_prep_ic_01_v2.1.1
34G     rrfs_prep_lbc_01_v2.1.1
125G    rrfs_save_fcst_01_v2.1.1
5.1G    rrfs_upp_01_v2.1.1
```