### PR TITLE
add two utilities: taskinfo and clean.comroot

### DIFF
--- a/workflow/ush/qrocoto/clean.comroot
+++ b/workflow/ush/qrocoto/clean.comroot
@@ -1,0 +1,36 @@
+#!/bin/bash
+# shellcheck disable=all
+# clean the experiment com outputs except UPP
+# by Guoqing Ge, 2025/07
+#
+declare -A cleans  # Declare an associative array
+
+cleans["ungrib_ic"]=true
+cleans["ungrib_lbc"]=true
+cleans["ic"]=true
+cleans["lbc"]=true
+cleans["ioda_bufr"]=true
+
+cleans["prep_ic"]=true
+cleans["prep_lbc"]=true
+cleans["fcst"]=true
+cleans["jedivar"]=true
+cleans["mpassit"]=true
+
+if [[ ! -s exp.setup ]]; then
+  echo "Run this command under the expdir where exp.setup is located"
+  exit
+fi
+source exp.setup
+
+RUN=rrfs
+
+for task in "${!cleans[@]}"; do
+  do_clean=${cleans[${task}]}
+  if ${do_clean}; then
+    echo -e "\n======  clean ${task} ======"
+    ### read YESNO
+    echo "rm -rf ${COMROOT}/${NET}/${VERSION}/${RUN}.*/*/${task}/${WGF}"
+    rm -rf ${COMROOT}/${NET}/${VERSION}/${RUN}.*/*/${task}/${WGF}
+  fi
+done

--- a/workflow/ush/qrocoto/taskinfo
+++ b/workflow/ush/qrocoto/taskinfo
@@ -1,0 +1,40 @@
+#!/bin/bash
+# shellcheck disable=all
+# find the log file for a given task at a given cycle
+# by Guoqing Ge, 2025/07
+#
+if [[ ! -s exp.setup ]]; then
+  echo "Run this command under the expdir where exp.setup is located"
+  exit
+fi
+source exp.setup
+if [[ $# < 2 ]]; then
+  echo "$(basename $0) <YYYYMMDDHH|YYYYMMDDHHmm> <task>"
+  exit
+fi
+
+RUN=rrfs
+
+CDATE=$1
+task=$2
+PDY=${CDATE:0:8}
+cyc=${CDATE:8:2}
+logroot=${COMROOT}/${NET}/${VERSION}/logs
+logfile="${logroot}/${RUN}.${PDY}/${cyc}/${WGF}/${RUN}_${task}_${TAG}_${PDY}${cyc}.log"
+echo "----log file:"
+ls ${logfile}*
+
+echo -e  "\n---com output:"
+comout="${COMROOT}/${NET}/${VERSION}/${RUN}.${PDY}/${cyc}/${task}/${WGF}"
+echo "${comout}"
+if [[ ! -d "${comout}" ]]; then
+  echo " !!! the above directory either NOT created, or has been purged !!!"
+fi
+
+echo -e "\n---stmp otuput:"
+stmpout="${DATAROOT}/${PDY}/${RUN}_${task}_${cyc}_${VERSION}/${WGF}"
+echo "${stmpout}"
+if [[ ! -d "${stmpout}" ]]; then
+  echo " !!! the above directory either NOT created, or has been purged !!!"
+fi
+

--- a/workflow/ush/qrocoto/taskinfo
+++ b/workflow/ush/qrocoto/taskinfo
@@ -31,7 +31,7 @@ if [[ ! -d "${comout}" ]]; then
   echo " !!! the above directory either NOT created, or has been purged !!!"
 fi
 
-echo -e "\n---stmp otuput:"
+echo -e "\n---stmp output:"
 stmpout="${DATAROOT}/${PDY}/${RUN}_${task}_${cyc}_${VERSION}/${WGF}"
 echo "${stmpout}"
 if [[ ! -d "${stmpout}" ]]; then


### PR DESCRIPTION
Per users' request, add two utilities `taskinfo` and `clean.comroot`.
1. `taskinfo` can be used to quickly get the logfile, com/stmp output directories for a given cycle and task.

Eg: when one gets the following output from checking the workflow run status:
`202405061200               save_fcst                     1686573           DEAD`
one would naturally want to check the logfile, com/stmp output directories.
Running the following command under expdir:
`taskinfo 202405061200 save_fcst`
will output:
```
----log file:
/scratch3/BMC/wrfruc/gge/rrfs2/rrfs_hour_Aug2025/c12km/com/rrfs/v2.1.1/logs/rrfs.20240506/12/det/rrfs_save_fcst_d12km_2024050612.log

---com output:
/scratch3/BMC/wrfruc/gge/rrfs2/rrfs_hour_Aug2025/c12km/com/rrfs/v2.1.1/rrfs.20240506/12/save_fcst/det

---stmp otuput:
/scratch3/BMC/wrfruc/gge/rrfs2/rrfs_hour_Aug2025/c12km/stmp/20240506/rrfs_save_fcst_12_v2.1.1/det
```
This help users to get needed information much faster.

2. stmp will be purged in time once PR #875 gets merged. But com directories will still take lots of disk space.

`clean.comroot` helps users to cleanup com directories (UPP directories will stay and NOT be cleaned).
Users can customize this script to only clean target tasks under COMROOT.