### PR TITLE
[rrfs-mpas-jedi] Update ioda_empty.nc to contain stationPressure

### DIFF
--- a/fix/jedi/ioda_empty.nc
+++ b/fix/jedi/ioda_empty.nc
@@ -1,1 +1,1 @@
-../.agent/jedi/ioda_empty.nc
+../.agent/jedi/ioda_empty_20250822.nc


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- This PR updates the link to the ioda_empty.nc file that that now contains stationPressure field.

## TESTS CONDUCTED: 
retros on Hera

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

