### PR TITLE
Fixed hard-code line number for sed command to pattern-based ranges f…

### DIFF
--- a/ush/yaml_from_parm.sh
+++ b/ush/yaml_from_parm.sh
@@ -7,12 +7,12 @@ if [[ "$1" == "jedivar" ]]; then
       -e "s/@HYB_WGT_STATIC@/${HYB_WGT_STATIC}/" -e "s/@HYB_WGT_ENS@/${HYB_WGT_ENS}/" \
       "${EXPDIR}/config/jedivar.yaml" > jedivar.yaml
   if [[ "${HYB_WGT_ENS}" == "0" ]] || [[ "${HYB_WGT_ENS}" == "0.0" ]]; then # pure 3DVAR
-    sed -i '127,152d' ./jedivar.yaml
+    sed -i '/- covariance:/,/HYB_WGT_ENS/d' ./jedivar.yaml
   elif [[ "${HYB_WGT_STATIC}" == "0" ]] || [[ "${HYB_WGT_STATIC}" == "0.0" ]] ; then # pure 3DEnVar
-    sed -i '80,126d' ./jedivar.yaml
+    sed -i '/- covariance:/,/HYB_WGT_STATIC/d' ./jedivar.yaml
   fi
   if [[ "${start_type}" == "cold" ]]; then
-      sed -i '7s/mpasout/ana/' jedivar.yaml
+      sed -i '/output:/,/stream name:/{s/mpasout/ana/}' jedivar.yaml
   fi
   template="jedivar.yaml"
 
@@ -25,7 +25,7 @@ else
   sed -e "s/@analysisDate@/${analysisDate}/" -e "s/@beginDate@/${beginDate}/" \
     "${EXPDIR}/config/getkf_${TYPE_SED}.yaml" > getkf.yaml
   if [[ ${start_type} == "cold" ]]; then
-      sed -i '43s/ens/ana/' getkf.yaml
+     sed -i '/output:/,/stream name:/{s/ens/ana/}' getkf.yaml
   fi
   template="getkf.yaml"
 fi

--- a/ush/yaml_from_parm.sh
+++ b/ush/yaml_from_parm.sh
@@ -7,9 +7,9 @@ if [[ "$1" == "jedivar" ]]; then
       -e "s/@HYB_WGT_STATIC@/${HYB_WGT_STATIC}/" -e "s/@HYB_WGT_ENS@/${HYB_WGT_ENS}/" \
       "${EXPDIR}/config/jedivar.yaml" > jedivar.yaml
   if [[ "${HYB_WGT_ENS}" == "0" ]] || [[ "${HYB_WGT_ENS}" == "0.0" ]]; then # pure 3DVAR
-    sed -i '/- covariance:/,/HYB_WGT_ENS/d' ./jedivar.yaml
+    sed -i '/- covariance:/{N;/covariance model: ensemble/{:a;N;/HYB_WGT_ENS/!ba;d}}' jedivar.yaml
   elif [[ "${HYB_WGT_STATIC}" == "0" ]] || [[ "${HYB_WGT_STATIC}" == "0.0" ]] ; then # pure 3DEnVar
-    sed -i '/- covariance:/,/HYB_WGT_STATIC/d' ./jedivar.yaml
+    sed -i '/- covariance:/{N;/covariance model: SABER/{:a;N;/HYB_WGT_STATIC/!ba;d}}' jedivar.yaml
   fi
   if [[ "${start_type}" == "cold" ]]; then
       sed -i '/output:/,/stream name:/{s/mpasout/ana/}' jedivar.yaml


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

Fixed file _ush/yaml_from_parm.sh_ for several **sed** commands, where it uses the hard-coded line numbers for several operations. It has been changed to use pattern-based ranges for flexibility.

## TESTS CONDUCTED: 
Tested using the CONUS3km workflow on Jet.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [x] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## CONTRIBUTORS (optional): 
 - Guoqing Ge
