### PR TITLE
[rrfs-mpas-jedi] Updates to ensemble recentering (lower bound for hydrometeors, more variables, etc.)

### DIFF
--- a/scripts/exrrfs_recenter.sh
+++ b/scripts/exrrfs_recenter.sh
@@ -50,8 +50,8 @@ cat << EOF > namelist.ens
   ens_size=${ENS_SIZE},
   filebase='mpasout'
   filetail(1)='.nc'
-  numvar(1)=22
-  varlist(1)="pressure_p rho qv qc qr qi qs qg ni nr ng nc nifa nwfa volg surface_pressure theta u uReconstructZonal uReconstructMeridional refl10cm w"
+  numvar(1)=24
+  varlist(1)="pressure_p rho qv qc qr qi qs qg ni nr ng nc nifa nwfa volg surface_pressure theta tslb q2 u uReconstructZonal uReconstructMeridional refl10cm w"
   l_write_mean=.true.
   l_recenter=.true.
 /

--- a/scripts/exrrfs_recenter.sh
+++ b/scripts/exrrfs_recenter.sh
@@ -50,8 +50,8 @@ cat << EOF > namelist.ens
   ens_size=${ENS_SIZE},
   filebase='mpasout'
   filetail(1)='.nc'
-  numvar(1)=6
-  varlist(1)="qv u w theta tslb q2"
+  numvar(1)=22
+  varlist(1)="pressure_p rho qv qc qr qi qs qg ni nr ng nc nifa nwfa volg surface_pressure theta u uReconstructZonal uReconstructMeridional refl10cm w"
   l_write_mean=.true.
   l_recenter=.true.
 /


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR includes a few updates for ensemble recentering. 

1. `RRFS_UTILS` is updated to incorporate its [PR #3](https://github.com/hu5970/RRFS_UTILS/pull/3) which allows for longer variable names and set a lower bound of 0 for additional hydrometeor variables. 
2. New logic is added to `workflow/rocoto_funcs/recenter.py` to get the recentering task to run even if `COLDSTART_CYCS_DO_DA=false`. See [#916](https://github.com/NOAA-EMC/rrfs-workflow/issues/916) for a description of that problem. 
3. More variables are now recentered in `scripts/exrrfs_recenter.sh` to account for additional analysis and updated variables when doing radar DA. The full list of variables is taken from [here](https://github.com/NOAA-EMC/rrfs-workflow/blob/abad864edaed6356f650e9989a87f8f7988ce403/scripts/exrrfs_jedivar.sh#L123) so I hope this encapsulates the full set of variables that need to be updated. 

Also, `q2` was originally listed as a variable to be recentered. I believe this is just a diagnostic variable so it should not be required for cycling, but I left it in case someone has specific need of it. 

Lastly, I should note that the recentering task runs extremely quickly (<1 min for the conus12km mesh) so adding the extra variables comes at very little cost. 


## TESTS CONDUCTED: 
I tested the recentering for a couple of cycles and the results look as expected. The ensemble forecasts also ran successfully for the next cycle after recentering was performed. See slides here: https://docs.google.com/presentation/d/1oGWKd5Wgg4nI5RTpHWik3Y-wCrvRmU8h1CLJkZvDM4s/edit?usp=sharing

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
#916 


