### PR TITLE
Hotfix: remove cascading cleaning up of UMBRELLA_DATA

### DIFF
--- a/jobs/JRRFS_FCST
+++ b/jobs/JRRFS_FCST
@@ -65,13 +65,8 @@ fi
 #----------------------------------------
 # Remove the Temporary working directory
 #----------------------------------------
-if [[ "${KEEPDATA}" == "NO" ]]; then
-  # rm -rf "${DATA}"
-# we cannot remove fcst DATA here since save_fcst lags behind and
-# still needs to access them. Instead, let save_fcst remove fcst DATA
-  rm -rf "${UMBRELLA_PREP_LBC_DATA}"
-  rm -rf "${UMBRELLA_PREP_IC_DATA}"
-fi
+# [[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
+# we cannot remove fcst DATA here since save_fcst lags behind and still need to access them
 #
 date
 echo "JOB ${jobid:-} HAS COMPLETED NORMALLY!"

--- a/jobs/JRRFS_IC
+++ b/jobs/JRRFS_IC
@@ -59,7 +59,6 @@ fi
 #
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_UNGRIB_IC_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_LBC
+++ b/jobs/JRRFS_LBC
@@ -68,7 +68,6 @@ fi
 #----------------------------------------
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_UNGRIB_LBC_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_MPASSIT
+++ b/jobs/JRRFS_MPASSIT
@@ -65,7 +65,6 @@ fi
 #----------------------------------------
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_SAVE_FCST_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_SAVE_FCST
+++ b/jobs/JRRFS_SAVE_FCST
@@ -61,7 +61,6 @@ fi
 #----------------------------------------
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_FCST_DATA}"
 fi
 #
 date

--- a/jobs/JRRFS_UPP
+++ b/jobs/JRRFS_UPP
@@ -64,7 +64,6 @@ fi
 #----------------------------------------
 if [[ "${KEEPDATA}" == "NO" ]]; then
   rm -rf "${DATA}"
-  rm -rf "${UMBRELLA_MPASSIT_DATA}"
 fi
 #
 date


### PR DESCRIPTION
PR #875 introduced cascading cleaning up of `UMBRELLA_DATA`.
This idea does not work in some situations, for example, the GETKF situation reported in issue #899 or using multiple groups of lbc tasks.
This PR is to revert changes made in PR #875 

For now, to meet data cleaning needs, one can set the following variables in exp files to only keep the latest once cycle of stmp data:
```
export DO_CLEAN=true
export STMP_CLEAN_HRS=1
export COM_CLEAN_HRS=840
export LOG_CLEAN_HRS=840
```

I have been working on expanding the `clean` task to purge UMBRELLA_DATA at the end of each cycle and will commit that in a separate PR later this week.