### PR TITLE
[rrfs-mpas-jedi] Add functionality to update w when assimilating radar refl obs

### DIFF
--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.control
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.control
@@ -7,3 +7,4 @@ uReconstructZonal
 uReconstructMeridional
 velocity_potential
 refl10cm
+w

--- a/parm/jedivar.yaml
+++ b/parm/jedivar.yaml
@@ -1,6 +1,6 @@
 _member: &memberConfig
   date: &analysisDate '@analysisDate@'
-  state variables: &incvars [water_vapor_mixing_ratio_wrt_moist_air, air_pressure_at_surface, air_temperature, northward_wind, eastward_wind, cloud_liquid_water, cloud_liquid_ice, rain_water, snow_water, graupel, equivalent_reflectivity_factor]
+  state variables: &incvars [water_vapor_mixing_ratio_wrt_moist_air, air_pressure_at_surface, air_temperature, northward_wind, eastward_wind, cloud_liquid_water, cloud_liquid_ice, rain_water, snow_water, graupel, equivalent_reflectivity_factor, upward_air_velocity]
   stream name: ensemble
 
 output:
@@ -70,6 +70,8 @@ cost function:
     - snow_water
     - cldfrac
     - equivalent_reflectivity_factor
+    - w
+    - upward_air_velocity
     filename: mpasin.nc
     date: *analysisDate
   background error:

--- a/ush/yaml_from_parm.sh
+++ b/ush/yaml_from_parm.sh
@@ -7,9 +7,9 @@ if [[ "$1" == "jedivar" ]]; then
       -e "s/@HYB_WGT_STATIC@/${HYB_WGT_STATIC}/" -e "s/@HYB_WGT_ENS@/${HYB_WGT_ENS}/" \
       "${EXPDIR}/config/jedivar.yaml" > jedivar.yaml
   if [[ "${HYB_WGT_ENS}" == "0" ]] || [[ "${HYB_WGT_ENS}" == "0.0" ]]; then # pure 3DVAR
-    sed -i '125,150d' ./jedivar.yaml
+    sed -i '127,152d' ./jedivar.yaml
   elif [[ "${HYB_WGT_STATIC}" == "0" ]] || [[ "${HYB_WGT_STATIC}" == "0.0" ]] ; then # pure 3DEnVar
-    sed -i '78,124d' ./jedivar.yaml
+    sed -i '80,126d' ./jedivar.yaml
   fi
   if [[ "${start_type}" == "cold" ]]; then
       sed -i '7s/mpasin/ana/' jedivar.yaml


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This is a small PR to vertical velocity to the list of analysis variables (and needed state variables) for deterministic jedivar. This functionality was added for ensemble DA as part of #859 but had yet to be included for jedivar. 

I tested this for 48-h of cycling 3DEnVar on conus12km. Full results from that retro are seen in slides 15-32 here: https://docs.google.com/presentation/d/1-fjyTTJldARJBSkwdAPwrd4i1OvwRRkjyN1CFIgXSdg/edit?usp=sharing

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
N/A


