### PR TITLE
[rrfs-mpas-jedi] Update paths to RRFS retro and fix data on WCOSS2

### DIFF
--- a/workflow/exp/baselines/exp.conus12km_3denvar_b001
+++ b/workflow/exp/baselines/exp.conus12km_3denvar_b001
@@ -115,10 +115,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/exp/baselines/exp.conus12km_3dvar_b001
+++ b/workflow/exp/baselines/exp.conus12km_3dvar_b001
@@ -115,10 +115,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/exp/baselines/exp.ens_conus12km_3denvar_b001
+++ b/workflow/exp/baselines/exp.ens_conus12km_3denvar_b001
@@ -105,10 +105,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GEFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -130,10 +130,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -129,10 +129,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -123,10 +123,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GEFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -124,10 +124,10 @@ case ${MACHINE} in
     export CLUSTER="c6"
     ;;
   "wcoss2")
-    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/GEFS"
+    export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/da/noscrub/samuel.degelia/RRFS2_RETRO_DATA/May2024/reflectivity"
+    export OBSPATH="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/obs_rap"
+    export OBSPATH_NSSLMOSAIC="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/reflectivity"
     export ACCOUNT="RRFS-DEV"
     export QUEUE="dev"
     export PARTITION=""

--- a/workflow/ush/init.sh
+++ b/workflow/ush/init.sh
@@ -7,7 +7,7 @@ source "${run_dir}/detect_machine.sh"
 
 case ${MACHINE} in
   wcoss2)
-    FIX_RRFS_LOCATION=/lfs/h2/emc/da/noscrub/samuel.degelia/FIX_RRFS2
+    FIX_RRFS_LOCATION=/lfs/h2/emc/lam/noscrub/FIX_RRFS2
     ;;
   hera)
     FIX_RRFS_LOCATION=/scratch4/BMC/rtrr/FIX_RRFS2


### PR DESCRIPTION


## DESCRIPTION OF CHANGES: 

The staged `FIX_RRFS2` and `RRFS2_RETRO_DATA` directories have been updated and moved to a new location on WCOSS2 after the previous production switch. This small PR updates rrfs-workflow to point to these new locations on WCOSS2. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Started a retro to make sure the data can be found correctly. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
N/A

