### PR TITLE
update jedivar.yaml and getkf.yaml to match the latest RDASApp changes

### DIFF
--- a/parm/getkf.yaml
+++ b/parm/getkf.yaml
@@ -134,7 +134,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t181.nc
@@ -410,7 +410,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t183.nc
@@ -684,7 +684,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t187.nc
@@ -959,7 +959,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q181.nc
@@ -1234,7 +1234,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q183.nc
@@ -1508,7 +1508,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q187.nc
@@ -1783,7 +1783,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps181.nc
@@ -2051,7 +2051,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps187.nc
@@ -2319,7 +2319,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv281.nc
@@ -2636,7 +2636,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv284.nc
@@ -2952,7 +2952,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv287.nc
@@ -3265,7 +3265,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t120.nc
@@ -3539,7 +3539,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t132.nc
@@ -3813,7 +3813,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q120.nc
@@ -4087,7 +4087,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q132.nc
@@ -4361,7 +4361,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_ps120.nc
@@ -4628,7 +4628,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv220.nc
@@ -4938,7 +4938,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv232.nc
@@ -5248,7 +5248,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircar_t133.nc
@@ -5522,7 +5522,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircar_q133.nc
@@ -5796,7 +5796,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircar_uv233.nc
@@ -6106,7 +6106,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t130.nc
@@ -6380,7 +6380,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t131.nc
@@ -6654,7 +6654,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t134.nc
@@ -6928,7 +6928,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t135.nc
@@ -7202,7 +7202,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_q134.nc
@@ -7476,7 +7476,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv230.nc
@@ -7786,7 +7786,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv231.nc
@@ -8096,7 +8096,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv234.nc
@@ -8406,7 +8406,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv235.nc
@@ -8719,7 +8719,7 @@ observations:
            sort variable: "pressure"
            sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_gnss_ztd.nc
@@ -8790,7 +8790,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_t188.nc
@@ -9064,7 +9064,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_q188.nc
@@ -9338,7 +9338,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_ps188.nc
@@ -9605,7 +9605,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_uv288.nc
@@ -10183,7 +10183,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_proflr_uv227.nc
@@ -10537,7 +10537,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_rassda_t126.nc
@@ -10811,7 +10811,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t180.nc
@@ -11085,7 +11085,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t182.nc
@@ -11360,7 +11360,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t183.nc
@@ -11634,7 +11634,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q180.nc
@@ -11908,7 +11908,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q182.nc
@@ -12183,7 +12183,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q183.nc
@@ -12457,7 +12457,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_ps180.nc
@@ -12733,7 +12733,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv280.nc
@@ -13049,7 +13049,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv282.nc
@@ -13366,7 +13366,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv284.nc
@@ -13682,7 +13682,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_vadwnd_uv224.nc
@@ -14047,7 +14047,7 @@ observations:
              obsfile: "data/obs/ioda_amsua_n19.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_amsua_n19.nc
@@ -14459,7 +14459,7 @@ observations:
              obsfile: "data/obs/ioda_atms_n20.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_atms_n20.nc
@@ -15003,7 +15003,7 @@ observations:
              obsfile: "data/obs/ioda_atms_npp.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_atms_npp.nc
@@ -15535,7 +15535,7 @@ observations:
              obsfile: "data/obs/ioda_abi_g16.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_abi_g16.nc
@@ -16016,7 +16016,7 @@ observations:
              obsfile: "data/obs/ioda_abi_g18.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_abi_g18.nc
@@ -16508,7 +16508,7 @@ observations:
              obsfile: "data/obs/ioda_atms_n21.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_atms_n21.nc
@@ -17041,7 +17041,7 @@ observations:
              obsfile: "data/obs/ioda_amsua_metop-b.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-b.nc
@@ -17442,7 +17442,7 @@ observations:
              obsfile: "data/obs/ioda_amsua_metop-c.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-c.nc

--- a/parm/getkf.yaml
+++ b/parm/getkf.yaml
@@ -127,13 +127,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t181.nc
@@ -150,7 +151,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfc_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -171,7 +172,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -184,7 +184,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -195,7 +194,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -292,6 +290,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -394,7 +393,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_t183
          distribution:
@@ -411,6 +410,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t183.nc
@@ -427,7 +427,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -447,8 +447,7 @@ observations:
          # airTemperature (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -461,7 +460,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -472,7 +470,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -568,6 +565,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -670,7 +668,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_t187
          distribution:
@@ -679,13 +677,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t187.nc
@@ -720,7 +719,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -733,7 +731,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -744,7 +741,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -798,7 +794,7 @@ observations:
                  # The new feature "surface observation error ramp"
                  # needs to be added to UFO to align with the ramp
                  # options for temperature and humidity in GSI.
-                 #surface observation error ramp: true
+                 surface observation error ramp: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -844,6 +840,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -946,7 +943,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_q181
          distribution:
@@ -955,13 +952,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q181.nc
@@ -978,7 +976,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfc_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -999,7 +997,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -1012,7 +1009,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1023,7 +1019,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -1074,7 +1069,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -1120,6 +1114,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1222,7 +1217,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_q183
          distribution:
@@ -1239,6 +1234,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q183.nc
@@ -1255,7 +1251,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -1275,8 +1271,7 @@ observations:
          # specificHumidity (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: specificHumidity
            where:
@@ -1289,7 +1284,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1300,7 +1294,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -1351,7 +1344,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -1397,6 +1389,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1499,7 +1492,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_q187
          distribution:
@@ -1508,13 +1501,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q187.nc
@@ -1549,7 +1543,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -1562,7 +1555,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1573,7 +1565,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -1624,7 +1615,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
                  # The new feature "surface observation error ramp"
                  # needs to be added to UFO to align with the ramp
                  # options for temperature and humidity in GSI.
@@ -1674,6 +1664,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1776,7 +1767,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_ps181
          distribution:
@@ -1785,13 +1776,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps181.nc
@@ -1822,7 +1814,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -1835,7 +1826,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1846,7 +1836,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -1943,6 +1932,7 @@ observations:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2045,7 +2035,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_ps187
          distribution:
@@ -2054,13 +2044,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps187.nc
@@ -2091,7 +2082,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -2104,7 +2094,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -2115,7 +2104,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -2212,6 +2200,7 @@ observations:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2314,7 +2303,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_uv281
          distribution:
@@ -2323,13 +2312,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv281.nc
@@ -2341,15 +2331,12 @@ observations:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfc_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -2371,7 +2358,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -2385,7 +2371,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -2396,7 +2381,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -2540,6 +2524,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2634,7 +2619,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_uv284
          distribution:
@@ -2651,6 +2636,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv284.nc
@@ -2667,7 +2653,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -2688,8 +2674,7 @@ observations:
          # wind (284)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -2703,7 +2688,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -2714,11 +2698,10 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -2858,6 +2841,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2952,7 +2936,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_uv287
          distribution:
@@ -2961,13 +2945,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv287.nc
@@ -2979,9 +2964,6 @@ observations:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
@@ -3006,7 +2988,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -3020,7 +3001,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3031,7 +3011,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -3175,6 +3154,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3269,7 +3249,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpupa_t120
          distribution:
@@ -3278,13 +3258,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t120.nc
@@ -3301,7 +3282,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -3322,7 +3303,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -3335,7 +3315,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3346,7 +3325,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -3442,6 +3420,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3544,7 +3523,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_t132
          distribution:
@@ -3553,13 +3532,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t132.nc
@@ -3576,7 +3556,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -3597,7 +3577,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -3610,7 +3589,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3621,7 +3599,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -3717,6 +3694,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3819,7 +3797,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_q120
          distribution:
@@ -3828,13 +3806,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q120.nc
@@ -3851,7 +3830,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_q_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -3872,7 +3851,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -3885,7 +3863,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3896,7 +3873,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -3947,7 +3923,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
          # Error inflation based on errormod (qcmod.f90)
          - filter: Perform Action
@@ -3993,6 +3968,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4095,7 +4071,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_q132
          distribution:
@@ -4104,13 +4080,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q132.nc
@@ -4127,7 +4104,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_q_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -4148,7 +4125,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -4161,7 +4137,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -4172,7 +4147,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -4223,7 +4197,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
          # Error inflation based on errormod (qcmod.f90)
          - filter: Perform Action
@@ -4269,6 +4242,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4371,7 +4345,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_ps120
          distribution:
@@ -4380,13 +4354,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_ps120.nc
@@ -4417,7 +4392,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -4430,7 +4404,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -4441,7 +4414,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -4537,6 +4509,7 @@ observations:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4639,7 +4612,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_uv220
          distribution:
@@ -4648,13 +4621,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv220.nc
@@ -4671,7 +4645,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -4693,7 +4667,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -4707,7 +4680,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -4718,7 +4690,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -4856,6 +4827,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4950,7 +4922,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_uv232
          distribution:
@@ -4959,13 +4931,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv232.nc
@@ -4982,7 +4955,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -5004,7 +4977,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -5018,7 +4990,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5029,7 +5000,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -5167,6 +5137,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5261,7 +5232,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: aircar_t133
          distribution:
@@ -5270,13 +5241,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircar.nc
+             obsfile: "data/obs/ioda_aircar.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_t133.nc
@@ -5293,7 +5265,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -5314,7 +5286,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -5327,7 +5298,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5338,7 +5308,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -5434,6 +5403,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5536,7 +5506,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircar_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircar_geovals_rrfs.nc
      - obs space:
          name: aircar_q133
          distribution:
@@ -5545,13 +5515,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircar.nc
+             obsfile: "data/obs/ioda_aircar.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_q133.nc
@@ -5568,7 +5539,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_q_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -5589,7 +5560,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -5602,7 +5572,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5613,7 +5582,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -5664,7 +5632,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -5710,6 +5677,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5812,7 +5780,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircar_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircar_geovals_rrfs.nc
      - obs space:
          name: aircar_uv233
          distribution:
@@ -5821,13 +5789,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircar.nc
+             obsfile: "data/obs/ioda_aircar.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_uv233.nc
@@ -5844,7 +5813,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -5866,7 +5835,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -5880,7 +5848,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5891,7 +5858,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -6029,6 +5995,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6123,7 +6090,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircar_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircar_geovals_rrfs.nc
      - obs space:
          name: aircft_t130
          distribution:
@@ -6132,13 +6099,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t130.nc
@@ -6155,7 +6123,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -6176,7 +6144,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -6189,7 +6156,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -6200,7 +6166,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -6296,6 +6261,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6398,7 +6364,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_t131
          distribution:
@@ -6407,13 +6373,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t131.nc
@@ -6430,7 +6397,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -6451,7 +6418,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -6464,7 +6430,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -6475,7 +6440,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -6571,6 +6535,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6673,7 +6638,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_t134
          distribution:
@@ -6682,13 +6647,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t134.nc
@@ -6705,7 +6671,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -6726,7 +6692,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -6739,7 +6704,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -6750,7 +6714,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -6846,6 +6809,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6948,7 +6912,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_t135
          distribution:
@@ -6957,13 +6921,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t135.nc
@@ -6980,7 +6945,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -7001,7 +6966,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -7014,7 +6978,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7025,7 +6988,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -7121,6 +7083,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7223,7 +7186,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_q134
          distribution:
@@ -7232,13 +7195,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_q134.nc
@@ -7255,7 +7219,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_q_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -7276,7 +7240,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -7289,7 +7252,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7300,7 +7262,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -7351,7 +7312,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -7397,6 +7357,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7499,7 +7460,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv230
          distribution:
@@ -7508,13 +7469,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv230.nc
@@ -7531,7 +7493,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -7553,7 +7515,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -7567,7 +7528,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7578,7 +7538,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -7716,6 +7675,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7810,7 +7770,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv231
          distribution:
@@ -7819,13 +7779,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv231.nc
@@ -7842,7 +7803,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -7864,7 +7825,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -7878,7 +7838,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7889,7 +7848,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -8027,6 +7985,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -8121,7 +8080,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv234
          distribution:
@@ -8130,13 +8089,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv234.nc
@@ -8153,7 +8113,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -8175,7 +8135,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -8189,7 +8148,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -8200,7 +8158,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -8338,6 +8295,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -8432,7 +8390,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv235
          distribution:
@@ -8441,13 +8399,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv235.nc
@@ -8464,7 +8423,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -8486,7 +8445,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -8500,7 +8458,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -8511,7 +8468,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -8649,6 +8605,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -8743,7 +8700,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: gnss_ztd
 
@@ -8754,7 +8711,7 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_gnss_ztd.nc
+             obsfile: "data/obs/ioda_gnss_ztd.nc"
              missing file action: "warn"
 
          obsgrouping:
@@ -8762,6 +8719,7 @@ observations:
            sort variable: "pressure"
            sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_gnss_ztd.nc
@@ -8775,7 +8733,6 @@ observations:
          name: GroundgnssMetOffice
        linear obs operator:
          name: GroundgnssMetOffice
-
          observation alias file: obsop_name_map.yaml
 
        obs error:
@@ -8786,28 +8743,6 @@ observations:
            lengthscale: 200e3
 
        obs filters:
-         # Pre-online regional domain check (latitude/longitude)
-         - filter: Domain Check
-           where:
-             - variable:
-                 name: MetaData/latitude
-               minvalue:  19.0
-               maxvalue:  62.0
-             - variable:
-                 name: MetaData/longitude
-               minvalue: 213.0
-               maxvalue: 312.0
-           action:
-              name: reduce obs space
-
-         # Online regional domain check (domain mask)
-         - filter: Domain Check
-           where:
-             - variable:
-                 name: GeoVaLs/observable_domain_mask
-               minvalue: 0.0
-               maxvalue: 0.5  # 0=interior, 1=outside of domain
-
          # Reject all obs with QualityMarker > 10
          - filter: Bounds Check
            filter variables:
@@ -8824,13 +8759,6 @@ observations:
              name: assign error
              error parameter: 0.01
 
-         # Monitoring mode (no assimilation, set QCflag=1)
-  #      - filter: Perform Action
-  #        filter variables:
-  #        - name: zenithTotalDelay
-  #        action:
-  #          name: passivate
-
          # Terrain Height Discrepancy Check
          - filter: Difference Check
            reference: MetaData/stationElevation
@@ -8841,12 +8769,12 @@ observations:
          - filter: Background Check
            threshold: 6
 
-  #      - filter: RejectList
-  #        where:
-  #        - variable: MetaData/productName
-  #          is_in: ["ROBG"]
-  #          is_in: ["LPT_"]
-  #          is_in: ["ROBG","LPT_"]
+#        - filter: RejectList
+#          where:
+#          - variable: MetaData/productName
+#            is_in: ["ROBG"]
+#            is_in: ["LPT_"]
+#            is_in: ["ROBG","LPT_"]
      - obs space:
          name: msonet_t188
          distribution:
@@ -8855,13 +8783,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_t188.nc
@@ -8878,7 +8807,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/sfc_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -8899,7 +8828,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -8912,7 +8840,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -8923,7 +8850,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -9019,6 +8945,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -9121,7 +9048,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: msonet_q188
          distribution:
@@ -9130,13 +9057,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_q188.nc
@@ -9153,7 +9081,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_q_geoval_2022052619.nc4"
+           #  filename: "obsout/sfc_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -9174,7 +9102,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -9187,7 +9114,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -9198,7 +9124,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -9249,7 +9174,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -9295,6 +9219,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -9397,7 +9322,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: msonet_ps188
          distribution:
@@ -9406,13 +9331,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_ps188.nc
@@ -9443,7 +9369,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -9456,7 +9381,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -9467,7 +9391,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -9563,6 +9486,7 @@ observations:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -9665,7 +9589,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: msonet_uv288
          distribution:
@@ -9674,13 +9598,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_uv288.nc
@@ -9692,15 +9617,12 @@ observations:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_winds_geoval_2022052619.nc4"
+           #  filename: "obsout/sfc_winds_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -9722,9 +9644,7 @@ observations:
          # ------------------
          # Mesonet winds provider/station use lists
          - filter: RejectList  # initially reject all providers
-           apply at iterations: 0,1
          - filter: AcceptList  # accept back selected providers
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["RAWS","NEDOR","SFWMD","MOComAgNet","UDFCD","CAIC",
@@ -9732,294 +9652,252 @@ observations:
                      "OK-Meso","MesoWest","WT-Meso","WYDOT","NOS-PORTS",
                      "NOS-NWLON","GoMOOS","HADS"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["AFA"]
            - variable: MetaData/stationIdentification
              is_in: ["AFA12","AFA09","AFA01","AFA11","AFA06","AFA03","AFA02","AFA04"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["APG"]
            - variable: MetaData/stationIdentification
              is_in: ["APG4","APG9","APG1","APG7"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["APRSWXNET"]
            - variable: MetaData/stationIdentification
              is_in: ["C5674","AR622","C4709","AR986","C5444","C4827","AR784","C3771","C8843","C2876","C5272","C6207","AR743","AR983","C3518","C4488","AP121","C1470","C4014","C4183","C8715","C8427","C5804","C7467","C7070","C1456","AR701","C4887","AR581","C7966","C8358","AR671","AS402","AS459","AS549","AR104","AS457","C7511","C5590","AP133","AP513","C8607","C8839","C2024","C5210","AP228","C4409","C5817","AP051","AR477","AP750","C6892","C6980","C5286","C1943","C8659","C7902","C2077","C8198","C5092","C6113","C4264","AS307","C6988","C5376","AR778","C2512","C3353","AP837","C2283","C2716","C1780","C3212","AR690","C1112","AP156","AP991","AR808","C3444","C4434","AR652","AP555","AR934","AS677","C8290","AP189","AR697","AR731","C2824","C4564","AP899","C3966","AS386","C7197","C4672","C0646","C4358","AR231","AR834","C7975","C4510","AS291","AS405","C7637","C1403","C2988","C7524","AS659","AP075","C4265","C3456","C7881","C0773","C4411","AR320","AS268","C2049","C6028","C1002","C2659","C0168","C3063","C3603","C5517","C6356","C6840","AS612","C7960","C4925","C7160","C5834","AS106","AR147","C0013","C3628","AR740","C5761","C4197","C7609","AP200","C1521","AR910","C3640","C3822","C4845","C6027","C8235","C8028","AR464","AR850","C6278","AS478","C5129","C7477","AR897","C2112","C4210","C5283","C0198","AS061","AS235","C0310","AS470","AS294","C6413","C6434","C8083","AP430","AP192","C5110","AS311","AR624","C8539","C1130","C2841","C6257","C7400","C3842","C8288","AR313","C0121","C5490","AP059","AS236","AP352","C0562","C3484","C3157","C4237","C5801","C4416","C6995","C7403","C4453","C4541","C1404","C8241","C7286","C8665","C1824","C1792","C0988","C2665","C5467","C5549","AP996","C5485","AP024","AP559","AR692","AS702","C3234","C3607","AS586","AP323","C5928","C3183","C5818","AS303","C7118","AS692","AS239","C2218","C4661","AP386","AP852","C3205","C2140","AS661","C8122","C4605","C1662","C4566","C7275","C8717","C1484","C3109","C6099","C2420","C2670","C2678","C6486","AS509","AR770","C2462","C3702","C4428","C5772","C5262","AP539","C7445","AS583","AP710","C3189","AP979","C6488","C5599","C4954","C6445","C6532","AP587","C5881","C4766","AR992","C0136","C4645","C5896","C6696","C7327","C7785","C7930","C8067","AS654","AP216","C2635","C6410","AR677","C6384","C5165","AS707","C8517","C2553","AS140","C2101","C4420","AS732","AS125","C5920","AR814","C3340","C6277","C3375","AR277","C0527","C7610","C5520","C4821","C2755","AS350","C8608","C8864","AR864","C6247","C2398","C8488","C5768","AR831","AR943","C1500","C1982","AP260","C7381","C5652","C7866","C7794","C8688","AR672","C5738","C4173","AP072","C6284","C8046","AR172","C4719","AP902","C4900","AP044","C3806","C6822","C6873","C8003","C8743","C8635","AP517","C6620","C0803","C4835","AS279","AP330","AS545","AP071","C7761","C2209","C8830","C2789","C1104","AS701","C4329","C6108","AR138","AR750","AS406","AR942","AS226","C1248","C2568","C5176","C5880","AR841","C4349","C6147","AS461","C4855","AS688","AS676","AR684","C1331","C5049","AR666","C6612","C3154","C3931","C3414","AS441","AP682","AR773","AS296","C4880","AR659","C1775","AS257","C1123","C7003","C6944","AR854","AS070","C0288","AS500","C7667","C2006","C8738","AP859","C6622","C7832","C1621","C5488","AS582","C2715","C0677","C4115","AS202","C3407","C3833","C0222","AS716","C8220","C1450","C7633","C5951","C4199","AR598","AR758","C2069","C3712","C7955","C8810","C0160","AS593","C8361","C4554","C6357","C5598","AS436","C3670","C4840","C6917","C1334","C3379","AP894","C0636","C4367","AR525","C6777","C6817","AP061","C1052","C1999","C8190","AR259","AR391","AP165","AP122","C3750","C1732","C1749","C3459","AR727","C5084","C3438","AS440","AS712","C5040","C5595","C5972","C1323","C6884","C7234","AS617","C5632","C3320","C2857","C0162","C6245","C1789","AR918","C2562","AS495","AS044","AS520","C7857","C0572","C5471","AP689","C4184","AR853","AP769","C2787","C7607","C7741","C6633","C5482","C5437","AP291","AS547","C7939","C8592","C7933","C8026","C4669","C5464","AR816","AS041","C4838","C0922","C0181","C3722","C6848","C2258","AP221","AP895","AR914","C2840","C7260","C8782","C3639","C5504","C5616","C2920","C6043","AP201","C6887","C8849","C2434","C7273","C5183","AS313","C8632","C3934","C4262","C5103","C1840","C3200","C4299","C3236","AS539","AS609","C8728","C8842","C2912","C6135","C2534","C5849","AS591","C4614","AR747","C7784","C8343","C1020","C6937","AS292","C7945","C0752","C6311","C7293","C0453","C2995","AS237","C2951","AP244","C3292","AP734","C2627","C2943","C4691","C5029","AR237","C2003","AS329","C1622","C7710","C0757","C0451","C4113","C5970","C6829","C3261","C1259","C0228","C6728","C6725","C0930","C5270","AR786","AS463","C6969","AR718","AP818","C5466","AS614","C5344","C0213","AR663","C1701","C3837","C3926","AS542","C3235","C1795","C7527","C7759","C6720","AP551","C5786","AP601","AR430","C2094","C3742","C3655","C3213","AP126","C8232","AP542","AR516","AR191","C4767","C7921","C4921","AS618","C3250","C3323","C3071","AS054","AS326","C2978","C4185","AS717","AP904","AP912","C7707","C8373","AR801","C6895","C4448","AR284","C4939","AR931","C5719","AR509","C4525","C0900","C6558","AR906","C1837","AS167","AP241","C8256","C8685","C0732","C6267","C7060","C6803","C0508","AS314","AS327","C7718","C7369","C2247","C6304","C4586","C7077","AS045","AS727","C4679","AR585","AR358","C0458","AS064","C2280","C8856"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["ARLFRD"]
            - variable: MetaData/stationIdentification
              is_in: ["TER","LOF","IDA","RIC"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["AWS"]
            - variable: MetaData/stationIdentification
              is_in: ["JKLNH","FRBRG","ATF29","PROUT","SSKTN","BMMNT","CVLTN","DEPEW","LITHS","MRIDN","VNNVA","CLIFT","PLNTT","PMPTN","MDRBC","TAYLR","ONSID","OMAHA","BEAUM","SANTN","CLMKS","KTHVL","LGNNG","GRNTT","LKLML","DALLS","RICMD","RONDV","WOBRG","THRNW","BALTN","FRLWM","TWNCR","HMOU3","SRFLD","TMWTR","NWHIT","SMTHV","SNTNO","HALFX","HCKTT","CPLAY","ONIDA","DUBOH","MLVEN","WCYBT","AIKEN","SHERM","NNSNV","BTHBS","SOMST","FMCNR","FSDRC","SLFDP","MMGRD","FLFRD","BSO03","DLND3","HLDHP","KHEAH","MRTNG","REDWD","NWHLP","MNOKA","COLOR","GDNGS","DNTNP","AXDRA","TFTCN","GALUP","WJRDN","CNTRY","SHEFF","SENSE","DUNCA","BGSND","BUDDY","HNCDL","PRTTS","GRMCG","KNGSM","ORLDO","ASTAG","PHCHS","GLMRG","CARTN","FLMTH","WKVIL","GRNDI","CRVFR","FORFX","TZWLL","DQUOI","GLDMD","DLRYD","PFDRK","DURNE","NTBND","WSHNJ","WHTNY","MARIC","HNDRT","WLSON","CHTNA","WHAVN","FREDC","MTHIN","ELBRN","RHIWY","HALTN","KGGES","VMCSN","BRMPL","RCKTM","SPEED","STVNO","RYRSF","HNVSL","PLNCP","BLMBL","CINNT","PLANV","BTPRM","SCOTT","SAPNG","MNREW","BBLKE","GSLNE","PTINE","BNSRS","DMSCS","BYRM2","PDNCT","DHRLT","RLGH2","CNLMS","CANBY","HFMHE","SYMSJ","LNFR9","ELWOD","AKRNL","MRTRV","HBBRD","HENSN","CHRCH","LVWTH","MEXIA","SANAO","WYLIE","PALSD","AZLTX","KRKBC","PHBOB","WSTJR","MYFLI","PITTN","A0045","RCHMB","PHLDH","MRRRV","JLTNS","HLLFR","STNTV","DBLNS","GSNAV","FMLCM","STFFR","KACHS","CUERO","HWKSH","BNTNH","CISPK","LBLLC","LNF45","KNNTT","ELGTX","TXRKN","RSSLL","VCTR1","BITOL","MORGN","RISTR","CRLLP","XLLMS","OFLLN","KSTFE","AMERY","AMRGS","STHJN","PNCTY","AUBUN","CPEVA","KESHA","LOCUT","BRKLI","LMNST","MMRMS","SLSBR","RDNTH","MZTGM","CRRLL","ASTAK","DLND1","MCCAL","ORTNG","JTMRH","SHNNH","WTRLC","HSSVP","KFDMT","PLSNJ","GRHBL","HRNDN","PDERI","WYNSB","SSSXW","ASHNN","MNNON","CLUBA","PTTSH","FRMYC","SNCPS","HRTWD","KNSMK","MLLCT","SVSPR","WSTNN","KLLES","DNEMR","BKNTZ","KTVKT","HDRSN","SWANS","WLDOR","MNTBR","CRDVG","NWTNC","OKSBA","VNDLC","BLMRB","SNHMB","FRLCC","CORON","SANTP","CHMPL","CLLYV","SBSTP","GWUNI","NEWCS","BNKRH","OCCTE","CHGPS","LNGGR","MSTIC","HNDFC","GAIBG","MMIFL","URBNN","LXNGN","BEUMT","LLMCH","VIDOR","FYTHS","GVECG","MPHS1","KLLMS","MOSSY","VGHN1","LBNNP","BRNTS","WNNVG","BEMA1","ANNEA","NOLSM","HSTKM","TLASS","STANW","PHELN","KDESG","FRTSG","DNDRN","ESTCH","VLNTW","CCHTT","CLYMR","ARPJH","CRSTV","BRDNJ","DNTNC","NWMRT","NVHVN","WLLST","BTHPG","FRDRD","DNVAL","TRNVS","PRSMC","SHLIS","JAYOK","INGLS","GRNBY","BLAIR","HBGIL","MAMIF","MOORE","RVRDG","BRMNG","CONTY","LILLI","SYKEV","WRNSE","SMMRV","EPLST","LVRCC","ATHEN","LUMBR","DETSC","NWTLD","KIIGS","CRSCS","CLDGE","HAVDG","MILVP","PRINC","ROMPA","CHTAN","WRWCK","FRDNA","NMTHB","CRMXL","HCKY1","RCKHL","HRNLK","MNKHN","BWCCD","SANDG","ARLNX","SNNWS","DLTON","RPLEY","MTRSN","WHTSV","HOBBS","MVSTA","WREGT","JEFFR","HYMRK","BELEV","FRDDC","LNCJF","SGRLF","SIMIV","CLEBE","BNSHS","EDONO","EWING","FRSBG","GLFRD","WODBG","WLWMS","MNTST","BCKNL","RIPTN","BUNNB","BURES","DVHCC","JCKSO","OWHMP","MTCHN","ASHBN","CSHRE","CULAL","ELZTN","NWBLM","UPPER","WRRNG","KNNPL","SMMTS","ALGNQ","BTTLB","PLVRN","LNRCU","PWTCS","RBBPH","FXBCV","MDTWN","AEXDR","A0020","NCKLS","STTLC","WNDMH","MASNC","MTBRD","MONEV","ELYNV","FLFRS","SLIDE","ELMSF","HSSLS","CLESP","COPLY","FALWR","LUMBE","GRVLL","PCNSM","WSTCI","LFRST","FRMNT","HMPSH","LONGD","RCESS","RCKTC","MILVL","WALDF","ALPLT","GALIN","PTESN","KNXVN","TMPSH","DLTH1","ASHRB","BEAVF","LALTO","BRSRS","TCMEE","MDINA","GRNLD","MODST","GRMBL","BMNBS","NPVN1","BTHLC","LNGLV","JCKHS","GREEL","MANFD","ESTRC","GRNSD","AVPGS","WSTDN","GLFNC","SEEKO","MCHPC","GGHRB","GTHBG","UNVRS","DPONT","RDFLD","PINEB","WLLWS","WURBR","DGHTN","PHLLL","MRTVL","ANDCS","CLMSD","FBGMC","KCLHS","MRTVM","RMSRM","ESTNP","FRSTG","BINKR","BRMDN","HCKRY","WETVL","CHEEK","TMBS7","RNBRN","JCKJR","RLDMN","CLVLN","WSHVG","PNXST","STBEN","GSCRK","CNGFL","MMMCH","CCCWS","PRTHR","MINNP","SMVWD","PARIS","WSHVL","MNWSH","WHATN","STAFF","DEWYV","ELPRG","WDWRD","ALVRT","MPLRG","KMOMS","LULNG","STTL1","WWBTV","FAYET","BVRTW","ROCKW","HRTSD","FRASR","LNSDL","CRSRV","CSPRG","EPRVD","CRLSC","SLMSP","CLWMM","TRMNF","JPPRN","DVRDH","ALBNY","OLDTP","RVRTN","FRRMF","CRKCT","SHRDN","BLSML","ASIND","CLEGE","STCLR","MANA2","HRTWL","BRPRS","VHSNA","NWEGT","STRTT","OLDFR","SLTNG","THMSC","PITT2","JMS03","SNRSC","WODBR","MNCRN","AVLCS","STLGL","GRVPR","SLSBY","WHRTN","BRWST","LSCRG","WSTPR","GRENR","AIKN1","SCTPL","CLNCL","WLKSB","RSMVA","DTMON","NATCT","HOTFR","SLMSH","SHLLL","WAVYT","JCKGP","RANIR","LCSTR","GVILL","SPGKF","AVNMT","CLPPR","MANHM","REDNG","RCHM2","NRWLK","PRBDN","RSVLL","FDRLW","OPRKN","RYNLD","NWRKS","VLNVH","CHVVS","WSTWN","LRNBG","SCCSN","GSTNA","LORTS","RCHBO","IMMKL","HOMLA","TNKHN","AMNAD","CRPWL","CABRD","MDLWS","CMPEM","WSTPN","CMBRK","ANNDL","WDSTK","BRWCK","ARCHS","LNF20","QNLAN","LNXBC","YLNC2","CHRNC","JECTY","LXTON","SHRWD","SLCUT","JNCTN","WDBJT","KGCBS","FTWTV","ELPRS","BOAZ1","WHTPL","NEWCN","BURNE","BXLDR","STPHN","VSLLS","LNDNN","YNGSJ","BRGPS","BTLCH","GNSCS","HRNVL","BRENH","GRNDO","ISSQH","MCCLE","MSSMC","PNBMC","HSHBY","HANOV","HGHPN","WHTVL","KUHES","RRNCH","SANTE","ONLGO","LARTY","CORFU","MILFL","WYSBO","CSTLW","NWMLF","WILMD","WRRNW","LHGTN","ORGTX","GLENW","NSTHB","WRNBG","SLNSC","HJHSB","APLMD","SDNBL","BULRD","GNIST","HAMLT","BSSMR","CRAIG","MNTCP","BMSPT","AUGDC","URBAN","CHTMG","WATGH","VRGCH","OCNCT","DPKNY","TACOM","SARDN","SNDYC","BRBYS","MMLMC","STLMS","REDPB","CLNLH","KRKLN","BSHPR","PNGCH","CFDPT","DTNTN","HUMHS","WDSWH","WYTHV","MCNCO","RRHMN","NRUHS","MARHU","LNGMD","STRSM","CPCOR","MIDVO","CLRWT","COVIN","TLRSS","SLMNC","ODNVL","RDMND","SPHSC","BRMRT","VERON","MAYVL","PNRGY","HRWNS","WURFR","CETRS","MPLWE","MCKNN","MCNGI","MTVR2","NEWBM","ARNCC","MMMDC","CHMBR","VWCCO","SPJDF","SMTHB","RYSFD","BLKVL","KHDHA","LAFYG","CMARN","CMDAR","FRFPW","CTVIL","MDSON","MNRVL","STORS","OKDL1","HRNLL","GLDSB","RLGH3","TLAHS","OPLCK","PNNNG","BLLVV","ALSVJ","MARRE","SCRON","HAGRS","SHBAB","STTMS","LODIM","ORNGF","ALDNA","CLMSC","CLMNS","BNGMN","LMNGR","SFFRN","CHPSB","BUMNT","LESSC","BRDFD","HAMLN","MANAS","GWNDA","CHSTS","PLMGV","CLNCP","OXFDN","CRLSB","SLDSM","WLLWH","CRTSM","BLMBH","WXYZT","CALFN","DTRED","TMBRK","NALSC","WHLRV","FRNDL","BYCTY","COVGT","MNSAS","WSTGV","CMLLS","BSDGT","CHRLR","MTESO","MNSS2","WTMTR","DCHEC","JCKHP","RMGTN","BATVL","MTQCR","DRSDN","ANSNA","ASHLY","DRRYN","MORTN","PROPL","LNCTN","CHSHS","CNPLS","LKWDW","SMRIA","LSCPA","ABONY","DKLND","SRTHF","ALXXD","SLSWM","DPSAR","NAPBS","OCCAL","LSBBL","WBNST","NRWDQ","WPSMH","DRPKN","NWHPR","ELLEN","WACO4","FTWR2","CHRTT","HKSTN","MYRST","ROMLS","NRTHJ","RSTRT","NESMR","MPTPR","KYHCC","BCYRS","SHNTN","ANTCH","BMNTR","MDWAY","BLMNT","LBNON","BFFLO","WDSTW","CLMBN","NPLSD","LEBNO","ALAP3","FRWSB","ALAP1","HUMBL","PTFSB","LRLJC","WRGHT","MARON","DCTUR","HRMTG","LVNMM","NFAIR","MYFLD","CAYGA","FERFL","FSLKE","SNJNC","JCKNO","MECNC","CHRLG","RLGH5","PHLDD","MNSSN","SLVLN","DRHMC","GNLCM","RNRMS","HAMOK","OSMNN","CPERL","RDNLP","ELKTN","WGGSC","CHRTY","BRSHM","ESTHR","LHSAL","ARRAN","APTS1","CONRO","KBBEJ","PNMES","DECAT","SOUDR","MRTHN","BRTWW","CRNDL","LRAY1","ESTHD","CHRON","SOLHS","GLDSP","STNWM","RSPFP","CHEKT","JMS04","BRTLS","RNTON","WNNMC","FFFMN","BRN01","KSTPT","BRDEN","SCHOL","NGMSS","BNLVL","EPHRA","MDLTV","BDFPV","CHPLH","MMLTN","BWLIG","LRTTC","PNTG5","LNGMP","CLDNY","HLLSB","GRNLN","FRCKP","BLLVU","CMNSL","MDLTN","YARDL","IMPRL","HSTN0","FRTGB","TRTLK","CALIF","FRNKV","OKDLE","LHMNL","BFLCH","CHYNY","WODBY","WNNFL","SETLE","LAGUN","HLLRD","PHILP","VNLND","GSHNJ","GRVSB","HRMNS","NWMDD","KIRBY","LKWLS","LAPTE","HWLND","CRSFL","RRTNN","UPTME","ABNHF","NAVAS","BLLMM","ESHBR","SHAKO","KSHRM","SGRNG","IMSVL","PELIN","PORCH","SCHAU","LKVLL","ELLNV","TRNLL","MIAM6","CYPRS","TCMWA","DRCHS","WLTRB","GLNRC","CRVST","KJOSC","KRMLG","WLSNC","CPRSS","PLMAL","RICHL","WSTMM","CPRVL","MTNWA","GLLWV","PNTGR","MLFHT","RYRFR","MNLSF","FRCST","CPDRL","CHHLS","MNTNC","RSTON","THPLN","HRRDS","HEGNS","JONES","WTFRD","SNDG1","ATTCA","MSSPQ","NLNDN","BRWNS","LHGHC","FT1MT","LRLHL","WTVQT","DLTPC","LKBNV","STHNG","MNRCM","CLRAH","LANGL","BFFLS","BONHM","MARLN","STBRG","GENEA","TOMBL","KNWAT","AUROH","WLMSV","NEWTN","JRMYN","BRDMN","FMYSN","MDSN1","VCHMN","DBNNW","STHNR","CRNX1","RCHWR","SNDI0","BLLVS","MCGVL","EGLRV","CMPBL","JZLTN","LEROY","BNTSL","PRRRY","NPRVD","CHRHU","CLWST","EGLNS","BRNSW","HILMR","LNXHS","CDDML","EURKB","SLNSA","PRTBY","FRSTB","FRDMY","SBS02","MNCNS","ELWRT","FMNTN","STLFC","EDNBR","TRFLG","BGLSB","SPRCT","HRHES","WFORT","DMOND","LIZTN","YKSHR","CHALS","SWFTW","WLLBG","AQLLI","GRNS1","NSTHH","HDLRD","PRVON","BFFLM","KWIES","MRCRS","PLMTT","PGHKA","JSTON","FRTDF","NAPA1","LCKPT","MERDN","POWHA","WNTZV","TOPKA","WTTRV","PLMTS","RSFRD","CAPCL","FTBCM","DISPT","NEWWM","MRAMR","APXNC","MIDBR","SPIGN","LEBON","QUAKT","FPDPT","SLLVN","TRYBU","JMS02","PHNSM","CESSC","HRSHM","CLFCO","POETT","BTHLS","BRNTW","MKSCR","ACMRS","BRUSW","NAMSS","WWLPG","STRLI","HGBRD","RCHST","NPLSL","CHRRS","FRMDD","CHRVL","PCHUT","KLEIN","MTENT","ABGTN","GUILF","MIAM2","RLGH1","TCMMF","WZVNT","MSHWL","BOLVR","OKFLD","GRNDR","LTHM1","BEFFL","PRNCS","BDFDV","WRWRG","WNTRE","FREDT","MKERK","NWTON","RCHDL","RSNGS","WAVRL","NSTSU","CRNNB","PWTCK","ESTFR","NWDST","WLDNP","DNSPS","BRDJW","SLDNR","ASHBR","NRTHU","MLTNL","NVADA","RSNRS","DOLPH","ELCTV","GBSNA","SAVTN","MNTVN","BTHMY","SMTHF","LESSF","MRCIL","CRSPO","SEAWR","SNJSE","NRTHR","A0031","LXNPP","CLRPH","MATLD","GSOCM","ASHSH","HSLND","PCBCH","WHTHL","MINLA","SRCHL","PRRV2","SPRHE","SPGDL","WWLPW","HLMSB","DNSTJ","CRTLS","SVGRD","AHSKE","MNSMF","VCLRV","ABRNS","BLAIN","LNNLN","BRSTW","FRANK","WKFST","WSWEC","BSO02","PRCSD","LSBES","DLVL3","CAPCO","ULYSS","BKFLD","EHAVN","KSSMS","OKLYV","MSCWL","JSPER","STHDY","WLMNE","EVJHA","DLLWY","DCECX","AKRNB","OSCLA","LANDO","DANVL","PTSTW","SYRCS","SLMCC","KNGWL","GRDNC","BRCKP","UNVPL","MARNO","CLMSN","RALGH","MNMNV","CHRDN","FRDBG","HMDEN","MRMAR","LAWNC","FRMNJ","DDLEY","WESSN","TACPE","WHNT2","DOYLT","MCHVL","WTRTN","ESTRR","MDLJR","NWTN1","PKTNN","JKKSN","NWIVN","PRRFR","MNNDR","BFMMA","OCCTY","OLYWB","ANDRW","CMBDC","KETUM","BNNYL","WLLWP","MSHIM","DIMCK","HFFMN","ALFRD","FLMDT","A0082","CRNLS","SEEKK","TKKWL","HGHSV","JSPRH","RSFHM","YANKE","MDGRD","WSTGR","PUALP","KNTWA","TACMA","HIGDN","OLDWS","DTRTV","RTTMN","WALLR","HESPE","WTNHT","HNVRT","ASTRA","FRKNN","MDBJH","BSO07","SARVR","ESTHS","CNTPL","PACSC","OKHRB","CAMAS","BRWLL","CBANY","MNTPL","BTHHA","DACSC","OFLCS","ROCHE","OZRDC","THMLM","ATOWN","GGAPL","EVADL","KUNTZ","MINRL","WNSKT","SLTHL","DNDNN","LGNTN","HLLRT","RLGHD","LXNGT","BRESC","RYREV","RBSNC","FWOTH","TCMAW","ALLNN","ATTLL","BOYER","UNVDE","JIMLW","CHNTL","WLCTT","LKWDA","CRMEL","SNYVL","CUMBR","OLEAN","SPGVL","PIRSN","SPNDR","HUTSV","NEWNJ","CLLMN","SHPBG","ETNVL","OTHLL","MOSCW","LXNGS","NTCHZ","GBFHP","NBUOH","ALTMN","MANSF","MDDON","STHLD","CENSQ","CHTTN","SBURY","MCHNC","VNCMB","NRTBY","DFBS1","PHLFF","DLND4","SMSTX","BBRNC","ALLCS","CHATT","HAMBR","FLKVL","GULF2","ELBAC","GBORO","WSTPA","MRRRJ","SLDAD","LYNJS","WRWNY","NORWH"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["AWX"]
            - variable: MetaData/stationIdentification
              is_in: ["AW314","AW281","AW381","AW233","AW345","AW213"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["CAIC"]
            - variable: MetaData/stationIdentification
              is_in: ["CAEGE"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["CODOT"]
            - variable: MetaData/stationIdentification
              is_in: ["CO102","CO006","CO001","CO103","CO096","CO104","CO066","CO020","CO071","CO095","CO089","CO008","CO084","CO067","CO097","CO065","CO099","CO073","CO072"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["COOP"]
            - variable: MetaData/stationIdentification
              is_in: ["PATM1","DANM1","RGLM1","ISPV1"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["DCNet"]
            - variable: MetaData/stationIdentification
              is_in: ["DC008","DC001","DC010","DC009","DC003","DC006"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["GADOT"]
            - variable: MetaData/stationIdentification
              is_in: ["GA109","GA113","GA114","GA104","GA103"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["GLDNWS"]
            - variable: MetaData/stationIdentification
              is_in: ["KCO0","KSYF"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["GoMOOS"]
            - variable: MetaData/stationIdentification
              is_in: ["44037","44029","44034","44024","44030","44035","D0201","44031","44032","44038"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["HADS"]
            - variable: MetaData/stationIdentification
              is_in: ["MRVA1","OBII2","OLCN6","SXHW3","BSBM4","SLVM5","CLSM4","JAKA1","LOKI2","PNGW3","WHRI2","SRDI2","OTNM4","RPRN6"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["IADOT"]
            - variable: MetaData/stationIdentification
              is_in: ["RBFI4","RLEI4","RIAI4","RCEI4","RWII4","RDVI4","RDCI4","ROSI4","RSDI4","RDWI4","RDSI4","RCAI4","RFDI4","RMCI4","RTOI4","RTNI4","RONI4","RSYI4","RSBI4","RSLI4","RMVI4","RMQI4","RAVI4"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["IEM"]
            - variable: MetaData/stationIdentification
              is_in: ["SCSI4","SPYI4","SAFI4","SGMM5","SGRI4","KKAS2","PESS2","SSAI4","SFAI4"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["INDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["IN001","IN009","IN014","IN008","IN004","IN002","IN016","IN018","IN005","IN013","IN011","IN015"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["INTERNET"]
            - variable: MetaData/stationIdentification
              is_in: ["NWTC","SRRL","CSUF"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["KSDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["K1EGN","K5KSM","K5EUR","K5EHT","K5KIO","K5ED7","K5OK7","K5LEA","K5WKY","K5WSU","K5NES","K5SLN","K5PEA","K5BCR","K5FRD"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MAP"]
            - variable: MetaData/stationIdentification
              is_in: ["LHSCA","CCOCA","BBYCA","CCLCA"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MDDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["MD020","MD040","MD054","MD038","MD043","MD018","MD012","MD011","MD037","MD027","MD029","MD004","MD023","MD016"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MNDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["MN011","MN035","MN037","MN010","MN095","MN024","MN032","MN091","MN086","MN080","MN015","MN008","MN025","MN014","MN057","MN082","MN029","MN076","MN018","MN044","MN052","MN079","MN045","MN059","MN071","MN021","MN026","MN038","MN043","MN036","MN030","MN075","MN042","MN096","MN022","MN065","MN007","MN084","MN063","MN028","MN033"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MOComAgNet"]
            - variable: MetaData/stationIdentification
              is_in: ["MOA14","MOA05","MOA06","MOA04","MOA01","MOA03","MOA08"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["Maritime"]
            - variable: MetaData/stationIdentification
              is_in: ["DBLN6","46012","45012","44044","MBLA1","45132","42003","LJPC1","41048","46027","44041","46091","LKWF1","42040","42019","PILM4","46026","45001","44017","45007","44007","44029","TPLM2","41025","CBIM2","46050","46147","PLSF1","41008","46047","45137","41046","46088","NPDW3","45135","THLO1","46005","KS063","42020","41013","42055","44053","CLKN7","44011","44030","46145","46059","41009","46092","SRST2","44150","CDRF1","42001","SBIO1","41010","LKPL1","44043","GDIV2","46025","44009","46093","SAUF1","42039","46131","42036","41012","FBIS1","44018","42035","SGNW3","45140","45004","45008","45006","41035","46233","46014","42002","45143","SYWW3","46029","45147","46022","SGOF1","42364","46013","46053","DPIA1","45139","46207","42056","44031","LONF1","TIBC1","KNSW3","41036","MHPA1","AGMW3","44004","KS057","CARO3","GSLM4","44038","44013","ABAN6","45005","44014","ACMN4"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MesoWest"]
            - variable: MetaData/stationIdentification
              is_in: ["CQ082","QSF","DSTU1","CQ089","ITD22","E5POR","QHW","TVANT","CQ148","JHR","TBLEW","KFCT","TIM60","CQ071","PYRLK","TSHER","CMP12","IMBO","TSUMA","A28","TSUMT","TCAND","MNDN8","GERW","MSCM8","CQ062","WRUN","TCHEL","QB4","HFRNK","CQ160","TLAUR","FOGO","TEAST","LMS","AAWC1","LFPBO","TSELL","ODT06","DPG20","ITD33","TBAIN","K4S1","TWHIT","CLR18","UWASH","MLAM","TOYST","ODT54","E1BEN","E9GRA","TKNAP","COVM","AWSC1","ENUMU","HHAMR","MKAR","SIGM","CMP23","CQ112","WGHA3","LIDW","CQ084","MARC","SEEU1","CQ098","DPG23","CTFPE","GFRI","RICH","MSWN","CQ063","DYER","TANAC","UP104","RXGI","CTHLT","SDMGR","WHALE","UT26","UP439","CQ035","ITD27","QWJ","A30","UTGRS","POR","UP353","UP459","UT23","MRSO","MESX","ITD41","ACOC1","STG48","ITD42","HRHW","CTANT","GUNN","CQ133","SEABE","OPH","ODT36","CLR17","MLPS","LYN21","T130T","CQ136","CQ060","DRLM","PICI","DENI","UP143","UP417","MWQHR","CTFYP","TI182","HRSPG","PTRCA","SDPOY","ODT20","ODT62","HRING","DPG05","DPG18","UP222","SDAPN","DEABT","HWYEB","CQ158","ODT33","TWALK","KCWU1","ODT01","ONTO","TACLS","HARMY","UP007","LDDW1","FALN","UT12","PCS","CMP04","CMP16","H200W","LDSM8","LVHF","RRWO3","SDPMS","RPTI","MNNM","CQ106","MYRI1","UP073","TSAMI","CCD","QRMO3","DPG04","PEN","SDHTB","KBDN","SUNUT","RDN","DPG12","HEDNA","TMARY","KQML","QHV","CQ178","MALI","TBLAI","CTVOL","CTOMS","SNI","MYEP","DPG15","MHYH","LAK","PUYSO","DPG10","DSKMT","CQ067","TSOAP","CQ144","CLR10","UP028","DPG02","CQ103","WPSPT","TRJO","UP164","CLR15","K92S","QHG","CQ070","ODT18","CPC01","CQ097","ITD29","A44","KQPW","TMUKI","CMP24","GDNSP","CPC02","CTDUN","CQ068","TEN","CLR05","ODT42","SDTEC","QBV","HRICH","CMP19","DPG09","UP156","AGKO","GVLI1","PEM","LAYUT","LORO","LANL2","TSPA1","RTB","HSURF","CQ032","MYRB","E8KLA","SDTSR","MPND","DPG21","QWV","SEADU","UTSTV","TIMN2","KQWT","TUNIN","ODT08","UP138","HP002","CQ147","RDHMT","MWQAR","QBR","DPG11","MLEW","ITD09","UT7","CTBOG","FTHI","UP289","CQ087","HBVLY","GOLW","WRDO","ITD45","KQCI","RVF","CQ102","CLR14","TSILI","TDRYD","CQ042","CQ074","LGVI1","MRED","MSCO","LOFUT","COAM8","DPG14","MRVJH","ITD03","MLOS","CQ099","CQ164","MTH04","MDEN","DPG25","UT3","SPOFE","TBULL","FMP","E3POR","ODSW","UP385","SDMEA","UTR20","STCA3","DPG13","FLU","MWQMN","CRVO","HERO","E3HAL","H100A","GNI","UP053","NUNC2","WEHN2","CLR02","MWQKT","CQ096","SBE","MBRM","FAU","GRS","UP225","NIPM8","TRGW4","JPHN2","CFO","MHCA3","ODT41","CQ104","FAFI","UTPSH","SJS","QMG","THFM8","ODT66","TES","UP196","CTBBS","MFLT","TSATU","LANL1","STB49","ITD44","DPG06","ODT67","CQ140","MGAR","MSWC","TMANE","MBVR","CQ040","CQ077","CQ093","CQ143","TUM43","URM","CLR01","CPC03","CQ031","HPASC","CMP09","CQ134","MGRN","NAM04","CLR03","KNTJC","ODT24","CMP13","CQ041","MWQEE","SKY","MTSC2","UP286","ODT17","LANL4","LEGW","TWFI","HVERN","ITD31","CQ132","SSWN2","ITD28","CQ154","MGOV","MGSA3","H100K","ITD35","DPG03","UTWTV","CRL","GROBT","MCHA3","TELKH","H100F","DPG08","VIOM8","ITD40","H200E","HHMS","CPC05","CQ117","CQ075","CQ146","CRSM","CEN","HPFP","CQ083","RES","MWQCN","NBDNB","TMANS","CMP25","CQ126","SDUSS","CTAND","DPG07","DPG24","TACAL","FVVLY","BULLF","CQ054","BURMA","CQ090","CQ170","CISCO","CUR","VRN","UP006","MWQRU","T2195","HGABW","HVSTA","ITD34","E3CAR","TKEYS","RDBM","T144T","CPC04","HBENT","CQ159","PRP","UP263","UP358","TWARD","ITD25","UTWLD","KQLX","ODT10","MMON","CSNSK","TSOUT","CQ065","ITD48","A05","A46","A13","LANL5","TMEDI","CQ052","CQ061","CQ129","CQ142","BKVO","TRITZ","CMP02","CQ162","DPG19","ODT29","KFLW"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NDDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["ND008","ND023","ND012","ND003","ND020","ND019","ND010","ND007","ND021","ND018","ND011","ND002","ND009","ND004"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NEDOR"]
            - variable: MetaData/stationIdentification
              is_in: ["NE029","NE011","NE039","NE000","NE059","NE017","NE006","NE056","NE037","NE026","NE049","NE058","NE008","NE016","NE005","NE057","NE015","NE027","NE042","NE045","NE054","NE014","NE041","NE009","NE047","NE050","NE030","NE028"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NERRS"]
            - variable: MetaData/stationIdentification
              is_in: ["WEXM1","BSLM2","ELXC1","NIWS1","NAXR1","MAXT2","GTXF1","RKXF1","SAXG1","GDXM6","TIXC1"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NHDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["NHLRV","NHSFD"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NJWxNet"]
            - variable: MetaData/stationIdentification
              is_in: ["KQ11","KQ59","KQ58","KQ43","KQ56","USFS2","USFS1","KQ55","KQ48","KQ49","KQ51","KQ52"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NonFedAWOS"]
            - variable: MetaData/stationIdentification
              is_in: ["KFPK","KS34","KMPR","KMYJ","K9S2","KHAE","KMAW","K78T","K2Q3","K6S8","KPYN","KN23","KUUV","KBTN","KTYQ","K1B1","K1D1","KCZG","KOIC","KHWQ","KTRK","KFSK","K97M","KSIK","KO70","KMBY","KX26","KEVU","KM75","KLRY"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["OHDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["OH105","OH039","OH160","OH165","OH055","OH064","OH062","OH101","OH154","OH027","OH044","OH040","OH164","OH115","OH124","OH036","OH090","OH014","OH162","OH106","OH126","OH050","OH011","OH076","OH096","OH163","OH158","OH060","OH148","OH107","OH116","OH135","OH109","OH140","OH147","OH117","OH097","OH150","OH034","OH023","OH159","OH032","OH142","OH111","OH083","OH030","OH166"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["RAWS"]
            - variable: MetaData/stationIdentification
              is_in: ["BBRC2","CCKT1","SRUC1","BVRC1","TS712","PRGV2","BFRI1","RSAC1","TS305","CBFI1","LCKI1","DUNN5","GRVN2","WFHC1","FADT2","UMTO3","LFFT1","DBYV1","NATW2","QPVA3","PRWF1","BMEC1","CPFO3","MCBT2","SSRT2","MILW1","LRLN7","ASTM2","ESPC2","LCLT1","FCRT1","BNTC1","CDHT2","GWRT2","OLFW1","DVLW4","OZNC1","MCLI1","MDHC1","BTRT2","NBKO3","HTSC1","ALRN2","SVNS1","CEKC2","RTGC1","BSAK2","CHRC2","SAWC2","GMTC1","RFPS2","COWW4","YEFO3","TS161","CNFO3","HDZC1","FMRM7","MAYW3","PIEM4","PLPW3","SEAM5","SRSS1","POEM8","RRAC1","BEFO3","ECSC1","MLLO3","TCRA3","WPKO3","TBSU1","MYFI1","TR490","CRKI1","MDRW1","OVLW1","CSTC1","KNNC1","TSOW1","SMFO3","HBFO3","MLKM8","TS395","RRDM8","GASI1","RRKN2","MRZW3","MTHI1","ALLN2","BCHN5","QSBA3","RANM4","TS211","BADU1","CISC1","BPYW4","QFSA3","SPMN2","WMTM4","BABC1","BMFW1","KRTC1","BGRM8","PIRC2","NHPC1","CHGG1","BQFO3","SPKW4","RPRT2","TS722","HBOM8","FHLC1","PKCC1","QMRA3","LDRC1","OJIC1","MRLV1","NPTN7","TR792","FFFO3","LDOI1","CICC1","PLIC1","BBYV2","CHEO1","LXFN7","GTGW4","TS583","AVLC1","HDRI3","LBLK2","POCN7","DKYC1","QENN5","GSCN5","RNFO3","CMRW4","BLAN4","GDSV2","HMEC2","TR272","CYFW1","GCRW4","CGLK1","LSNC1","PBUI1","MVVM7","SRYM8","CHFT1","NNHM6","FRNM5","TNBM1","LKRV2","GDRC2","TCKC1","TR192","RASW4","CIMN5","GALN2","KMFW1","TABC1","BRHC1","HHFO3","JAYC2","LVMC1","MIPC1","EDTF1","WLHS1","TR127","CAMW4","GMFW1","BBNL1","ARAU1","CDDT2","DNFI1","LRCM8","RHCM6","MPAM6","MWRM1","GLFM8","BNGC1","OTRU1","STKM8","FHFI1","JMRM5","LKNC1","MORN2","RLKN2","VENU1","BRUO3","OHOI1","SETC1","BIRM5","CITM7","FNWC1","GUML1","HBRM8","KTLW1","CMDT1","ESDA4","CPGT2","HPFI1","HSRU1","SADI1","SBWU1","CONM8","HYFO3","IVET2","KRBT2","EURM8","CLRW3","CUWN7","ELOM5","WNKN6","GPRM8","BENC1","VABC1","TS123","FLEI1","STGM8","FLSO3","CMAC1","NZAC1","CAZC1","KNXC1","MZHM5","MDEC1","ATNC1","CEKC1","CYFI1","FLFI1","JVLA4","BTTC1","EPKC1","LRRA4","PPRC1","BLDT1","HOBW4","MUDW4","WRRT2","BAFN8","DMMC2","FBFW1","OWFO3","LAUM6","LOLP1","SDFO1","WCAS2","TEXT2","TR543","SPGN2","BLCM6","SHPN6","NLHV1","CDFO3","RESN1","YLSU1","BYCU1","SDLC1","WTPC1","BATN5","MCDM8","BNRI1","CRGC1","FNWO3","SBFN1","GARL1","QBMA3","RNRM5","DOUW1","OBRC1","PCRW4","RSBU1","SYWC1","CTOC1","RDVC1","CPPN5","TR201","CKNT2","QFLA3","DVLO3","DARN7","RUTN7","TCCG1","TS199","CWLW2","ROCI1","BIGI3","SNDN5","QHQA3","TWBI1","MMRC2","IPFI1","WUEW3","MFCM6","SRRM8","TS698","MIGC1","SFAN6","FCHC1","MSAT2","QMLA3","PEEW3","TS350","MPAN5","SNGN8","MPRC2","TS623","HWDW3","REXM4","TS575","CRSN2","DRYW1","QUPA3","TR956","TS529","GSPC2","BHFA1","PYNC1","MSLM8","SKFI1","TS376","TS686","OVYC1","THRW4","ROVC1","BLNN6","HCOT1","LDRC2","NEFW1","INBS2","RBTN2","CSMN5","PSAT2","GNSC1","KOSW1","WMRO2","SDAM8","CPMG1","ESXV1","CGFW1","CUHC2","DEAI1","MGFO3","FMFO3","QSPA3","BPKC1","FIVU1","LAGO3","HAFW4","LSCU1","DEHI1","NCSW1","PANN2","HRDG1","LBHM8","ASYU1","WSFM8","KEHW3","MGST1","TS663","HIBW1","TS304","GRBO3","MOUC1","NUCI1","STMN2","NUCC2","RNDC1","RSPC1","AELG1","HFMN7","GCRN7","GFSK2","RFEC2","TR130","CDAW4","SLWC1","GUIN7","APBN6","PRID1","ZSFO1","BNHT2","PSTM8","AWWN8","PNRC2","SPAI1","LGNT2","TR269","TR007","JACN4","KOMK2","MAHN7","MMOM4","WOBN4","ARFO3","ERAW4","BLCN5","CHAC1","CHEA3","TS481","BLAU1","SMYI1","SHZM1","PAFO3","PLAG1","NATN7","SAMF1","LEFW1","MTZC1","NEHW3","TS545","DYLC1","MEGT2","LSRT2","FIEM8","PJNT2","PLEC1","TS674","TS720","BHRC2","KPRU1","HBYT2","MIRT2","WRRU1","CVEC1","SSMM8","ECRN1","BOLG1","FSTM6","GDNW3","MTIN7","HTVT2","CALN4","ATRC1","CAPT2","CVBC1","EVFO3","QRCA3","ABMN6","TS338","UTMN5","SMFW1","NBRN7","RRRC1","BEFM8","DENC1","OTOW1","PIBC1","TS631","LAHC1","RLAS2","RNEM6","RVZN7","TNFM6","SNYM4","WHBU1","TS429","SWNF1","EMTW1","LITM5","MPOC1","HTRC1","MIDW1","AGOW3","DSFI2","FVRV2","ISAM5","TAWW3","FBRN7","MATT2","TGSK1","VCRT2","BOOM8","NFFI1","CEEC1","HOTM8","BRSG1","SRON6","MKLN7","OKMA1","OPNA1","RKIF1","LACL1","DAFT1","PLAM8","PRFO3","PSGT2","RCPC1","WRSS2","BNFO3","SDMW1","WNTU1","NAOG1","SRVS1","JCKS1","MRRN5","TS726","TULG1","BYDW4","GDBT2","BAFO3","UINU1","POTI1","QISA3","TWRW1","EJAG1","JEFS1","TS682","CLHC1","PGRU1","RFTI1","JCRC2","TS164","EMRV1","RHOM6","BIIC1","FMRC1","DIAU1","COIN2","MSAC1","HUFW1","CYVC1","LPSA4","ORBM5","BHMM8","HCKC2","JVAU1","KYCN2","KCPT2","BPKN2","GELT2","STOC2","TR968","MPEC1","UNFN7","WSHW3","BRLW4","HBFI1","MIAC1","TS651","THKO2","BUFC1","TS341","ZNRN5","COWI2","GLMT2","QADW4","QCAC1","MRAG1","TS098","CLBC1","SAFO3","NINM8","CKST2","TMKO3","BYRG1","LBRM4","BUGC1","STVM8","TRDK1","KLOM8","HLKC1","LANS2","LICC1","STHC2","BUCO3","SNOW4","GRYT2","DRAC2","GMLN5","RSHC1","BDEM6","MTFG1","BXYG1","RMAM6","KNGS1","KLYW4","CVFO3","LRWT2","RONM8","SIAN2","SDRC1","WWDC1","YELK2","JONG1","DLSG1","RLFO3","TS724","LWDN8","TR297","KNMM5","TRMK2","BKBW1","RACF1","BLUM8","EGLW4","NPFO3","TS390","VLYC1","RLDM6","DFSM7","TS693","CHOM7","HDRT2","BKFS2","LOMN5","RHKW4","BFYI1","BRKO2","INDI1","QGTA3","FART2","TS619","FLSN2","PCKI1","SQSC1","OCOF1","BCFI1","BNVA4","CMMM7","DENT2","GINM8","QPFO3","RTCT2","RVZU1","SWLC1","KGWW2","LCFM8","BMJM5","LEVL1","KEEO3","STNI1","TROM8","PAMC1","TR285","IRFO3","ELRN7","FRCC1","SAUC1","PLTC1","HAYI1","SDNA4","SYNO3","LPOW1","THDC1","TR077","OLSF1","WHSF1","WINM6","TURN7","LPSN6","LPRC2","ELKW4","TS312","LSFC1","MSCN5","SLTO3","WKFM4","BLGT2","CSVC1","ENTU1","HIBM5","QTWA3","OKPC1","SUAM8","PRDM8","DESN2","HOHU1","SEVN5","TAYN7","LGRW2","BNDC1","LTJC1","OKSC1","TR369","TS689","MEAM5","TR532","VLCC1","WSRM8","EMRC1","MMTC1","GSNM8","AGZM5","GMFN6","WTHS1","TRII1","TS642","GNLW1","TLGC1","ACRI1","DHOC2","KBFO3","BKSC1","GRAI1","HHRW4","LCBC1","LNCM8","MDDC1","PEFW1","VRNL1","MRFC2","BKIN7","UPTW2","SAWW4","CLFU1","CTGC1","DLVC1","SRXC1","SVFO3","TR257","JSPU1","NSWI4","LFSM5","MLCN5","BENL1","IMWN2","MCKU1","SLKO3","BCHN6","NNAG1","KIGM8","TS690","TS718","WEFI1","BRNW3","LAAW3","STOM4","WMGI2","RMFN7","SMTM8","HSEC1","TS428","CMFW1","BHRO3","PRMS2","WISC1","LOHF1","SPLS1","LDYW3","LOUG1","BNYN7","SEEM8","GBON7","LPIF1","HOAC1","MSRU1","TS713","EGKO3","PHGM8","SHFO3","TMPT2","BATN2","PCLC1","CMLG1","GMWP1","BMOC2","RCRO3","COAT2","ADFW1","CQFO3","DEDN2","EFFM5","IMTW1","QGDA3","WHHM8","MMRO3","BBEC1","FISN2","SPLW4","PCFT1","JPRC1","WALC1","QHUA3","SIGU1","BOGC1","BFSF1","WHIN7","CSPC1","FBGG1","BFRW2","LPZC1","CACM8","RSCN2","BCNC1","ENFO3","ENNM8","RVYC1","MOWC1","RTFO3","SBFN6","TS556","FORN1","LGLA1","DOEM4","REDD1","DJTC2","TS659","CADT2","QLKA3","AMDN8","SRTC1","PARN8","MVAN6","FLRW2","SHLA1","TISM6","ATSC1","TCAC1","BLRA4","QSTA3","RBYC1","SFKO3","NATL1","NBRC1","APLT2","QNRK1","WSBO3","CGLN7","CLNC1","CYNC2","SLFC1","RYDM4","BTTM5","GSFO3","BIVU1"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["SAO"]
            - variable: MetaData/stationIdentification
              is_in: ["WLV","WSF","WUY","WQQ","WGN","WWN","WWP","WUT","WSU","WNC","WMI"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["SFWMD"]
            - variable: MetaData/stationIdentification
              is_in: ["S331W","BELLW","S7WX","S61W","ROTNW","SGGEW","WRWX","BCSI","LXWS","S78W"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["UDFCD"]
            - variable: MetaData/stationIdentification
              is_in: ["SAPC2","EBBC2"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["UrbaNet"]
            - variable: MetaData/stationIdentification
              is_in: ["LEMNT","PSCBH","CNNMN","EVRGR","LSV02","LSCRS","RSWLL","ALSTN","NWOCH","DRPRK","HNTRY","HARHN","LSVJC","PTOMC","STHGT","LVEGS","LSVRB","RVDAL","TKMPR","GLFPC","DRCUT","ADK15","WDSTC","A0022","STHTN","DGLSV","AMBLR","BNDVL","CRSRS","RPVRD","EVERT","MLTNO","DPTFR","RVRIL","MNTPR","DSNTN","MNSFL","BRNK5","DOVR1","IRVIG","SEUNI","LTTFA","BRON1","LSVGR","HENDR","NORRI","NWYK1","MSPTH","LNGBH","LSVG3","PHLDP","CLFFS","GLASB","PHLJW","PHILD","ALIVE","SPRMG","NWLNX","EWPLE","RDGFL","ALCES","CHCSS","CPTHT","MDLNL","LVGGH","CASLM","MLNPK","BLLMW","PS002","BRBNK","SHRNS","GORMS","LASVU","WBZT2","MESQT","HSTAS","REVER","PNSHH","LVGME","ATFR7","LNSDW","NRIST","LXVGS","ISVGS","HSTDW","GRMRC","WSHMG","HAKSK","LVGST","CMCRD","SCCSC","FXBRG","METRE","WNTHR","GMBRD","BRKYL","SGRLN","DWEBB","HNSPT","WSTNX","CALLS","LNBTW","HNFRS","DESOT","CLYMN","STNMO","EHDRS","AGTON","CHHCG","BLCKD","PASNA","CRLNG","NOLSV","JNBRO","YSNGL","NW7DC","OWYRK","WASDC","ARDMR","JNSYC","REGWD","NYSTS","PHL01","SLVSP","BTNRB","BTKLY","LVSVS","BX368","WHWKN","CHRCM","PHLD9","CRNYS","HDSMA","HSTWH","CHHRS","HSTNO","LVGMR","LVNGN","RTWYN","LASVG","LSVGV","LRLNL","LSNGH","DLCMC","JSBRO","LSVG6","LSVSA","PTRSN","NYSTH","LSVGS","PHLRH","MNDRS","MLVRM","HLLSD","CDRGR","TTTLT","PEPCO","NHCHL","ERNKL","PHIL2","LAVSS","BRCKT","ELZBS","NYPSW","BRX34","HNDLH","BLRNG","WDRDG","DLLS3","PHLD5","LSVG2","LSFGS","IRVNG","FRKHS","GRMKM","WSTOP","LVMJC","CINNM","BRKLA","STTCD","CANTO","NETWN","PHLDM","HSTCH","CRLTX","FSTRV","PHILA","GPRIE","CMCFD","BMILR","LNDNB","LOXES","WSING","HDSST","ADK14","BRDFR","LSVHH","ASTON","CHSTU","HVAND","LSVHF","HSTNU","LINCO","IRVIN","PRTHM","CJHCG","BTHWJ","HVRTW","ORNGM","FSTPR","ASTLL","PICYN","MOKEN","NWTVN","ADKL4","FRTWS","LSVG8","PHLDB","CHSBC","MLBRO","WRMIN","WSTKR","NBERG","SLDCS","TWKSB","WMARB","UMBC1","NEADC","ANDGL","GERTN","PHLCS","BNSLM","MS133","LWLLB","STTNL","LSV01","PS36K","SCKLV","REVSE","RCKWY","PHLDL","LTVGS","LSVG7","CNTNM","LSVCM","QNSFP","CHNOK","DLC01","CARHS","PHLD7","NRLNG","BRKLN","TCMFP","AWTY1","MCDON","ALVRD","PHLNE","CMDNN","KNTWH","GRLNC","READG","HNKES","WASTO","MCKLT","PS102","LAKMD","WTVNJ","AHSTN","BFDHQ","WLMNI","ECLFS","BKLIN","PHLDN","BRNXA","PLSDS","LFVGS","LOXLY","JMCST","BSTON","BRKAM","HSTN8","LSVGA","BROKL","PHLD3","FRTWY","NRRST","PHLD8","BRCMC","STINY","BRNSR","BRYNM","BRWYN","BLCKW","FRTWH","LSNDP","PHLPA","JNKNT","WHTMN","AWSHQ","USSAL","CRRBF","LVGRC","NWYR2","CURIE","WLLNG","PHLDO","CSVGS","PHLDY","BRST1","BRKTN","BYSD1","WSHDD","BRLNG","CHGMT","BFD32","CHHOS","NTHLV","NLMSF","HSTPN","EGLVL","LSNGN","HSGHC","BROOY","ELZBJ","HUNTI","ASNNU","ASVGS","TRRNC","FSLSS","LMBRT","CHESA","MTLR3","STHBH","HCKHL","BRKN3","LWELL","JRSYE","STPNS","BKBHS","BTRGB","DRXHL","CMDNC","BDRCT","LSVSS","HSHCH","NANDV","CHICG","MRLTN","KNRTB","MSFLD","GRMNW","LSNVT","DLLSL","LSVCT","HUTON","OKELS"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["VADOT"]
            - variable: MetaData/stationIdentification
              is_in: ["VA006","VA013","VA017","VA029","VA016","VA041","VA022","VA019","VA003","VA011","VA031","VA026","VA004","VA023","VA015","VA021","VA032","VA027","VA040"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["VTDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["VT002","VT001"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["WIDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["EKNW3","WAKW3","WI054","HAUW3","PAKW3","HSNW3","MNRW3"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["WXforYou"]
            - variable: MetaData/stationIdentification
              is_in: ["H0269","H0313","H0300","H0080","H0346","H0164","H0005","H0177","H0041","H0498","H0338","H0062","H0244","H0203","H0237","H0030","H0322","H0560","H0140","H0447"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["WYDOT"]
@@ -10028,7 +9906,6 @@ observations:
 
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -10042,7 +9919,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10053,7 +9929,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -10197,6 +10072,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -10291,7 +10167,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: proflr_uv227
          distribution:
@@ -10300,13 +10176,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_proflr.nc
+             obsfile: "data/obs/ioda_proflr.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_proflr_uv227.nc
@@ -10323,7 +10200,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/windprof_geoval_2024052700.nc4"
+           #  filename: "obsout/windprof_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -10345,7 +10222,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -10359,7 +10235,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10370,7 +10245,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -10647,7 +10521,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/proflr_geovals_rrfs.nc4
+         #  filename: ./data/geovals/proflr_geovals_rrfs.nc
      - obs space:
          name: rassda_t126
          distribution:
@@ -10656,13 +10530,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_rassda.nc
+             obsfile: "data/obs/ioda_rassda.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_rassda_t126.nc
@@ -10679,7 +10554,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/rass_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/rass_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -10699,8 +10574,7 @@ observations:
          # airTemperature (126)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -10713,7 +10587,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10724,7 +10597,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -10820,6 +10692,9 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
+           action:
+             name: reduce obs space
 
          # Bounds Check (ObsValue)
          - filter: Bounds Check
@@ -10920,7 +10795,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/rassda_geovals_rrfs.nc4
+         #  filename: ./data/geovals/rassda_geovals_rrfs.nc
      - obs space:
          name: sfcshp_t180
          distribution:
@@ -10936,6 +10811,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t180.nc
@@ -10952,7 +10828,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -10973,7 +10849,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -10986,7 +10861,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10997,7 +10871,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -11093,6 +10966,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -11195,7 +11069,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_t182
          distribution:
@@ -11211,6 +11085,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t182.nc
@@ -11227,7 +11102,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -11247,8 +11122,7 @@ observations:
          # airTemperature (182)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -11261,7 +11135,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11272,7 +11145,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -11368,6 +11240,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -11470,7 +11343,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_t183
          distribution:
@@ -11487,6 +11360,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t183.nc
@@ -11503,7 +11377,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -11523,8 +11397,7 @@ observations:
          # airTemperature (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -11537,7 +11410,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11548,7 +11420,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -11644,6 +11515,7 @@ observations:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -11746,7 +11618,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_q180
          distribution:
@@ -11762,6 +11634,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q180.nc
@@ -11778,7 +11651,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -11799,7 +11672,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -11812,7 +11684,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11823,7 +11694,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -11874,7 +11744,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -11920,6 +11789,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12022,7 +11892,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_q182
          distribution:
@@ -12038,6 +11908,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q182.nc
@@ -12054,7 +11925,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -12074,8 +11945,7 @@ observations:
          # specificHumidity (182)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: specificHumidity
            where:
@@ -12088,7 +11958,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12099,7 +11968,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -12150,7 +12018,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -12196,6 +12063,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12298,7 +12166,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_q183
          distribution:
@@ -12315,6 +12183,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q183.nc
@@ -12331,7 +12200,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -12351,8 +12220,7 @@ observations:
          # specificHumidity (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: specificHumidity
            where:
@@ -12365,7 +12233,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12376,7 +12243,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -12427,7 +12293,6 @@ observations:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -12473,6 +12338,7 @@ observations:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12575,7 +12441,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_ps180
          distribution:
@@ -12591,6 +12457,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_ps180.nc
@@ -12621,7 +12488,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -12634,7 +12500,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12645,7 +12510,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -12750,6 +12614,7 @@ observations:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12852,7 +12717,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_uv280
          distribution:
@@ -12868,6 +12733,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv280.nc
@@ -12879,15 +12745,12 @@ observations:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -12909,7 +12772,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -12923,7 +12785,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12934,11 +12795,10 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -12981,8 +12841,6 @@ observations:
            where:
            - variable: ObsType/windEastward
              is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_not_in: 522, 523, 531
            action:
              name: inflate error
              inflation variable:
@@ -13001,8 +12859,6 @@ observations:
            where:
            - variable: ObsType/windNorthward
              is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_not_in: 522, 523, 531
            action:
              name: inflate error
              inflation variable:
@@ -13013,46 +12869,6 @@ observations:
                  SetSfcWndObsHeight: true
                  AddObsHeightToStationElevation: true
                  AssumedSfcWndObsHeight: 10
-
-#         # Error inflation (windEastward) based on pressure check (setupw.f90)
-#         - filter: Perform Action
-#           filter variables:
-#           - name: windEastward
-#           where:
-#           - variable: ObsType/windEastward
-#             is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_in: 522, 523, 531
-#           action:
-#             name: inflate error
-#             inflation variable:
-#               name: ObsFunction/ObsErrorFactorPressureCheck
-#               options:
-#                 variable: windEastward
-#                 inflation factor: 4.0
-#                 SetSfcWndObsHeight: true
-#                 AddObsHeightToStationElevation: false
-#                 AssumedSfcWndObsHeight: 20
-
-#         # Error inflation (windNorthward) based on pressure check (setupw.f90)
-#         - filter: Perform Action
-#           filter variables:
-#           - name: windNorthward
-#           where:
-#           - variable: ObsType/windNorthward
-#             is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_in: 522, 523, 531
-#           action:
-#             name: inflate error
-#             inflation variable:
-#               name: ObsFunction/ObsErrorFactorPressureCheck
-#               options:
-#                 variable: windNorthward
-#                 inflation factor: 4.0
-#                 SetSfcWndObsHeight: true
-#                 AddObsHeightToStationElevation: false
-#                 AssumedSfcWndObsHeight: 20
 
 #         # Error inflation (windEastward) based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -13122,6 +12938,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -13216,7 +13033,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_uv282
          distribution:
@@ -13232,6 +13049,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv282.nc
@@ -13243,15 +13061,12 @@ observations:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -13272,8 +13087,7 @@ observations:
          # wind (282)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -13287,7 +13101,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -13298,11 +13111,10 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -13442,6 +13254,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -13536,7 +13349,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_uv284
          distribution:
@@ -13553,6 +13366,7 @@ observations:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv284.nc
@@ -13569,7 +13383,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -13590,8 +13404,7 @@ observations:
          # wind (284)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -13605,7 +13418,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -13616,11 +13428,10 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -13760,6 +13571,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -13854,7 +13666,7 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: vadwnd_uv224
          distribution:
@@ -13863,13 +13675,14 @@ observations:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_vadwnd.nc
+             obsfile: "data/obs/ioda_vadwnd.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_vadwnd_uv224.nc
@@ -13886,7 +13699,7 @@ observations:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/vadwind_geoval_2024052700.nc4"
+           #  filename: "obsout/vadwind_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -13908,7 +13721,6 @@ observations:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -13922,7 +13734,6 @@ observations:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -13933,7 +13744,6 @@ observations:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -14071,6 +13881,7 @@ observations:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
 
          # Bounds Check (ObsValue)
          - filter: Bounds Check
@@ -14217,29 +14028,38 @@ observations:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/vadwnd_geovals_rrfs.nc4
+         #  filename: ./data/geovals/vadwnd_geovals_rrfs.nc
      - obs space:
          name: amsua_n19
+         _anchor_channels: &amsua_n19_channels 1-15
+         _anchor_use_flag: &amsua_n19_use_flag [ 1,  1,  1,  1,  1, 1, -1, -1,  1,  1, -1,  -1,  -1,  1,  1 ]
+         _anchor_error: &amsua_n19_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
+         _anchor_obserr_bound_max: &amsua_n19_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
          distribution:
            name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_amsua_n19.nc
+             obsfile: "data/obs/ioda_amsua_n19.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_amsua_n19.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &amsua_n19_channels 1-15
+         channels: *amsua_n19_channels
        obs operator:
          name: CRTM
-         Absorbers: [H2O,O3]
+         Absorbers: [H2O,O3,CO2]
          SurfaceWindGeoVars: uv
          Clouds: [Water, Ice]
+         Cloud_Seeding: true
          Cloud_Fraction: 1.0
          obs options:
            Sensor_ID: amsua_n19
@@ -14252,14 +14072,14 @@ observations:
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file: data/obs/amsua_n19.satbias.nc
-         output file: out_amsua_n19.satbias.nc
+         input file: data/satbias_in/amsua_n19.satbias.nc
+         output file: data/satbias_out/amsua_n19.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &amsua_n19_tlapse data/obs/amsua_n19.tlapse.txt
+             tlapse: &amsua_n19_tlapse data/satbias_in/amsua_n19.tlapse.txt
            - name: lapseRate
              tlapse: *amsua_n19_tlapse
            - name: emissivityJacobian
@@ -14276,12 +14096,36 @@ observations:
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/amsua_n19.satbias_cov.nc
+             input file: data/satbias_in/amsua_n19.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_amsua_n19.satbias_cov.nc
-       obs filters:
+           output file: data/satbias_out/amsua_n19.satbias_cov.nc
+       obs pre filters:
+       # Regional domain check to remove data outside of model domain
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_n19_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+        #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_n19_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *amsua_n19_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
        - filter: BlackList
          filter variables:
          - name: brightnessTemperature
@@ -14349,9 +14193,7 @@ observations:
            channels: *amsua_n19_channels
            options:
              channels: *amsua_n19_channels
-             obserr_clearsky: [ 2.500, 2.200, 2.000, 0.550, 0.300,
-                                0.230, 0.230, 0.250, 0.250, 0.350,
-                                0.400, 0.550, 0.800, 3.000, 3.500]
+             obserr_clearsky: *amsua_n19_error
              clwret_function:
                name: ObsFunction/CLWRetMW
                options:
@@ -14503,9 +14345,7 @@ observations:
                    err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                             0.300,  0.230,  0.250,  0.250,  0.350,
                             0.400,  0.550,  0.800,  3.000, 18.000]
-               obserr_clearsky: [2.500, 2.200, 2.000, 0.550, 0.300,
-                                  0.230, 0.230, 0.250, 0.250, 0.350,
-                                  0.400, 0.550, 0.800, 3.000, 3.500]
+               obserr_clearsky: *amsua_n19_error
        #  Gross check
        - filter: Background Check
          filter variables:
@@ -14556,9 +14396,7 @@ observations:
                  err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                           0.300,  0.230,  0.250,  0.250,  0.350,
                           0.400,  0.550,  0.800,  3.000, 18.000]
-             obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
-                                2.0, 2.0, 2.0, 2.0, 2.0,
-                                2.5, 3.5, 4.5, 4.5, 4.5]
+             obserr_bound_max: *amsua_n19_obserr_bound_max
          action:
            name: reject
        #  Inter-channel check
@@ -14572,9 +14410,7 @@ observations:
            options:
              channels: *amsua_n19_channels
              sensor: amsua_n19
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1, -1, -1,  1,  1,
-                         1,  1,  1, -1,  1 ]
+             use_flag: *amsua_n19_use_flag
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -14589,29 +14425,47 @@ observations:
            options:
              sensor: amsua_n19
              channels: *amsua_n19_channels
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1, -1, -1,  1,  1,
-                         1,  1,  1, -1,  1 ]
+             use_flag: *amsua_n19_use_flag
          minvalue: 1.0e-12
          action:
            name: reject
      - obs space:
-         name: amsua_n20
+         name: atms_n20
+         _anchor_channels: &atms_n20_channels 1-22
+         _anchor_use_flag: &atms_n20_use_flag
+             [ 1,  1,  1,  1,  1,
+               1,  1,  1,  1,  1,
+               1,  1,  1, -1, -1,
+               1,  1,  1,  1,  1,
+               1,  1]
+         _anchor_error: &atms_n20_error [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000]
+         _anchor_obserr_bound_max: &atms_n20_obserr_bound_max
+             [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
          distribution:
            name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_amsua_n20.nc
+             obsfile: "data/obs/ioda_atms_n20.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
-             obsfile: jdiag_amsua_n20.nc
+             obsfile: jdiag_atms_n20.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &amsua_n20_channels 1-22
+         channels: *atms_n20_channels
        obs operator:
            name: CRTM
            Absorbers: [H2O,O3,CO2]
@@ -14620,7 +14474,7 @@ observations:
            Cloud_Seeding: true
            SurfaceWindGeoVars: uv
            obs options:
-             Sensor_ID: amsua_n20
+             Sensor_ID: atms_n20
              EndianType: little_endian
              CoefficientPath: data/crtm/
              IRVISlandCoeff: IGBP
@@ -14630,16 +14484,16 @@ observations:
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file:  data/obs/amsua_n20.satbias.nc
-         output file: out_amsua_n20.satbias.nc
+         input file:  data/satbias_in/atms_n20.satbias.nc
+         output file: data/satbias_out/atms_n20.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &amsua_n20_tlapse  data/obs/amsua_n20.tlapse.txt
+             tlapse: &atms_n20_tlapse  data/satbias_in/atms_n20.tlapse.txt
            - name: lapseRate
-             tlapse: *amsua_n20_tlapse
+             tlapse: *atms_n20_tlapse
            - name: emissivityJacobian
            - name: sensorScanAngle
              order: 4
@@ -14654,58 +14508,13 @@ observations:
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/amsua_n20.satbias_cov.nc
+             input file: data/satbias_in/atms_n20.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_amsua_n20.satbias_cov.nc
+           output file: data/satbias_out/atms_n20.satbias_cov.nc
 
        obs pre filters:
-       # Step 0-A: Create Diagnostic Flags
-       - filter: Create Diagnostic Flags
-         filter variables:
-         - name: brightnessTemperature
-           channels: *amsua_n20_channels
-         flags:
-         - name: ScanEdgeRemoval
-           initial value: false
-           force reinitialization: false
-         - name: Thinning
-           initial value: false
-           force reinitialization: false
-         - name: CLWRetrievalCheck
-           initial value: false
-           force reinitialization: false
-         - name: WindowChannelExtremeResidual
-           initial value: false
-           force reinitialization: false
-         - name: HydrometeorCheck
-           initial value: false
-           force reinitialization: false
-         - name: GrossCheck
-           initial value: false
-           force reinitialization: false
-         - name: InterChannelConsistency
-           initial value: false
-           force reinitialization: false
-         - name: UseflagCheck
-           initial value: false
-           force reinitialization: false
-
-       obs post filters:
-       # Step 0-B: Calculate derived variables
-       # Calculate CLW retrieved from observation
-       - filter: Variable Assignment
-         assignments:
-         - name: CLWRetFromObs@DerivedMetaData
-           type: float
-           function:
-             name: CLWRetMW@ObsFunction
-             options:
-               clwret_ch238: 1
-               clwret_ch314: 2
-               clwret_types: [ObsValue]
-
        # Calculate CLW retrieved from observation
        - filter: Variable Assignment
          assignments:
@@ -14764,13 +14573,13 @@ observations:
        - filter: Variable Assignment
          assignments:
          - name: CLWMatchIndex@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: CLWMatchIndexMW@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
+               channels: *atms_n20_channels
                clwobs_function:
                  name: CLWRetFromObs@DerivedMetaData
                clwbkg_function:
@@ -14785,13 +14594,13 @@ observations:
        - filter: Variable Assignment
          assignments:
          - name: InitialObsError@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorModelRamp@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
+               channels: *atms_n20_channels
                xvar:
                  name: CLWRetSymmetric@DerivedMetaData
                x0:    [ 0.030,  0.030,  0.030,  0.020,  0.030,
@@ -14819,26 +14628,31 @@ observations:
        - filter: Variable Assignment
          assignments:
          - name: Innovation@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsFunction/Arithmetic
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
                variables:
                - name: brightnessTemperature@ObsValue
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                - name: brightnessTemperature@HofX
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+        # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
-           channels: *amsua_n20_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         - name: brightnessTemperature
+           channels: *atms_n20_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_n20_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -14846,7 +14660,7 @@ observations:
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: GeoVaLs/observable_domain_mask
            flag all filter variables if any test variable is out of bounds: true
@@ -14857,12 +14671,12 @@ observations:
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: assign error
            error function:
              name: InitialObsError@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 1: Remove Observations from the Edge of the Scan
        - filter: Domain Check
@@ -14937,31 +14751,27 @@ observations:
        - filter: Variable Assignment
          assignments:
          - name: DerivedMetaData/HydrometeorCheckATMS
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: HydrometeorCheckATMS@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               channels: *atms_n20_channels
+               obserr_clearsky: *atms_n20_error
                clwret_function:
                  name: CLWRetFromObs@DerivedMetaData
                obserr_function:
                  name: InitialObsError@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
 
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: DerivedMetaData/HydrometeorCheckATMS
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          maxvalue: 0.0
          actions:
            - name: set
@@ -14973,84 +14783,84 @@ observations:
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorTopo@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorTopoRad@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorTopo@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 7: Obs Error Inflation based on TOA Transmittancec Check
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorTransmitTop@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorTransmitTopRad@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
+               channels: *atms_n20_channels
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorTransmitTop@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 8: Observation Error Inflation based on Surface Jacobian Check
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorSurfJacobian@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorSurfJacobianRad@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
                obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
                obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorSurfJacobian@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 9: Situation Dependent Check
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorSituDepend@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorSituDependMW@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
                clwbkg_function:
                  name: CLWRetFromBkg@DerivedMetaData
                clwobs_function:
@@ -15059,25 +14869,21 @@ observations:
                  name: SIRetFromObs@DerivedMetaData
                clwmatchidx_function:
                  name: CLWMatchIndex@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                obserr_function:
                  name: InitialObsError@DerivedMetaData
-                 channels: *amsua_n20_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+                 channels: *atms_n20_channels
+               obserr_clearsky: *atms_n20_error
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorSituDepend@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 10: Gross check
        # Remove data if abs(Obs-HofX) > absolute threhold
@@ -15093,41 +14899,37 @@ observations:
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorBound@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorBoundMW@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
                obserr_bound_latitude:
                  name: ObsErrorFactorLat@DerivedMetaData
                obserr_bound_transmittop:
                  name: ObsErrorFactorTransmitTop@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                  options:
-                   channels: *amsua_n20_channels
+                   channels: *atms_n20_channels
                obserr_bound_topo:
                  name: ObsErrorFactorTopo@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                obserr_function:
                  name: InitialObsError@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                  threhold: 3
-               obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
-                                  1.0, 1.0, 1.0, 1.0, 1.0,
-                                  1.0, 1.0, 1.0, 2.0, 4.5,
-                                  4.5, 2.0, 2.0, 2.0, 2.0,
-                                  2.0, 2.0]
+               obserr_bound_max: *atms_n20_obserr_bound_max
 
        - filter: Background Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          function absolute threshold:
          - name: ObsErrorBound@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          actions:
            - name: set
              flag: GrossCheck
@@ -15138,19 +14940,15 @@ observations:
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: InterChannelConsistencyCheck@ObsFunction
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            options:
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              use passive_bc: true
-             sensor: amsua_n20
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
+             sensor: atms_n20
+             use_flag: *atms_n20_use_flag
          maxvalue: 1.0e-12
          actions:
            - name: set
@@ -15162,17 +14960,13 @@ observations:
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: ObsFunction/ChannelUseflagCheckRad
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            options:
-             channels: *amsua_n20_channels
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
+             channels: *atms_n20_channels
+             use_flag: *atms_n20_use_flag
          minvalue: 1.0e-12
          actions:
            - name: set
@@ -15181,21 +14975,41 @@ observations:
            - name: reject
      - obs space:
          name: atms_npp
+         _anchor_channels: &atms_npp_channels 1-22
+         _anchor_use_flag: &atms_npp_use_flag
+             [ 1,  1,  1,  1,  1,
+               1,  1,  1,  1,  1,
+               1,  1,  1, -1, -1,
+               1,  1,  1,  1,  1,
+               1,  1]
+         _anchor_error: &atms_npp_error [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000]
+         _anchor_obserr_bound_max: &atms_npp_obserr_bound_max
+             [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
          distribution:
            name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_atms_npp.nc
+             obsfile: "data/obs/ioda_atms_npp.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_atms_npp.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &atms_npp_channels 1-22
+         channels: *atms_npp_channels
        obs operator:
            name: CRTM
            Absorbers: [H2O,O3,CO2]
@@ -15215,14 +15029,14 @@ observations:
            lengthscale: 200e3 # orig
 
        obs bias:
-         input file:  data/obs/atms_npp.satbias.nc
-         output file: out_atms_npp.satbias.nc
+         input file:  data/satbias_in/atms_npp.satbias.nc
+         output file: data/satbias_out/atms_npp.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &atms_npp_tlapse  data/obs/atms_npp.tlapse.txt
+             tlapse: &atms_npp_tlapse  data/satbias_in/atms_npp.tlapse.txt
            - name: lapseRate
              tlapse: *atms_npp_tlapse
            - name: emissivityJacobian
@@ -15239,58 +15053,13 @@ observations:
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/atms_npp.satbias_cov.nc
+             input file: data/satbias_in/atms_npp.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_atms_npp.satbias_cov.nc
+           output file: data/satbias_out/atms_npp.satbias_cov.nc
 
        obs pre filters:
-       # Step 0-A: Create Diagnostic Flags
-       - filter: Create Diagnostic Flags
-         filter variables:
-         - name: brightnessTemperature
-           channels: *atms_npp_channels
-         flags:
-         - name: ScanEdgeRemoval
-           initial value: false
-           force reinitialization: false
-         - name: Thinning
-           initial value: false
-           force reinitialization: false
-         - name: CLWRetrievalCheck
-           initial value: false
-           force reinitialization: false
-         - name: WindowChannelExtremeResidual
-           initial value: false
-           force reinitialization: false
-         - name: HydrometeorCheck
-           initial value: false
-           force reinitialization: false
-         - name: GrossCheck
-           initial value: false
-           force reinitialization: false
-         - name: InterChannelConsistency
-           initial value: false
-           force reinitialization: false
-         - name: UseflagCheck
-           initial value: false
-           force reinitialization: false
-
-       obs post filters:
-       # Step 0-B: Calculate derived variables
-       # Calculate CLW retrieved from observation
-       - filter: Variable Assignment
-         assignments:
-         - name: CLWRetFromObs@DerivedMetaData
-           type: float
-           function:
-             name: CLWRetMW@ObsFunction
-             options:
-               clwret_ch238: 1
-               clwret_ch314: 2
-               clwret_types: [ObsValue]
-
        # Calculate CLW retrieved from observation
        - filter: Variable Assignment
          assignments:
@@ -15417,13 +15186,18 @@ observations:
                  channels: *atms_npp_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+       # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
+         - name: brightnessTemperature
            channels: *atms_npp_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_npp_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -15529,11 +15303,7 @@ observations:
              channels: *atms_npp_channels
              options:
                channels: *atms_npp_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_npp_error
                clwret_function:
                  name: CLWRetFromObs@DerivedMetaData
                obserr_function:
@@ -15648,11 +15418,7 @@ observations:
                obserr_function:
                  name: InitialObsError@DerivedMetaData
                  channels: *atms_npp_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_npp_error
 
        - filter: Perform Action
          filter variables:
@@ -15700,11 +15466,7 @@ observations:
                  name: InitialObsError@DerivedMetaData
                  channels: *atms_npp_channels
                  threhold: 3
-               obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
-                                  1.0, 1.0, 1.0, 1.0, 1.0,
-                                  1.0, 1.0, 1.0, 2.0, 4.5,
-                                  4.5, 2.0, 2.0, 2.0, 2.0,
-                                  2.0, 2.0]
+               obserr_bound_max: *atms_npp_obserr_bound_max
 
        - filter: Background Check
          filter variables:
@@ -15731,12 +15493,7 @@ observations:
              channels: *atms_npp_channels
              use passive_bc: true
              sensor: atms_npp
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
-         maxvalue: 1.0e-12
+             use_flag: *atms_npp_use_flag
          actions:
            - name: set
              flag: InterChannelConsistency
@@ -15753,11 +15510,7 @@ observations:
            channels: *atms_npp_channels
            options:
              channels: *atms_npp_channels
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
+             use_flag: *atms_npp_use_flag
          minvalue: 1.0e-12
          actions:
            - name: set
@@ -15768,15 +15521,21 @@ observations:
   # -----------------------
      - obs space:
          name: abi_g16
+         _anchor_channels: &abi_g16_channels 7-16
+         _anchor_use_flag: &abi_g16_use_flag [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+         _anchor_use_flag_clddet: &abi_g16_use_flag_clddet [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+         _anchor_error: &abi_g16_error [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+         _anchor_obserr_bound_max: &abi_g16_obserr_bound_max [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
          distribution:
            name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_abi_g16.nc
+             obsfile: "data/obs/ioda_abi_g16.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_abi_g16.nc
@@ -15784,7 +15543,7 @@ observations:
            max pool size: 1
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &abi_g16_channels 7-16
+         channels: *abi_g16_channels
 
   # Observation Operator
   # --------------------
@@ -15804,17 +15563,18 @@ observations:
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
+
   # Observation Bias Correction (VarBC)
   # -----------------------------------
        obs bias:
-         input file: data/obs/abi_g16.satbias.nc
-         output file: out_abi_g16.satbias.nc
+         input file: data/satbias_in/abi_g16.satbias.nc
+         output file: data/satbias_out/abi_g16.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &abi_g16_tlapse data/obs/abi_g16.tlapse.txt
+             tlapse: &abi_g16_tlapse data/satbias_in/abi_g16.tlapse.txt
            - name: lapseRate
              tlapse: *abi_g16_tlapse
            - name: emissivityJacobian
@@ -15835,14 +15595,43 @@ observations:
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/abi_g16.satbias_cov.nc
+             input file: data/satbias_in/abi_g16.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_abi_g16.satbias_cov.nc
+           output file: data/satbias_out/abi_g16.satbias_cov.nc
 
   # Observation Filters (QC)
   # ------------------------
+       obs pre filters:
+       # from read_abi: Reject when cloud fraction is more than 30
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         where:
+         - variable:
+             name: MetaData/cloudAmount
+             channels: 8
+           maxvalue: 30.
+         action:
+           name: reduce obs space
+
+       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         where:
+         - variable:
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8-10
+           maxvalue: 1.3
+           max_exclusive: true
+         action:
+           name: reduce obs space
+
+
        obs prior filters:
        # Initial obs error assignment
        - filter: Perform Action
@@ -15851,7 +15640,7 @@ observations:
            channels: *abi_g16_channels
          action:
            name: assign error
-           error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+           error parameter vector: *abi_g16_error
 
        # Surface flag assignment from geoval
        - filter: Variable Assignment
@@ -15917,33 +15706,6 @@ observations:
                    minvalue: 0.99
                  value: 15
 
-       # Criteria assignment for Thinning
-       - filter: Variable Assignment
-         assignments:
-         - name: DerivedMetaData/thinningCriteria
-           type: int
-           function:
-             name: IntObsFunction/Arithmetic
-             options:
-               variables:
-               - name: DerivedMetaData/surfaceParam
-               coefs: [1]
-
-       # Thinning
-       - filter: Gaussian Thinning
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         horizontal_mesh: 60
-         use_reduced_horizontal_grid: true
-         distance_norm: maximum
-         time_mesh: 'PT06H'
-         time_min: '2024-05-26T22:30:00Z'
-         time_max: '2024-05-27T01:30:00Z'
-         priority_variable: DerivedMetaData/thinningCriteria
-         action:
-           name: reject
-
        obs post filters:
        # Regional domain check to remove data outside of model domain
        - filter: Bounds Check
@@ -15956,42 +15718,23 @@ observations:
            minvalue: 0.0
            maxvalue: 0.5
 
-       # Satellite Zenith Angle Check
-       - filter: Bounds Check
+       #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g16_channels
-         test variables:
-         - name: MetaData/sensorZenithAngle
-         maxvalue: 65.
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *abi_g16_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
-       # from read_abi: Reject when cloud fraction is more than 30
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         where:
-         - variable:
-             name: MetaData/cloudAmount
-             channels: 8
-           maxvalue: 30.
-
-       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         where:
-         - variable:
-             name: ClearSkyStdDev/brightnessTemperature
-             channels: 8-10
-           maxvalue: 1.3
-           max_exclusive: true
-
        # Surface type check
-       # Toss channels 7, 11-16 over land
+       # Toss channels 7,11-16 over land
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -16077,10 +15820,10 @@ observations:
            channels: *abi_g16_channels
            options:
              channels: *abi_g16_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
-             use_flag_clddet: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+             use_flag: *abi_g16_use_flag
+             use_flag_clddet: *abi_g16_use_flag_clddet
              obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             error parameter vector: *abi_g16_error
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16165,7 +15908,7 @@ observations:
            channels: *abi_g16_channels
            options:
              channels: *abi_g16_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+             use_flag: *abi_g16_use_flag
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16251,23 +15994,29 @@ observations:
                channels: *abi_g16_channels
                options:
                  channels: *abi_g16_channels
-             obserr_bound_max: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             obserr_bound_max: *abi_g16_obserr_bound_max
+             error parameter vector: *abi_g16_error
          action:
            name: reject
   # Observation Space (I/O)
   # -----------------------
      - obs space:
          name: abi_g18
+         _anchor_channels: &abi_g18_channels 7-16
+         _anchor_use_flag: &abi_g18_use_flag [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+         _anchor_use_flag_clddet: &abi_g18_use_flag_clddet [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+         _anchor_error: &abi_g18_error [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+         _anchor_obserr_bound_max: &abi_g18_obserr_bound_max [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
          distribution:
            name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_abi_g18.nc
+             obsfile: "data/obs/ioda_abi_g18.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_abi_g18.nc
@@ -16275,7 +16024,7 @@ observations:
            max pool size: 1
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &abi_g18_channels 7-16
+         channels: *abi_g18_channels
 
   # Observation Operator
   # --------------------
@@ -16299,14 +16048,14 @@ observations:
   # Observation Bias Correction (VarBC)
   # -----------------------------------
        obs bias:
-         input file: data/obs/abi_g18.satbias.nc
-         output file: out_abi_g18.satbias.nc
+         input file: data/satbias_in/abi_g18.satbias.nc
+         output file: data/satbias_out/abi_g18.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &abi_g18_tlapse data/obs/abi_g18.tlapse.txt
+             tlapse: &abi_g18_tlapse data/satbias_in/abi_g18.tlapse.txt
            - name: lapseRate
              tlapse: *abi_g18_tlapse
            - name: emissivityJacobian
@@ -16327,14 +16076,42 @@ observations:
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/abi_g18.satbias_cov.nc
+             input file: data/satbias_in/abi_g18.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_abi_g18.satbias_cov.nc
+           output file: data/satbias_out/abi_g18.satbias_cov.nc
 
   # Observation Filters (QC)
   # ------------------------
+       obs pre filters:
+       # from read_abi: Reject when cloud fraction is more than 30
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         where:
+         - variable:
+             name: MetaData/cloudAmount
+             channels: 8
+           maxvalue: 30.
+         action:
+           name: reduce obs space
+
+       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         where:
+         - variable:
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8-10
+           maxvalue: 1.3
+           max_exclusive: true
+         action:
+           name: reduce obs space
+
        obs prior filters:
        # Initial obs error assignment
        - filter: Perform Action
@@ -16343,7 +16120,7 @@ observations:
            channels: *abi_g18_channels
          action:
            name: assign error
-           error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+           error parameter vector: *abi_g18_error
 
        # Surface flag assignment from geoval
        - filter: Variable Assignment
@@ -16409,33 +16186,6 @@ observations:
                    minvalue: 0.99
                  value: 15
 
-       # Criteria assignment for Thinning
-       - filter: Variable Assignment
-         assignments:
-         - name: DerivedMetaData/thinningCriteria
-           type: int
-           function:
-             name: IntObsFunction/Arithmetic
-             options:
-               variables:
-               - name: DerivedMetaData/surfaceParam
-               coefs: [1]
-
-       # Thinning
-       - filter: Gaussian Thinning
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         horizontal_mesh: 60
-         use_reduced_horizontal_grid: true
-         distance_norm: maximum
-         time_mesh: 'PT06H'
-         time_min: '2024-05-26T22:30:00Z'
-         time_max: '2024-05-27T01:30:00Z'
-         priority_variable: DerivedMetaData/thinningCriteria
-         action:
-           name: reject
-
        obs post filters:
        # Regional domain check to remove data outside of model domain
        - filter: Bounds Check
@@ -16448,39 +16198,20 @@ observations:
            minvalue: 0.0
            maxvalue: 0.5
 
-       # Satellite Zenith Angle Check
-       - filter: Bounds Check
+       # Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g18_channels
-         test variables:
-         - name: MetaData/sensorZenithAngle
-         maxvalue: 65.
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *abi_g18_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
-
-       # from read_abi: Reject when cloud fraction is more than 30
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         where:
-         - variable:
-             name: MetaData/cloudAmount
-             channels: 8
-           maxvalue: 30.
-
-       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         where:
-         - variable:
-             name: ClearSkyStdDev/brightnessTemperature
-             channels: 8-10
-           maxvalue: 1.3
-           max_exclusive: true
 
        # Surface type check
        # Toss channels 7,11-16 over land
@@ -16569,10 +16300,10 @@ observations:
            channels: *abi_g18_channels
            options:
              channels: *abi_g18_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
-             use_flag_clddet: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+             use_flag: *abi_g18_use_flag
+             use_flag_clddet: *abi_g18_use_flag_clddet
              obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             error parameter vector: *abi_g18_error
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16657,7 +16388,7 @@ observations:
            channels: *abi_g18_channels
            options:
              channels: *abi_g18_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+             use_flag: *abi_g18_use_flag
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16711,6 +16442,7 @@ observations:
                  channels: 14
                coefs: [1, -1, 1, -1, 1, -1]
 
+       # Use split window chns to remove opaque clouds
        # Toss Channels 7, 10-16, when OmFNBC < -0.75
        - filter: Domain Check
          filter variables:
@@ -16742,7 +16474,1354 @@ observations:
                channels: *abi_g18_channels
                options:
                  channels: *abi_g18_channels
-             obserr_bound_max: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             obserr_bound_max: *abi_g18_obserr_bound_max
+             error parameter vector: *abi_g18_error
+         action:
+           name: reject
+     - obs space:
+         name: atms_n21
+         _anchor_channels: &atms_n21_channels 1-22
+         _anchor_use_flag: &atms_n21_use_flag
+             [ 1,  1,  1,  1,  1,
+               1,  1,  1,  1,  1,
+               1,  1,  1, -1, -1,
+               1,  1,  1,  1,  1,
+               1,  1]
+         _anchor_obserr_bound_max: &atms_n21_obserr_bound_max
+             [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
+         _anchor_error: &atms_n21_error
+             [ 4.500,  4.500,  4.500,  2.500,  0.550,
+               0.300,  0.300,  0.400,  0.400,  0.400,
+               0.450,  0.450,  0.550,  0.800,  4.000,
+               4.000,  4.000,  3.500,  3.000,  3.000,
+               3.000,  3.000]
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_atms_n21.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "skip output"
+           engine:
+             type: H5File
+             obsfile: jdiag_atms_n21.nc
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: *atms_n21_channels
+       obs operator:
+           name: CRTM
+           Absorbers: [H2O,O3,CO2]
+           Clouds: [Water, Ice]
+           Cloud_Fraction: 1.0
+           Cloud_Seeding: true
+           SurfaceWindGeoVars: uv
+           obs options:
+             Sensor_ID: atms_n21
+             EndianType: little_endian
+             CoefficientPath: data/crtm/
+             IRVISlandCoeff: IGBP
+           linear obs operator:
+             Absorbers: [H2O, O3]
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
+       obs bias:
+         input file:  data/satbias_in/atms_n21.satbias.nc
+         output file: data/satbias_out/atms_n21.satbias.nc
+         variational bc:
+           predictors:
+           - name: constant
+           - name: lapseRate
+             order: 2
+             tlapse: &atms_n21_tlapse  data/satbias_in/atms_n21.tlapse.txt
+           - name: lapseRate
+             tlapse: *atms_n21_tlapse
+           - name: emissivityJacobian
+           - name: sensorScanAngle
+             order: 4
+           - name: sensorScanAngle
+             order: 3
+           - name: sensorScanAngle
+             order: 2
+           - name: sensorScanAngle
+         covariance:
+           minimal required obs number: 20
+           variance range: [1.0e-6, 10.0]
+           step size: 1.0e-4
+           largest analysis variance: 10000.0
+           prior:
+             input file: data/satbias_in/atms_n21.satbias_cov.nc
+             inflation:
+               ratio: 1.1
+               ratio for small dataset: 2.0
+           output file: data/satbias_out/atms_n21.satbias_cov.nc
+
+       obs pre filters:
+       # Calculate CLW retrieved from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetFromBkg@DerivedMetaData
+           type: float
+           function:
+             name: CLWRetMW@ObsFunction
+             options:
+               clwret_ch238: 1
+               clwret_ch314: 2
+               clwret_types: [HofX]
+
+       # Calculate symmetric retrieved CLW
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetSymmetric@DerivedMetaData
+           type: float
+           value: 1000.0
+
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: CLWRetFromObs@DerivedMetaData
+           minvalue:   0.
+           maxvalue: 999.
+         - variable:
+             name: CLWRetFromBkg@DerivedMetaData
+           minvalue:   0.
+           maxvalue: 999.
+         where operator: and
+         assignments:
+         - name: CLWRetSymmetric@DerivedMetaData
+           type: float
+           function:
+             name: Arithmetic@ObsFunction
+             options:
+               variables:
+               - name: CLWRetFromObs@DerivedMetaData
+               - name: CLWRetFromBkg@DerivedMetaData
+               total coefficient: 0.5
+
+       # Calculate scattering index from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: SIRetFromObs@DerivedMetaData
+           type: float
+           function:
+             name: SCATRetMW@ObsFunction
+             options:
+               scatret_ch238: 1
+               scatret_ch314: 2
+               scatret_ch890: 16
+               scatret_types: [ObsValue]
+
+       # Calculate CLW obs/bkg match index
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWMatchIndex@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: CLWMatchIndexMW@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+               clwobs_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               clwbkg_function:
+                 name: CLWRetFromBkg@DerivedMetaData
+               clwret_clearsky: [ 0.030,  0.030,  0.030,  0.020,  0.030,
+                                  0.080,  0.150,  0.000,  0.000,  0.000,
+                                  0.000,  0.000,  0.000,  0.000,  0.000,
+                                  0.020,  0.030,  0.030,  0.030,  0.030,
+                                  0.050,  0.100]
+
+       # Calculate symmetric observation error
+       - filter: Variable Assignment
+         assignments:
+         - name: InitialObsError@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorModelRamp@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+               xvar:
+                 name: CLWRetSymmetric@DerivedMetaData
+               x0:    [ 0.030,  0.030,  0.030,  0.020,  0.030,
+                        0.080,  0.150,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.000,
+                        0.020,  0.030,  0.030,  0.030,  0.030,
+                        0.050,  0.100]
+               x1:    [ 0.350,  0.380,  0.400,  0.450,  0.500,
+                        1.000,  1.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.000,
+                        0.350,  0.500,  0.500,  0.500,  0.500,
+                        0.500,  0.500]
+               err0:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
+                        0.300,  0.300,  0.400,  0.400,  0.400,
+                        0.450,  0.450,  0.550,  0.800,  4.000,
+                        4.000,  4.000,  3.500,  3.000,  3.000,
+                        3.000,  3.000]
+               err1:  [20.000, 25.000, 12.000,  7.000,  3.500,
+                        3.000,  0.800,  0.400,  0.400,  0.400,
+                        0.450,  0.450,  0.550,  0.800,  4.000,
+                       19.000, 30.000, 25.000, 16.500, 12.000,
+                        9.000,  6.500]
+
+       # Calculate Innovation@DerivedMetaData
+       - filter: Variable Assignment
+         assignments:
+         - name: Innovation@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsFunction/Arithmetic
+             channels: *atms_n21_channels
+             options:
+               variables:
+               - name: brightnessTemperature@ObsValue
+                 channels: *atms_n21_channels
+               - name: brightnessTemperature@HofX
+                 channels: *atms_n21_channels
+               coefs: [1, -1]
+
+       # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_n21_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
+
+       # Regional Domain Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+
+       # Step 0-C: Assign Initial All-Sky Observation Error
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: assign error
+           error function:
+             name: InitialObsError@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 1: Remove Observations from the Edge of the Scan
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-22
+         where:
+         - variable:
+             name: MetaData/sensorScanPosition
+           is_in: 7-90
+         actions:
+           - name: set
+             flag: ScanEdgeRemoval
+           - name: reject
+
+       # Step 2: data Thinning
+       - filter: Gaussian Thinning
+         #horizontal_mesh: 145
+         horizontal_mesh: 60
+         use_reduced_horizontal_grid: true
+         distance_norm: geodesic
+       #  round_horizontal_bin_count_to_nearest: true
+       #  partition_longitude_bins_using_mesh: true
+         actions:
+           - name: set
+             flag: Thinning
+           - name: reject
+
+       # Step 3A: CLW Retrieval Check (observation_based)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16-22
+         test variables:
+         - name: CLWRetFromObs@DerivedMetaData
+         maxvalue: 999.0
+         actions:
+           - name: set
+             flag: CLWRetrievalCheck
+           - name: reject
+
+       # Step 3B: CLW Retrieval Check (background_based)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16-22
+         test variables:
+         - name: CLWRetFromBkg@DerivedMetaData
+         maxvalue: 999.0
+         actions:
+           - name: set
+             flag: CLWRetrievalCheck
+           - name: reject
+
+       # Step 4: Window Channel Sanity Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16, 17-22
+         test variables:
+         - name: Innovation@DerivedMetaData
+           channels: 1, 2, 5-7, 16
+         maxvalue: 200.0
+         minvalue: -200.0
+         flag all filter variables if any test variable is out of bounds: true
+         actions:
+           - name: set
+             flag: WindowChannelExtremeResidual
+           - name: reject
+
+       # Step 5: Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/HydrometeorCheckATMS
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: HydrometeorCheckATMS@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+               obserr_clearsky: *atms_n21_error
+               clwret_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_n21_channels
+
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: DerivedMetaData/HydrometeorCheckATMS
+           channels: *atms_n21_channels
+         maxvalue: 0.0
+         actions:
+           - name: set
+             flag: HydrometeorCheck
+             ignore: rejected observations
+           - name: reject
+
+       # Step 6: Observation Error Inflation based on Topography Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorTopo@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorTopoRad@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorTopo@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 7: Obs Error Inflation based on TOA Transmittancec Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorTransmitTop@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorTransmitTopRad@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorTransmitTop@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 8: Observation Error Inflation based on Surface Jacobian Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorSurfJacobian@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorSurfJacobianRad@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorSurfJacobian@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 9: Situation Dependent Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorSituDepend@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorSituDependMW@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+               clwbkg_function:
+                 name: CLWRetFromBkg@DerivedMetaData
+               clwobs_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               scatobs_function:
+                 name: SIRetFromObs@DerivedMetaData
+               clwmatchidx_function:
+                 name: CLWMatchIndex@DerivedMetaData
+                 channels: *atms_n21_channels
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_n21_channels
+               obserr_clearsky: *atms_n21_error
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorSituDepend@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 10: Gross check
+       # Remove data if abs(Obs-HofX) > absolute threhold
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorLat@DerivedMetaData
+           type: float
+           function:
+             name: ObsErrorFactorLatRad@ObsFunction
+             options:
+               latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorBound@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorBoundMW@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+               obserr_bound_latitude:
+                 name: ObsErrorFactorLat@DerivedMetaData
+               obserr_bound_transmittop:
+                 name: ObsErrorFactorTransmitTop@DerivedMetaData
+                 channels: *atms_n21_channels
+                 options:
+                   channels: *atms_n21_channels
+               obserr_bound_topo:
+                 name: ObsErrorFactorTopo@DerivedMetaData
+                 channels: *atms_n21_channels
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_n21_channels
+                 threhold: 3
+               obserr_bound_max: *atms_n21_obserr_bound_max
+
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         function absolute threshold:
+         - name: ObsErrorBound@DerivedMetaData
+           channels: *atms_n21_channels
+         actions:
+           - name: set
+             flag: GrossCheck
+             ignore: rejected observations
+           - name: reject
+
+       # Step 11: Inter-Channel Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: InterChannelConsistencyCheck@ObsFunction
+           channels: *atms_n21_channels
+           options:
+             channels: *atms_n21_channels
+             use passive_bc: true
+             sensor: atms_n21
+             use_flag: *atms_n21_use_flag
+         maxvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: InterChannelConsistency
+             ignore: rejected observations
+           - name: reject
+
+       # Step 12: Useflag Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *atms_n21_channels
+           options:
+             channels: *atms_n21_channels
+             use_flag: *atms_n21_use_flag
+         minvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: UseflagCheck
+             ignore: rejected observations
+           - name: reject
+
+     - obs space:
+         name: amsua_metop-b
+         _anchor_channels: &amsua_metop-b_channels 1-15
+         _anchor_use_flag: &amsua_metop-b_use_flag [ -1,  -1,  -1,  -1,  -1, -1, -1,  1,  1,  1,  -1,   -1,   -1, -1,  -1 ]
+         _anchor_error: &amsua_metop-b_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
+         _anchor_obserr_bound_max: &amsua_metop-b_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_amsua_metop-b.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "skip output"
+           engine:
+             type: H5File
+             obsfile: jdiag_amsua_metop-b.nc
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: *amsua_metop-b_channels
+       obs operator:
+         name: CRTM
+         Absorbers: [H2O,O3,CO2]
+         SurfaceWindGeoVars: uv
+         Clouds: [Water, Ice]
+         Cloud_Seeding: true
+         Cloud_Fraction: 1.0
+         obs options:
+           Sensor_ID: amsua_metop-b
+           EndianType: little_endian
+           CoefficientPath: data/crtm/
+           IRVISlandCoeff: IGBP
+         linear obs operator:
+           Absorbers: [H2O, O3]
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
+       obs bias:
+         input file: data/satbias_in/amsua_metop-b.satbias.nc
+         output file: data/satbias_out/amsua_metop-b.satbias.nc
+         variational bc:
+           predictors:
+           - name: constant
+           - name: lapseRate
+             order: 2
+             tlapse: &amsua_metop-b_tlapse data/satbias_in/amsua_metop-b.tlapse.txt
+           - name: lapseRate
+             tlapse: *amsua_metop-b_tlapse
+           - name: emissivityJacobian
+           - name: sensorScanAngle
+             order: 4
+           - name: sensorScanAngle
+             order: 3
+           - name: sensorScanAngle
+             order: 2
+           - name: sensorScanAngle
+         covariance:
+           minimal required obs number: 20
+           variance range: [1.0e-6, 10.0]
+           step size: 1.0e-4
+           largest analysis variance: 10000.0
+           prior:
+             input file: data/satbias_in/amsua_metop-b.satbias_cov.nc
+             inflation:
+               ratio: 1.1
+               ratio for small dataset: 2.0
+           output file: data/satbias_out/amsua_metop-b.satbias_cov.nc
+       obs pre filters:
+       # Regional domain check to remove data outside of model domain
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+        #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *amsua_metop-b_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: assign error
+           error function:
+             name: ObsFunction/ObsErrorModelRamp
+             channels: *amsua_metop-b_channels
+             options:
+               channels: *amsua_metop-b_channels
+               xvar:
+                 name: ObsFunction/CLWRetSymmetricMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue, HofX]
+               x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                        0.100,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.030]
+               x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                        1.500,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.200]
+               err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                        0.230,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000,  3.500]
+               err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                        0.300,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000, 18.000]
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [ObsValue]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [HofX]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: ObsFunction/HydrometeorCheckAMSUA
+           channels: *amsua_metop-b_channels
+           options:
+             channels: *amsua_metop-b_channels
+             obserr_clearsky: *amsua_metop-b_error
+             clwret_function:
+               name: ObsFunction/CLWRetMW
+               options:
+                 clwret_ch238: 1
+                 clwret_ch314: 2
+                 clwret_types: [ObsValue]
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                         0.300,  0.230,  0.250,  0.250,  0.350,
+                         0.400,  0.550,  0.800,  3.000, 18.000]
+         maxvalue: 0.0
+         action:
+           name: reject
+       #  Topography check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTopoRad
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+       #  Transmittnace Top Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTransmitTopRad
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+       #  Surface Jacobian check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSurfJacobianRad
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+       #  Situation dependent Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSituDependMW
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+               clwobs_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue]
+               clwbkg_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [HofX]
+                   bias_application: HofX
+               scatobs_function:
+                 name: ObsFunction/SCATRetMW
+                 options:
+                   scatret_ch238: 1
+                   scatret_ch314: 2
+                   scatret_ch890: 15
+                   scatret_types: [ObsValue]
+                   bias_application: HofX
+               clwmatchidx_function:
+                 name: ObsFunction/CLWMatchIndexMW
+                 channels: *amsua_metop-b_channels
+                 options:
+                   channels: *amsua_metop-b_channels
+                   clwobs_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue]
+                   clwbkg_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [HofX]
+                       bias_application: HofX
+                   clwret_clearsky: [0.050, 0.030, 0.030, 0.020, 0.000,
+                                     0.100, 0.000, 0.000, 0.000, 0.000,
+                                     0.000, 0.000, 0.000, 0.000, 0.030]
+               obserr_function:
+                 name: ObsFunction/ObsErrorModelRamp
+                 channels: *amsua_metop-b_channels
+                 options:
+                   channels: *amsua_metop-b_channels
+                   xvar:
+                     name: ObsFunction/CLWRetSymmetricMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue, HofX]
+                   x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                            0.100,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.030]
+                   x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                            1.500,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.200]
+                   err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                            0.230,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000,  3.500]
+                   err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                            0.300,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000, 18.000]
+               obserr_clearsky: *amsua_metop-b_error
+
+       #  Gross check
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         function absolute threshold:
+         - name: ObsFunction/ObsErrorBoundMW
+           channels: *amsua_metop-b_channels
+           options:
+             sensor: amsua_metop-b
+             channels: *amsua_metop-b_channels
+             obserr_bound_latitude:
+               name: ObsFunction/ObsErrorFactorLatRad
+               options:
+                 latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+             obserr_bound_transmittop:
+               name: ObsFunction/ObsErrorFactorTransmitTopRad
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+             obserr_bound_topo:
+               name: ObsFunction/ObsErrorFactorTopoRad
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+                 sensor: amsua_metop-b
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                     bias_application: HofX
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                          0.300,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000, 18.000]
+             obserr_bound_max: *amsua_metop-b_obserr_bound_max
+         action:
+           name: reject
+       #  Inter-channel check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: ObsFunction/InterChannelConsistencyCheck
+           channels: *amsua_metop-b_channels
+           options:
+             channels: *amsua_metop-b_channels
+             sensor: amsua_metop-b
+             use_flag: *amsua_metop-b_use_flag
+         maxvalue: 1.0e-12
+         action:
+           name: reject
+       #  Useflag check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *amsua_metop-b_channels
+           options:
+             sensor: amsua_metop-b
+             channels: *amsua_metop-b_channels
+             use_flag: *amsua_metop-b_use_flag
+         minvalue: 1.0e-12
+         action:
+           name: reject
+     - obs space:
+         name: amsua_metop-c
+         _anchor_channels: &amsua_metop-c_channels 1-15
+         _anchor_use_flag: &amsua_metop-c_use_flag [ 1,  1,  1,  1,  1, 1, 1,  1,  1,  1, -1,  -1,  -1, 1,  1 ]
+         _anchor_error: &amsua_metop-c_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
+         _anchor_obserr_bound_max: &amsua_metop-c_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_amsua_metop-c.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "skip output"
+           engine:
+             type: H5File
+             obsfile: jdiag_amsua_metop-c.nc
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: *amsua_metop-c_channels
+       obs operator:
+         name: CRTM
+         Absorbers: [H2O,O3,CO2]
+         SurfaceWindGeoVars: uv
+         Clouds: [Water, Ice]
+         Cloud_Seeding: true
+         Cloud_Fraction: 1.0
+         obs options:
+           Sensor_ID: amsua_metop-c
+           EndianType: little_endian
+           CoefficientPath: data/crtm/
+           IRVISlandCoeff: IGBP
+         linear obs operator:
+           Absorbers: [H2O, O3]
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
+       obs bias:
+         input file: data/satbias_in/amsua_metop-c.satbias.nc
+         output file: data/satbias_out/amsua_metop-c.satbias.nc
+         variational bc:
+           predictors:
+           - name: constant
+           - name: lapseRate
+             order: 2
+             tlapse: &amsua_metop-c_tlapse data/satbias_in/amsua_metop-c.tlapse.txt
+           - name: lapseRate
+             tlapse: *amsua_metop-c_tlapse
+           - name: emissivityJacobian
+           - name: sensorScanAngle
+             order: 4
+           - name: sensorScanAngle
+             order: 3
+           - name: sensorScanAngle
+             order: 2
+           - name: sensorScanAngle
+         covariance:
+           minimal required obs number: 20
+           variance range: [1.0e-6, 10.0]
+           step size: 1.0e-4
+           largest analysis variance: 10000.0
+           prior:
+             input file: data/satbias_in/amsua_metop-c.satbias_cov.nc
+             inflation:
+               ratio: 1.1
+               ratio for small dataset: 2.0
+           output file: data/satbias_out/amsua_metop-c.satbias_cov.nc
+       obs pre filters:
+       # Regional domain check to remove data outside of model domain
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+        #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *amsua_metop-c_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: assign error
+           error function:
+             name: ObsFunction/ObsErrorModelRamp
+             channels: *amsua_metop-c_channels
+             options:
+               channels: *amsua_metop-c_channels
+               xvar:
+                 name: ObsFunction/CLWRetSymmetricMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue, HofX]
+               x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                        0.100,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.030]
+               x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                        1.500,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.200]
+               err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                        0.230,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000,  3.500]
+               err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                        0.300,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000, 18.000]
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [ObsValue]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [HofX]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: ObsFunction/HydrometeorCheckAMSUA
+           channels: *amsua_metop-c_channels
+           options:
+             channels: *amsua_metop-c_channels
+             obserr_clearsky: *amsua_metop-c_error
+             clwret_function:
+               name: ObsFunction/CLWRetMW
+               options:
+                 clwret_ch238: 1
+                 clwret_ch314: 2
+                 clwret_types: [ObsValue]
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                         0.300,  0.230,  0.250,  0.250,  0.350,
+                         0.400,  0.550,  0.800,  3.000, 18.000]
+         maxvalue: 0.0
+         action:
+           name: reject
+       #  Topography check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTopoRad
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+       #  Transmittnace Top Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTransmitTopRad
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+       #  Surface Jacobian check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSurfJacobianRad
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+       #  Situation dependent Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSituDependMW
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+               clwobs_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue]
+               clwbkg_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [HofX]
+                   bias_application: HofX
+               scatobs_function:
+                 name: ObsFunction/SCATRetMW
+                 options:
+                   scatret_ch238: 1
+                   scatret_ch314: 2
+                   scatret_ch890: 15
+                   scatret_types: [ObsValue]
+                   bias_application: HofX
+               clwmatchidx_function:
+                 name: ObsFunction/CLWMatchIndexMW
+                 channels: *amsua_metop-c_channels
+                 options:
+                   channels: *amsua_metop-c_channels
+                   clwobs_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue]
+                   clwbkg_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [HofX]
+                       bias_application: HofX
+                   clwret_clearsky: [0.050, 0.030, 0.030, 0.020, 0.000,
+                                     0.100, 0.000, 0.000, 0.000, 0.000,
+                                     0.000, 0.000, 0.000, 0.000, 0.030]
+               obserr_function:
+                 name: ObsFunction/ObsErrorModelRamp
+                 channels: *amsua_metop-c_channels
+                 options:
+                   channels: *amsua_metop-c_channels
+                   xvar:
+                     name: ObsFunction/CLWRetSymmetricMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue, HofX]
+                   x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                            0.100,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.030]
+                   x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                            1.500,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.200]
+                   err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                            0.230,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000,  3.500]
+                   err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                            0.300,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000, 18.000]
+               obserr_clearsky: *amsua_metop-c_error
+
+       #  Gross check
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         function absolute threshold:
+         - name: ObsFunction/ObsErrorBoundMW
+           channels: *amsua_metop-c_channels
+           options:
+             sensor: amsua_metop-c
+             channels: *amsua_metop-c_channels
+             obserr_bound_latitude:
+               name: ObsFunction/ObsErrorFactorLatRad
+               options:
+                 latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+             obserr_bound_transmittop:
+               name: ObsFunction/ObsErrorFactorTransmitTopRad
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+             obserr_bound_topo:
+               name: ObsFunction/ObsErrorFactorTopoRad
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+                 sensor: amsua_metop-c
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                     bias_application: HofX
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                          0.300,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000, 18.000]
+             obserr_bound_max: *amsua_metop-c_obserr_bound_max
+         action:
+           name: reject
+       #  Inter-channel check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: ObsFunction/InterChannelConsistencyCheck
+           channels: *amsua_metop-c_channels
+           options:
+             channels: *amsua_metop-c_channels
+             sensor: amsua_metop-c
+             use_flag: *amsua_metop-c_use_flag
+         maxvalue: 1.0e-12
+         action:
+           name: reject
+       #  Useflag check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *amsua_metop-c_channels
+           options:
+             sensor: amsua_metop-c
+             channels: *amsua_metop-c_channels
+             use_flag: *amsua_metop-c_use_flag
+         minvalue: 1.0e-12
          action:
            name: reject

--- a/parm/jedivar.yaml
+++ b/parm/jedivar.yaml
@@ -208,7 +208,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t181.nc
@@ -484,7 +484,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t183.nc
@@ -758,7 +758,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t187.nc
@@ -1033,7 +1033,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q181.nc
@@ -1308,7 +1308,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q183.nc
@@ -1582,7 +1582,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q187.nc
@@ -1857,7 +1857,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps181.nc
@@ -2125,7 +2125,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps187.nc
@@ -2393,7 +2393,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv281.nc
@@ -2710,7 +2710,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv284.nc
@@ -3026,7 +3026,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv287.nc
@@ -3339,7 +3339,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t120.nc
@@ -3613,7 +3613,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t132.nc
@@ -3887,7 +3887,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q120.nc
@@ -4161,7 +4161,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q132.nc
@@ -4435,7 +4435,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_ps120.nc
@@ -4702,7 +4702,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv220.nc
@@ -5012,7 +5012,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv232.nc
@@ -5322,7 +5322,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircar_t133.nc
@@ -5596,7 +5596,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircar_q133.nc
@@ -5870,7 +5870,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircar_uv233.nc
@@ -6180,7 +6180,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t130.nc
@@ -6454,7 +6454,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t131.nc
@@ -6728,7 +6728,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t134.nc
@@ -7002,7 +7002,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t135.nc
@@ -7276,7 +7276,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_q134.nc
@@ -7550,7 +7550,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv230.nc
@@ -7860,7 +7860,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv231.nc
@@ -8170,7 +8170,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv234.nc
@@ -8480,7 +8480,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv235.nc
@@ -8793,7 +8793,7 @@ cost function:
            sort variable: "pressure"
            sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_gnss_ztd.nc
@@ -8864,7 +8864,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_t188.nc
@@ -9138,7 +9138,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_q188.nc
@@ -9412,7 +9412,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_ps188.nc
@@ -9679,7 +9679,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_msonet_uv288.nc
@@ -10257,7 +10257,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_proflr_uv227.nc
@@ -10611,7 +10611,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_rassda_t126.nc
@@ -10885,7 +10885,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t180.nc
@@ -11159,7 +11159,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t182.nc
@@ -11434,7 +11434,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t183.nc
@@ -11708,7 +11708,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q180.nc
@@ -11982,7 +11982,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q182.nc
@@ -12257,7 +12257,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q183.nc
@@ -12531,7 +12531,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_ps180.nc
@@ -12807,7 +12807,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv280.nc
@@ -13123,7 +13123,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv282.nc
@@ -13440,7 +13440,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv284.nc
@@ -13756,7 +13756,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_vadwnd_uv224.nc
@@ -14121,7 +14121,7 @@ cost function:
              obsfile: "data/obs/ioda_amsua_n19.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_amsua_n19.nc
@@ -14533,7 +14533,7 @@ cost function:
              obsfile: "data/obs/ioda_atms_n20.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_atms_n20.nc
@@ -15077,7 +15077,7 @@ cost function:
              obsfile: "data/obs/ioda_atms_npp.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_atms_npp.nc
@@ -15609,7 +15609,7 @@ cost function:
              obsfile: "data/obs/ioda_abi_g16.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_abi_g16.nc
@@ -16090,7 +16090,7 @@ cost function:
              obsfile: "data/obs/ioda_abi_g18.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_abi_g18.nc
@@ -16582,7 +16582,7 @@ cost function:
              obsfile: "data/obs/ioda_atms_n21.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_atms_n21.nc
@@ -17115,7 +17115,7 @@ cost function:
              obsfile: "data/obs/ioda_amsua_metop-b.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-b.nc
@@ -17516,7 +17516,7 @@ cost function:
              obsfile: "data/obs/ioda_amsua_metop-c.nc"
              missing file action: "warn"
          obsdataout:
-           empty obs space action: "skip output"
+           empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-c.nc

--- a/parm/jedivar.yaml
+++ b/parm/jedivar.yaml
@@ -159,6 +159,9 @@ cost function:
      observers:
      - obs space:
          name: refl10cm
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -179,6 +182,9 @@ cost function:
          observation vertical coordinate: height
          interpolation method: linear
          observation alias file: obsop_name_map.yaml
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
        _obsname: refl10cm
        obs filters:
        - filter: Background Check
@@ -191,17 +197,18 @@ cost function:
          name: adpsfc_t181
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t181.nc
@@ -218,7 +225,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfc_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -231,7 +238,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -239,7 +246,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -252,7 +258,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -263,7 +268,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -360,6 +364,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -462,12 +467,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_t183
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -479,6 +484,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t183.nc
@@ -495,7 +501,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -508,15 +514,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # airTemperature (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -529,7 +534,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -540,7 +544,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -636,6 +639,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -738,22 +742,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_t187
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_t187.nc
@@ -780,7 +785,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -788,7 +793,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -801,7 +805,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -812,7 +815,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -912,6 +914,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1014,22 +1017,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_q181
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q181.nc
@@ -1046,7 +1050,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfc_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -1059,7 +1063,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -1067,7 +1071,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -1080,7 +1083,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1091,7 +1093,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -1142,7 +1143,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -1188,6 +1188,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1290,12 +1291,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_q183
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -1307,6 +1308,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q183.nc
@@ -1323,7 +1325,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -1336,15 +1338,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # specificHumidity (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: specificHumidity
            where:
@@ -1357,7 +1358,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1368,7 +1368,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -1419,7 +1418,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -1465,6 +1463,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1567,22 +1566,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_q187
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_q187.nc
@@ -1609,7 +1609,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -1617,7 +1617,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -1630,7 +1629,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1641,7 +1639,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -1692,7 +1689,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
                  # The new feature "surface observation error ramp"
                  # needs to be added to UFO to align with the ramp
                  # options for temperature and humidity in GSI.
@@ -1742,6 +1738,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -1844,22 +1841,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_ps181
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps181.nc
@@ -1882,7 +1880,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -1890,7 +1888,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -1903,7 +1900,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -1914,7 +1910,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -2011,6 +2006,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2113,22 +2109,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_ps187
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_ps187.nc
@@ -2151,7 +2148,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -2159,7 +2156,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -2172,7 +2168,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -2183,7 +2178,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -2280,6 +2274,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2382,22 +2377,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_uv281
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv281.nc
@@ -2409,15 +2405,12 @@ cost function:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfc_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -2431,7 +2424,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -2439,7 +2432,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -2453,7 +2445,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -2464,7 +2455,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -2608,6 +2598,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -2702,12 +2693,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_uv284
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -2719,6 +2710,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv284.nc
@@ -2735,7 +2727,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -2749,15 +2741,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # wind (284)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -2771,7 +2762,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -2782,11 +2772,10 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -2926,6 +2915,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3020,22 +3010,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpsfc_uv287
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpsfc.nc
+             obsfile: "data/obs/ioda_adpsfc.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_uv287.nc
@@ -3063,7 +3054,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -3071,7 +3062,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -3085,7 +3075,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3096,7 +3085,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -3240,6 +3228,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3334,22 +3323,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpsfc_geovals_rrfs.nc
      - obs space:
          name: adpupa_t120
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t120.nc
@@ -3366,7 +3356,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -3379,7 +3369,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -3387,7 +3377,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -3400,7 +3389,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3411,7 +3399,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -3507,6 +3494,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3609,22 +3597,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_t132
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_t132.nc
@@ -3641,7 +3630,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -3654,7 +3643,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -3662,7 +3651,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -3675,7 +3663,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3686,7 +3673,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -3782,6 +3768,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -3884,22 +3871,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_q120
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q120.nc
@@ -3916,7 +3904,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_q_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -3929,7 +3917,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -3937,7 +3925,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -3950,7 +3937,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -3961,7 +3947,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -4012,7 +3997,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
          # Error inflation based on errormod (qcmod.f90)
          - filter: Perform Action
@@ -4058,6 +4042,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4160,22 +4145,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_q132
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_q132.nc
@@ -4192,7 +4178,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_q_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -4205,7 +4191,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -4213,7 +4199,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -4226,7 +4211,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -4237,7 +4221,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -4288,7 +4271,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
          # Error inflation based on errormod (qcmod.f90)
          - filter: Perform Action
@@ -4334,6 +4316,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4436,22 +4419,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_ps120
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_ps120.nc
@@ -4474,7 +4458,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -4482,7 +4466,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -4495,7 +4478,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -4506,7 +4488,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -4602,6 +4583,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -4704,22 +4686,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_uv220
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv220.nc
@@ -4736,7 +4719,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -4750,7 +4733,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -4758,7 +4741,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -4772,7 +4754,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -4783,7 +4764,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -4921,6 +4901,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5015,22 +4996,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: adpupa_uv232
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_adpupa.nc
+             obsfile: "data/obs/ioda_adpupa.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_uv232.nc
@@ -5047,7 +5029,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sondes_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/sondes_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -5061,7 +5043,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -5069,7 +5051,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -5083,7 +5064,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5094,7 +5074,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -5232,6 +5211,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5326,22 +5306,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4
+         #  filename: ./data/geovals/adpupa_geovals_rrfs.nc
      - obs space:
          name: aircar_t133
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircar.nc
+             obsfile: "data/obs/ioda_aircar.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_t133.nc
@@ -5358,7 +5339,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -5371,7 +5352,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -5379,7 +5360,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -5392,7 +5372,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5403,7 +5382,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -5499,6 +5477,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5601,22 +5580,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircar_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircar_geovals_rrfs.nc
      - obs space:
          name: aircar_q133
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircar.nc
+             obsfile: "data/obs/ioda_aircar.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_q133.nc
@@ -5633,7 +5613,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_q_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -5646,7 +5626,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -5654,7 +5634,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -5667,7 +5646,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5678,7 +5656,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -5729,7 +5706,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -5775,6 +5751,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -5877,22 +5854,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircar_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircar_geovals_rrfs.nc
      - obs space:
          name: aircar_uv233
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircar.nc
+             obsfile: "data/obs/ioda_aircar.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_uv233.nc
@@ -5909,7 +5887,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -5923,7 +5901,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -5931,7 +5909,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -5945,7 +5922,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -5956,7 +5932,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -6094,6 +6069,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6188,22 +6164,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircar_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircar_geovals_rrfs.nc
      - obs space:
          name: aircft_t130
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t130.nc
@@ -6220,7 +6197,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -6233,7 +6210,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -6241,7 +6218,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -6254,7 +6230,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -6265,7 +6240,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -6361,6 +6335,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6463,22 +6438,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_t131
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t131.nc
@@ -6495,7 +6471,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -6508,7 +6484,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -6516,7 +6492,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -6529,7 +6504,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -6540,7 +6514,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -6636,6 +6609,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -6738,22 +6712,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_t134
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t134.nc
@@ -6770,7 +6745,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -6783,7 +6758,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -6791,7 +6766,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -6804,7 +6778,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -6815,7 +6788,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -6911,6 +6883,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7013,22 +6986,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_t135
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_t135.nc
@@ -7045,7 +7019,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -7058,7 +7032,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -7066,7 +7040,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -7079,7 +7052,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7090,7 +7062,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -7186,6 +7157,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7288,22 +7260,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_q134
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_q134.nc
@@ -7320,7 +7293,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_q_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -7333,7 +7306,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -7341,7 +7314,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -7354,7 +7326,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7365,7 +7336,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -7416,7 +7386,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -7462,6 +7431,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7564,22 +7534,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv230
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv230.nc
@@ -7596,7 +7567,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -7610,7 +7581,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -7618,7 +7589,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -7632,7 +7602,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7643,7 +7612,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -7781,6 +7749,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -7875,22 +7844,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv231
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv231.nc
@@ -7907,7 +7877,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -7921,7 +7891,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -7929,7 +7899,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -7943,7 +7912,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -7954,7 +7922,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -8092,6 +8059,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -8186,22 +8154,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv234
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv234.nc
@@ -8218,7 +8187,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -8232,7 +8201,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -8240,7 +8209,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -8254,7 +8222,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -8265,7 +8232,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -8403,6 +8369,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -8497,22 +8464,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: aircft_uv235
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_aircft.nc
+             obsfile: "data/obs/ioda_aircft.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_uv235.nc
@@ -8529,7 +8497,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc4"
+           #  filename: "obsout/aircraft_uv_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -8543,7 +8511,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -8551,7 +8519,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -8565,7 +8532,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -8576,7 +8542,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -8714,6 +8679,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -8808,18 +8774,18 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/aircft_geovals_rrfs.nc4
+         #  filename: ./data/geovals/aircft_geovals_rrfs.nc
      - obs space:
          name: gnss_ztd
 
          distribution:   # for LETKF
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
 
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_gnss_ztd.nc
+             obsfile: "data/obs/ioda_gnss_ztd.nc"
              missing file action: "warn"
 
          obsgrouping:
@@ -8827,6 +8793,7 @@ cost function:
            sort variable: "pressure"
            sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_gnss_ztd.nc
@@ -8840,7 +8807,6 @@ cost function:
          name: GroundgnssMetOffice
        linear obs operator:
          name: GroundgnssMetOffice
-
          observation alias file: obsop_name_map.yaml
 
        obs error:
@@ -8848,31 +8814,9 @@ cost function:
 
        obs localizations:   # for LETKF
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3
+           lengthscale: 200e3
 
        obs filters:
-         # Pre-online regional domain check (latitude/longitude)
-         - filter: Domain Check
-           where:
-             - variable:
-                 name: MetaData/latitude
-               minvalue:  19.0
-               maxvalue:  62.0
-             - variable:
-                 name: MetaData/longitude
-               minvalue: 213.0
-               maxvalue: 312.0
-           action:
-              name: reduce obs space
-
-         # Online regional domain check (domain mask)
-         - filter: Domain Check
-           where:
-             - variable:
-                 name: GeoVaLs/observable_domain_mask
-               minvalue: 0.0
-               maxvalue: 0.5  # 0=interior, 1=outside of domain
-
          # Reject all obs with QualityMarker > 10
          - filter: Bounds Check
            filter variables:
@@ -8889,13 +8833,6 @@ cost function:
              name: assign error
              error parameter: 0.01
 
-         # Monitoring mode (no assimilation, set QCflag=1)
-  #      - filter: Perform Action
-  #        filter variables:
-  #        - name: zenithTotalDelay
-  #        action:
-  #          name: passivate
-
          # Terrain Height Discrepancy Check
          - filter: Difference Check
            reference: MetaData/stationElevation
@@ -8906,27 +8843,28 @@ cost function:
          - filter: Background Check
            threshold: 6
 
-  #      - filter: RejectList
-  #        where:
-  #        - variable: MetaData/productName
-  #          is_in: ["ROBG"]
-  #          is_in: ["LPT_"]
-  #          is_in: ["ROBG","LPT_"]
+#        - filter: RejectList
+#          where:
+#          - variable: MetaData/productName
+#            is_in: ["ROBG"]
+#            is_in: ["LPT_"]
+#            is_in: ["ROBG","LPT_"]
      - obs space:
          name: msonet_t188
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_t188.nc
@@ -8943,7 +8881,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_tsen_geoval_2022052619.nc4"
+           #  filename: "obsout/sfc_tsen_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -8956,7 +8894,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -8964,7 +8902,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -8977,7 +8914,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -8988,7 +8924,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -9084,6 +9019,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -9186,22 +9122,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: msonet_q188
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_q188.nc
@@ -9218,7 +9155,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_q_geoval_2022052619.nc4"
+           #  filename: "obsout/sfc_q_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -9231,7 +9168,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -9239,7 +9176,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -9252,7 +9188,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -9263,7 +9198,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -9314,7 +9248,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -9360,6 +9293,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -9462,22 +9396,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: msonet_ps188
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_ps188.nc
@@ -9500,7 +9435,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -9508,7 +9443,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -9521,7 +9455,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -9532,7 +9465,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -9628,6 +9560,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -9730,22 +9663,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: msonet_uv288
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_msonet.nc
+             obsfile: "data/obs/ioda_msonet.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_uv288.nc
@@ -9757,15 +9691,12 @@ cost function:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfc_winds_geoval_2022052619.nc4"
+           #  filename: "obsout/sfc_winds_geoval_2022052619.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -9779,7 +9710,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -9787,9 +9718,7 @@ cost function:
          # ------------------
          # Mesonet winds provider/station use lists
          - filter: RejectList  # initially reject all providers
-           apply at iterations: 0,1
          - filter: AcceptList  # accept back selected providers
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["RAWS","NEDOR","SFWMD","MOComAgNet","UDFCD","CAIC",
@@ -9797,294 +9726,252 @@ cost function:
                      "OK-Meso","MesoWest","WT-Meso","WYDOT","NOS-PORTS",
                      "NOS-NWLON","GoMOOS","HADS"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["AFA"]
            - variable: MetaData/stationIdentification
              is_in: ["AFA12","AFA09","AFA01","AFA11","AFA06","AFA03","AFA02","AFA04"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["APG"]
            - variable: MetaData/stationIdentification
              is_in: ["APG4","APG9","APG1","APG7"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["APRSWXNET"]
            - variable: MetaData/stationIdentification
              is_in: ["C5674","AR622","C4709","AR986","C5444","C4827","AR784","C3771","C8843","C2876","C5272","C6207","AR743","AR983","C3518","C4488","AP121","C1470","C4014","C4183","C8715","C8427","C5804","C7467","C7070","C1456","AR701","C4887","AR581","C7966","C8358","AR671","AS402","AS459","AS549","AR104","AS457","C7511","C5590","AP133","AP513","C8607","C8839","C2024","C5210","AP228","C4409","C5817","AP051","AR477","AP750","C6892","C6980","C5286","C1943","C8659","C7902","C2077","C8198","C5092","C6113","C4264","AS307","C6988","C5376","AR778","C2512","C3353","AP837","C2283","C2716","C1780","C3212","AR690","C1112","AP156","AP991","AR808","C3444","C4434","AR652","AP555","AR934","AS677","C8290","AP189","AR697","AR731","C2824","C4564","AP899","C3966","AS386","C7197","C4672","C0646","C4358","AR231","AR834","C7975","C4510","AS291","AS405","C7637","C1403","C2988","C7524","AS659","AP075","C4265","C3456","C7881","C0773","C4411","AR320","AS268","C2049","C6028","C1002","C2659","C0168","C3063","C3603","C5517","C6356","C6840","AS612","C7960","C4925","C7160","C5834","AS106","AR147","C0013","C3628","AR740","C5761","C4197","C7609","AP200","C1521","AR910","C3640","C3822","C4845","C6027","C8235","C8028","AR464","AR850","C6278","AS478","C5129","C7477","AR897","C2112","C4210","C5283","C0198","AS061","AS235","C0310","AS470","AS294","C6413","C6434","C8083","AP430","AP192","C5110","AS311","AR624","C8539","C1130","C2841","C6257","C7400","C3842","C8288","AR313","C0121","C5490","AP059","AS236","AP352","C0562","C3484","C3157","C4237","C5801","C4416","C6995","C7403","C4453","C4541","C1404","C8241","C7286","C8665","C1824","C1792","C0988","C2665","C5467","C5549","AP996","C5485","AP024","AP559","AR692","AS702","C3234","C3607","AS586","AP323","C5928","C3183","C5818","AS303","C7118","AS692","AS239","C2218","C4661","AP386","AP852","C3205","C2140","AS661","C8122","C4605","C1662","C4566","C7275","C8717","C1484","C3109","C6099","C2420","C2670","C2678","C6486","AS509","AR770","C2462","C3702","C4428","C5772","C5262","AP539","C7445","AS583","AP710","C3189","AP979","C6488","C5599","C4954","C6445","C6532","AP587","C5881","C4766","AR992","C0136","C4645","C5896","C6696","C7327","C7785","C7930","C8067","AS654","AP216","C2635","C6410","AR677","C6384","C5165","AS707","C8517","C2553","AS140","C2101","C4420","AS732","AS125","C5920","AR814","C3340","C6277","C3375","AR277","C0527","C7610","C5520","C4821","C2755","AS350","C8608","C8864","AR864","C6247","C2398","C8488","C5768","AR831","AR943","C1500","C1982","AP260","C7381","C5652","C7866","C7794","C8688","AR672","C5738","C4173","AP072","C6284","C8046","AR172","C4719","AP902","C4900","AP044","C3806","C6822","C6873","C8003","C8743","C8635","AP517","C6620","C0803","C4835","AS279","AP330","AS545","AP071","C7761","C2209","C8830","C2789","C1104","AS701","C4329","C6108","AR138","AR750","AS406","AR942","AS226","C1248","C2568","C5176","C5880","AR841","C4349","C6147","AS461","C4855","AS688","AS676","AR684","C1331","C5049","AR666","C6612","C3154","C3931","C3414","AS441","AP682","AR773","AS296","C4880","AR659","C1775","AS257","C1123","C7003","C6944","AR854","AS070","C0288","AS500","C7667","C2006","C8738","AP859","C6622","C7832","C1621","C5488","AS582","C2715","C0677","C4115","AS202","C3407","C3833","C0222","AS716","C8220","C1450","C7633","C5951","C4199","AR598","AR758","C2069","C3712","C7955","C8810","C0160","AS593","C8361","C4554","C6357","C5598","AS436","C3670","C4840","C6917","C1334","C3379","AP894","C0636","C4367","AR525","C6777","C6817","AP061","C1052","C1999","C8190","AR259","AR391","AP165","AP122","C3750","C1732","C1749","C3459","AR727","C5084","C3438","AS440","AS712","C5040","C5595","C5972","C1323","C6884","C7234","AS617","C5632","C3320","C2857","C0162","C6245","C1789","AR918","C2562","AS495","AS044","AS520","C7857","C0572","C5471","AP689","C4184","AR853","AP769","C2787","C7607","C7741","C6633","C5482","C5437","AP291","AS547","C7939","C8592","C7933","C8026","C4669","C5464","AR816","AS041","C4838","C0922","C0181","C3722","C6848","C2258","AP221","AP895","AR914","C2840","C7260","C8782","C3639","C5504","C5616","C2920","C6043","AP201","C6887","C8849","C2434","C7273","C5183","AS313","C8632","C3934","C4262","C5103","C1840","C3200","C4299","C3236","AS539","AS609","C8728","C8842","C2912","C6135","C2534","C5849","AS591","C4614","AR747","C7784","C8343","C1020","C6937","AS292","C7945","C0752","C6311","C7293","C0453","C2995","AS237","C2951","AP244","C3292","AP734","C2627","C2943","C4691","C5029","AR237","C2003","AS329","C1622","C7710","C0757","C0451","C4113","C5970","C6829","C3261","C1259","C0228","C6728","C6725","C0930","C5270","AR786","AS463","C6969","AR718","AP818","C5466","AS614","C5344","C0213","AR663","C1701","C3837","C3926","AS542","C3235","C1795","C7527","C7759","C6720","AP551","C5786","AP601","AR430","C2094","C3742","C3655","C3213","AP126","C8232","AP542","AR516","AR191","C4767","C7921","C4921","AS618","C3250","C3323","C3071","AS054","AS326","C2978","C4185","AS717","AP904","AP912","C7707","C8373","AR801","C6895","C4448","AR284","C4939","AR931","C5719","AR509","C4525","C0900","C6558","AR906","C1837","AS167","AP241","C8256","C8685","C0732","C6267","C7060","C6803","C0508","AS314","AS327","C7718","C7369","C2247","C6304","C4586","C7077","AS045","AS727","C4679","AR585","AR358","C0458","AS064","C2280","C8856"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["ARLFRD"]
            - variable: MetaData/stationIdentification
              is_in: ["TER","LOF","IDA","RIC"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["AWS"]
            - variable: MetaData/stationIdentification
              is_in: ["JKLNH","FRBRG","ATF29","PROUT","SSKTN","BMMNT","CVLTN","DEPEW","LITHS","MRIDN","VNNVA","CLIFT","PLNTT","PMPTN","MDRBC","TAYLR","ONSID","OMAHA","BEAUM","SANTN","CLMKS","KTHVL","LGNNG","GRNTT","LKLML","DALLS","RICMD","RONDV","WOBRG","THRNW","BALTN","FRLWM","TWNCR","HMOU3","SRFLD","TMWTR","NWHIT","SMTHV","SNTNO","HALFX","HCKTT","CPLAY","ONIDA","DUBOH","MLVEN","WCYBT","AIKEN","SHERM","NNSNV","BTHBS","SOMST","FMCNR","FSDRC","SLFDP","MMGRD","FLFRD","BSO03","DLND3","HLDHP","KHEAH","MRTNG","REDWD","NWHLP","MNOKA","COLOR","GDNGS","DNTNP","AXDRA","TFTCN","GALUP","WJRDN","CNTRY","SHEFF","SENSE","DUNCA","BGSND","BUDDY","HNCDL","PRTTS","GRMCG","KNGSM","ORLDO","ASTAG","PHCHS","GLMRG","CARTN","FLMTH","WKVIL","GRNDI","CRVFR","FORFX","TZWLL","DQUOI","GLDMD","DLRYD","PFDRK","DURNE","NTBND","WSHNJ","WHTNY","MARIC","HNDRT","WLSON","CHTNA","WHAVN","FREDC","MTHIN","ELBRN","RHIWY","HALTN","KGGES","VMCSN","BRMPL","RCKTM","SPEED","STVNO","RYRSF","HNVSL","PLNCP","BLMBL","CINNT","PLANV","BTPRM","SCOTT","SAPNG","MNREW","BBLKE","GSLNE","PTINE","BNSRS","DMSCS","BYRM2","PDNCT","DHRLT","RLGH2","CNLMS","CANBY","HFMHE","SYMSJ","LNFR9","ELWOD","AKRNL","MRTRV","HBBRD","HENSN","CHRCH","LVWTH","MEXIA","SANAO","WYLIE","PALSD","AZLTX","KRKBC","PHBOB","WSTJR","MYFLI","PITTN","A0045","RCHMB","PHLDH","MRRRV","JLTNS","HLLFR","STNTV","DBLNS","GSNAV","FMLCM","STFFR","KACHS","CUERO","HWKSH","BNTNH","CISPK","LBLLC","LNF45","KNNTT","ELGTX","TXRKN","RSSLL","VCTR1","BITOL","MORGN","RISTR","CRLLP","XLLMS","OFLLN","KSTFE","AMERY","AMRGS","STHJN","PNCTY","AUBUN","CPEVA","KESHA","LOCUT","BRKLI","LMNST","MMRMS","SLSBR","RDNTH","MZTGM","CRRLL","ASTAK","DLND1","MCCAL","ORTNG","JTMRH","SHNNH","WTRLC","HSSVP","KFDMT","PLSNJ","GRHBL","HRNDN","PDERI","WYNSB","SSSXW","ASHNN","MNNON","CLUBA","PTTSH","FRMYC","SNCPS","HRTWD","KNSMK","MLLCT","SVSPR","WSTNN","KLLES","DNEMR","BKNTZ","KTVKT","HDRSN","SWANS","WLDOR","MNTBR","CRDVG","NWTNC","OKSBA","VNDLC","BLMRB","SNHMB","FRLCC","CORON","SANTP","CHMPL","CLLYV","SBSTP","GWUNI","NEWCS","BNKRH","OCCTE","CHGPS","LNGGR","MSTIC","HNDFC","GAIBG","MMIFL","URBNN","LXNGN","BEUMT","LLMCH","VIDOR","FYTHS","GVECG","MPHS1","KLLMS","MOSSY","VGHN1","LBNNP","BRNTS","WNNVG","BEMA1","ANNEA","NOLSM","HSTKM","TLASS","STANW","PHELN","KDESG","FRTSG","DNDRN","ESTCH","VLNTW","CCHTT","CLYMR","ARPJH","CRSTV","BRDNJ","DNTNC","NWMRT","NVHVN","WLLST","BTHPG","FRDRD","DNVAL","TRNVS","PRSMC","SHLIS","JAYOK","INGLS","GRNBY","BLAIR","HBGIL","MAMIF","MOORE","RVRDG","BRMNG","CONTY","LILLI","SYKEV","WRNSE","SMMRV","EPLST","LVRCC","ATHEN","LUMBR","DETSC","NWTLD","KIIGS","CRSCS","CLDGE","HAVDG","MILVP","PRINC","ROMPA","CHTAN","WRWCK","FRDNA","NMTHB","CRMXL","HCKY1","RCKHL","HRNLK","MNKHN","BWCCD","SANDG","ARLNX","SNNWS","DLTON","RPLEY","MTRSN","WHTSV","HOBBS","MVSTA","WREGT","JEFFR","HYMRK","BELEV","FRDDC","LNCJF","SGRLF","SIMIV","CLEBE","BNSHS","EDONO","EWING","FRSBG","GLFRD","WODBG","WLWMS","MNTST","BCKNL","RIPTN","BUNNB","BURES","DVHCC","JCKSO","OWHMP","MTCHN","ASHBN","CSHRE","CULAL","ELZTN","NWBLM","UPPER","WRRNG","KNNPL","SMMTS","ALGNQ","BTTLB","PLVRN","LNRCU","PWTCS","RBBPH","FXBCV","MDTWN","AEXDR","A0020","NCKLS","STTLC","WNDMH","MASNC","MTBRD","MONEV","ELYNV","FLFRS","SLIDE","ELMSF","HSSLS","CLESP","COPLY","FALWR","LUMBE","GRVLL","PCNSM","WSTCI","LFRST","FRMNT","HMPSH","LONGD","RCESS","RCKTC","MILVL","WALDF","ALPLT","GALIN","PTESN","KNXVN","TMPSH","DLTH1","ASHRB","BEAVF","LALTO","BRSRS","TCMEE","MDINA","GRNLD","MODST","GRMBL","BMNBS","NPVN1","BTHLC","LNGLV","JCKHS","GREEL","MANFD","ESTRC","GRNSD","AVPGS","WSTDN","GLFNC","SEEKO","MCHPC","GGHRB","GTHBG","UNVRS","DPONT","RDFLD","PINEB","WLLWS","WURBR","DGHTN","PHLLL","MRTVL","ANDCS","CLMSD","FBGMC","KCLHS","MRTVM","RMSRM","ESTNP","FRSTG","BINKR","BRMDN","HCKRY","WETVL","CHEEK","TMBS7","RNBRN","JCKJR","RLDMN","CLVLN","WSHVG","PNXST","STBEN","GSCRK","CNGFL","MMMCH","CCCWS","PRTHR","MINNP","SMVWD","PARIS","WSHVL","MNWSH","WHATN","STAFF","DEWYV","ELPRG","WDWRD","ALVRT","MPLRG","KMOMS","LULNG","STTL1","WWBTV","FAYET","BVRTW","ROCKW","HRTSD","FRASR","LNSDL","CRSRV","CSPRG","EPRVD","CRLSC","SLMSP","CLWMM","TRMNF","JPPRN","DVRDH","ALBNY","OLDTP","RVRTN","FRRMF","CRKCT","SHRDN","BLSML","ASIND","CLEGE","STCLR","MANA2","HRTWL","BRPRS","VHSNA","NWEGT","STRTT","OLDFR","SLTNG","THMSC","PITT2","JMS03","SNRSC","WODBR","MNCRN","AVLCS","STLGL","GRVPR","SLSBY","WHRTN","BRWST","LSCRG","WSTPR","GRENR","AIKN1","SCTPL","CLNCL","WLKSB","RSMVA","DTMON","NATCT","HOTFR","SLMSH","SHLLL","WAVYT","JCKGP","RANIR","LCSTR","GVILL","SPGKF","AVNMT","CLPPR","MANHM","REDNG","RCHM2","NRWLK","PRBDN","RSVLL","FDRLW","OPRKN","RYNLD","NWRKS","VLNVH","CHVVS","WSTWN","LRNBG","SCCSN","GSTNA","LORTS","RCHBO","IMMKL","HOMLA","TNKHN","AMNAD","CRPWL","CABRD","MDLWS","CMPEM","WSTPN","CMBRK","ANNDL","WDSTK","BRWCK","ARCHS","LNF20","QNLAN","LNXBC","YLNC2","CHRNC","JECTY","LXTON","SHRWD","SLCUT","JNCTN","WDBJT","KGCBS","FTWTV","ELPRS","BOAZ1","WHTPL","NEWCN","BURNE","BXLDR","STPHN","VSLLS","LNDNN","YNGSJ","BRGPS","BTLCH","GNSCS","HRNVL","BRENH","GRNDO","ISSQH","MCCLE","MSSMC","PNBMC","HSHBY","HANOV","HGHPN","WHTVL","KUHES","RRNCH","SANTE","ONLGO","LARTY","CORFU","MILFL","WYSBO","CSTLW","NWMLF","WILMD","WRRNW","LHGTN","ORGTX","GLENW","NSTHB","WRNBG","SLNSC","HJHSB","APLMD","SDNBL","BULRD","GNIST","HAMLT","BSSMR","CRAIG","MNTCP","BMSPT","AUGDC","URBAN","CHTMG","WATGH","VRGCH","OCNCT","DPKNY","TACOM","SARDN","SNDYC","BRBYS","MMLMC","STLMS","REDPB","CLNLH","KRKLN","BSHPR","PNGCH","CFDPT","DTNTN","HUMHS","WDSWH","WYTHV","MCNCO","RRHMN","NRUHS","MARHU","LNGMD","STRSM","CPCOR","MIDVO","CLRWT","COVIN","TLRSS","SLMNC","ODNVL","RDMND","SPHSC","BRMRT","VERON","MAYVL","PNRGY","HRWNS","WURFR","CETRS","MPLWE","MCKNN","MCNGI","MTVR2","NEWBM","ARNCC","MMMDC","CHMBR","VWCCO","SPJDF","SMTHB","RYSFD","BLKVL","KHDHA","LAFYG","CMARN","CMDAR","FRFPW","CTVIL","MDSON","MNRVL","STORS","OKDL1","HRNLL","GLDSB","RLGH3","TLAHS","OPLCK","PNNNG","BLLVV","ALSVJ","MARRE","SCRON","HAGRS","SHBAB","STTMS","LODIM","ORNGF","ALDNA","CLMSC","CLMNS","BNGMN","LMNGR","SFFRN","CHPSB","BUMNT","LESSC","BRDFD","HAMLN","MANAS","GWNDA","CHSTS","PLMGV","CLNCP","OXFDN","CRLSB","SLDSM","WLLWH","CRTSM","BLMBH","WXYZT","CALFN","DTRED","TMBRK","NALSC","WHLRV","FRNDL","BYCTY","COVGT","MNSAS","WSTGV","CMLLS","BSDGT","CHRLR","MTESO","MNSS2","WTMTR","DCHEC","JCKHP","RMGTN","BATVL","MTQCR","DRSDN","ANSNA","ASHLY","DRRYN","MORTN","PROPL","LNCTN","CHSHS","CNPLS","LKWDW","SMRIA","LSCPA","ABONY","DKLND","SRTHF","ALXXD","SLSWM","DPSAR","NAPBS","OCCAL","LSBBL","WBNST","NRWDQ","WPSMH","DRPKN","NWHPR","ELLEN","WACO4","FTWR2","CHRTT","HKSTN","MYRST","ROMLS","NRTHJ","RSTRT","NESMR","MPTPR","KYHCC","BCYRS","SHNTN","ANTCH","BMNTR","MDWAY","BLMNT","LBNON","BFFLO","WDSTW","CLMBN","NPLSD","LEBNO","ALAP3","FRWSB","ALAP1","HUMBL","PTFSB","LRLJC","WRGHT","MARON","DCTUR","HRMTG","LVNMM","NFAIR","MYFLD","CAYGA","FERFL","FSLKE","SNJNC","JCKNO","MECNC","CHRLG","RLGH5","PHLDD","MNSSN","SLVLN","DRHMC","GNLCM","RNRMS","HAMOK","OSMNN","CPERL","RDNLP","ELKTN","WGGSC","CHRTY","BRSHM","ESTHR","LHSAL","ARRAN","APTS1","CONRO","KBBEJ","PNMES","DECAT","SOUDR","MRTHN","BRTWW","CRNDL","LRAY1","ESTHD","CHRON","SOLHS","GLDSP","STNWM","RSPFP","CHEKT","JMS04","BRTLS","RNTON","WNNMC","FFFMN","BRN01","KSTPT","BRDEN","SCHOL","NGMSS","BNLVL","EPHRA","MDLTV","BDFPV","CHPLH","MMLTN","BWLIG","LRTTC","PNTG5","LNGMP","CLDNY","HLLSB","GRNLN","FRCKP","BLLVU","CMNSL","MDLTN","YARDL","IMPRL","HSTN0","FRTGB","TRTLK","CALIF","FRNKV","OKDLE","LHMNL","BFLCH","CHYNY","WODBY","WNNFL","SETLE","LAGUN","HLLRD","PHILP","VNLND","GSHNJ","GRVSB","HRMNS","NWMDD","KIRBY","LKWLS","LAPTE","HWLND","CRSFL","RRTNN","UPTME","ABNHF","NAVAS","BLLMM","ESHBR","SHAKO","KSHRM","SGRNG","IMSVL","PELIN","PORCH","SCHAU","LKVLL","ELLNV","TRNLL","MIAM6","CYPRS","TCMWA","DRCHS","WLTRB","GLNRC","CRVST","KJOSC","KRMLG","WLSNC","CPRSS","PLMAL","RICHL","WSTMM","CPRVL","MTNWA","GLLWV","PNTGR","MLFHT","RYRFR","MNLSF","FRCST","CPDRL","CHHLS","MNTNC","RSTON","THPLN","HRRDS","HEGNS","JONES","WTFRD","SNDG1","ATTCA","MSSPQ","NLNDN","BRWNS","LHGHC","FT1MT","LRLHL","WTVQT","DLTPC","LKBNV","STHNG","MNRCM","CLRAH","LANGL","BFFLS","BONHM","MARLN","STBRG","GENEA","TOMBL","KNWAT","AUROH","WLMSV","NEWTN","JRMYN","BRDMN","FMYSN","MDSN1","VCHMN","DBNNW","STHNR","CRNX1","RCHWR","SNDI0","BLLVS","MCGVL","EGLRV","CMPBL","JZLTN","LEROY","BNTSL","PRRRY","NPRVD","CHRHU","CLWST","EGLNS","BRNSW","HILMR","LNXHS","CDDML","EURKB","SLNSA","PRTBY","FRSTB","FRDMY","SBS02","MNCNS","ELWRT","FMNTN","STLFC","EDNBR","TRFLG","BGLSB","SPRCT","HRHES","WFORT","DMOND","LIZTN","YKSHR","CHALS","SWFTW","WLLBG","AQLLI","GRNS1","NSTHH","HDLRD","PRVON","BFFLM","KWIES","MRCRS","PLMTT","PGHKA","JSTON","FRTDF","NAPA1","LCKPT","MERDN","POWHA","WNTZV","TOPKA","WTTRV","PLMTS","RSFRD","CAPCL","FTBCM","DISPT","NEWWM","MRAMR","APXNC","MIDBR","SPIGN","LEBON","QUAKT","FPDPT","SLLVN","TRYBU","JMS02","PHNSM","CESSC","HRSHM","CLFCO","POETT","BTHLS","BRNTW","MKSCR","ACMRS","BRUSW","NAMSS","WWLPG","STRLI","HGBRD","RCHST","NPLSL","CHRRS","FRMDD","CHRVL","PCHUT","KLEIN","MTENT","ABGTN","GUILF","MIAM2","RLGH1","TCMMF","WZVNT","MSHWL","BOLVR","OKFLD","GRNDR","LTHM1","BEFFL","PRNCS","BDFDV","WRWRG","WNTRE","FREDT","MKERK","NWTON","RCHDL","RSNGS","WAVRL","NSTSU","CRNNB","PWTCK","ESTFR","NWDST","WLDNP","DNSPS","BRDJW","SLDNR","ASHBR","NRTHU","MLTNL","NVADA","RSNRS","DOLPH","ELCTV","GBSNA","SAVTN","MNTVN","BTHMY","SMTHF","LESSF","MRCIL","CRSPO","SEAWR","SNJSE","NRTHR","A0031","LXNPP","CLRPH","MATLD","GSOCM","ASHSH","HSLND","PCBCH","WHTHL","MINLA","SRCHL","PRRV2","SPRHE","SPGDL","WWLPW","HLMSB","DNSTJ","CRTLS","SVGRD","AHSKE","MNSMF","VCLRV","ABRNS","BLAIN","LNNLN","BRSTW","FRANK","WKFST","WSWEC","BSO02","PRCSD","LSBES","DLVL3","CAPCO","ULYSS","BKFLD","EHAVN","KSSMS","OKLYV","MSCWL","JSPER","STHDY","WLMNE","EVJHA","DLLWY","DCECX","AKRNB","OSCLA","LANDO","DANVL","PTSTW","SYRCS","SLMCC","KNGWL","GRDNC","BRCKP","UNVPL","MARNO","CLMSN","RALGH","MNMNV","CHRDN","FRDBG","HMDEN","MRMAR","LAWNC","FRMNJ","DDLEY","WESSN","TACPE","WHNT2","DOYLT","MCHVL","WTRTN","ESTRR","MDLJR","NWTN1","PKTNN","JKKSN","NWIVN","PRRFR","MNNDR","BFMMA","OCCTY","OLYWB","ANDRW","CMBDC","KETUM","BNNYL","WLLWP","MSHIM","DIMCK","HFFMN","ALFRD","FLMDT","A0082","CRNLS","SEEKK","TKKWL","HGHSV","JSPRH","RSFHM","YANKE","MDGRD","WSTGR","PUALP","KNTWA","TACMA","HIGDN","OLDWS","DTRTV","RTTMN","WALLR","HESPE","WTNHT","HNVRT","ASTRA","FRKNN","MDBJH","BSO07","SARVR","ESTHS","CNTPL","PACSC","OKHRB","CAMAS","BRWLL","CBANY","MNTPL","BTHHA","DACSC","OFLCS","ROCHE","OZRDC","THMLM","ATOWN","GGAPL","EVADL","KUNTZ","MINRL","WNSKT","SLTHL","DNDNN","LGNTN","HLLRT","RLGHD","LXNGT","BRESC","RYREV","RBSNC","FWOTH","TCMAW","ALLNN","ATTLL","BOYER","UNVDE","JIMLW","CHNTL","WLCTT","LKWDA","CRMEL","SNYVL","CUMBR","OLEAN","SPGVL","PIRSN","SPNDR","HUTSV","NEWNJ","CLLMN","SHPBG","ETNVL","OTHLL","MOSCW","LXNGS","NTCHZ","GBFHP","NBUOH","ALTMN","MANSF","MDDON","STHLD","CENSQ","CHTTN","SBURY","MCHNC","VNCMB","NRTBY","DFBS1","PHLFF","DLND4","SMSTX","BBRNC","ALLCS","CHATT","HAMBR","FLKVL","GULF2","ELBAC","GBORO","WSTPA","MRRRJ","SLDAD","LYNJS","WRWNY","NORWH"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["AWX"]
            - variable: MetaData/stationIdentification
              is_in: ["AW314","AW281","AW381","AW233","AW345","AW213"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["CAIC"]
            - variable: MetaData/stationIdentification
              is_in: ["CAEGE"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["CODOT"]
            - variable: MetaData/stationIdentification
              is_in: ["CO102","CO006","CO001","CO103","CO096","CO104","CO066","CO020","CO071","CO095","CO089","CO008","CO084","CO067","CO097","CO065","CO099","CO073","CO072"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["COOP"]
            - variable: MetaData/stationIdentification
              is_in: ["PATM1","DANM1","RGLM1","ISPV1"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["DCNet"]
            - variable: MetaData/stationIdentification
              is_in: ["DC008","DC001","DC010","DC009","DC003","DC006"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["GADOT"]
            - variable: MetaData/stationIdentification
              is_in: ["GA109","GA113","GA114","GA104","GA103"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["GLDNWS"]
            - variable: MetaData/stationIdentification
              is_in: ["KCO0","KSYF"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["GoMOOS"]
            - variable: MetaData/stationIdentification
              is_in: ["44037","44029","44034","44024","44030","44035","D0201","44031","44032","44038"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["HADS"]
            - variable: MetaData/stationIdentification
              is_in: ["MRVA1","OBII2","OLCN6","SXHW3","BSBM4","SLVM5","CLSM4","JAKA1","LOKI2","PNGW3","WHRI2","SRDI2","OTNM4","RPRN6"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["IADOT"]
            - variable: MetaData/stationIdentification
              is_in: ["RBFI4","RLEI4","RIAI4","RCEI4","RWII4","RDVI4","RDCI4","ROSI4","RSDI4","RDWI4","RDSI4","RCAI4","RFDI4","RMCI4","RTOI4","RTNI4","RONI4","RSYI4","RSBI4","RSLI4","RMVI4","RMQI4","RAVI4"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["IEM"]
            - variable: MetaData/stationIdentification
              is_in: ["SCSI4","SPYI4","SAFI4","SGMM5","SGRI4","KKAS2","PESS2","SSAI4","SFAI4"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["INDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["IN001","IN009","IN014","IN008","IN004","IN002","IN016","IN018","IN005","IN013","IN011","IN015"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["INTERNET"]
            - variable: MetaData/stationIdentification
              is_in: ["NWTC","SRRL","CSUF"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["KSDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["K1EGN","K5KSM","K5EUR","K5EHT","K5KIO","K5ED7","K5OK7","K5LEA","K5WKY","K5WSU","K5NES","K5SLN","K5PEA","K5BCR","K5FRD"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MAP"]
            - variable: MetaData/stationIdentification
              is_in: ["LHSCA","CCOCA","BBYCA","CCLCA"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MDDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["MD020","MD040","MD054","MD038","MD043","MD018","MD012","MD011","MD037","MD027","MD029","MD004","MD023","MD016"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MNDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["MN011","MN035","MN037","MN010","MN095","MN024","MN032","MN091","MN086","MN080","MN015","MN008","MN025","MN014","MN057","MN082","MN029","MN076","MN018","MN044","MN052","MN079","MN045","MN059","MN071","MN021","MN026","MN038","MN043","MN036","MN030","MN075","MN042","MN096","MN022","MN065","MN007","MN084","MN063","MN028","MN033"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MOComAgNet"]
            - variable: MetaData/stationIdentification
              is_in: ["MOA14","MOA05","MOA06","MOA04","MOA01","MOA03","MOA08"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["Maritime"]
            - variable: MetaData/stationIdentification
              is_in: ["DBLN6","46012","45012","44044","MBLA1","45132","42003","LJPC1","41048","46027","44041","46091","LKWF1","42040","42019","PILM4","46026","45001","44017","45007","44007","44029","TPLM2","41025","CBIM2","46050","46147","PLSF1","41008","46047","45137","41046","46088","NPDW3","45135","THLO1","46005","KS063","42020","41013","42055","44053","CLKN7","44011","44030","46145","46059","41009","46092","SRST2","44150","CDRF1","42001","SBIO1","41010","LKPL1","44043","GDIV2","46025","44009","46093","SAUF1","42039","46131","42036","41012","FBIS1","44018","42035","SGNW3","45140","45004","45008","45006","41035","46233","46014","42002","45143","SYWW3","46029","45147","46022","SGOF1","42364","46013","46053","DPIA1","45139","46207","42056","44031","LONF1","TIBC1","KNSW3","41036","MHPA1","AGMW3","44004","KS057","CARO3","GSLM4","44038","44013","ABAN6","45005","44014","ACMN4"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["MesoWest"]
            - variable: MetaData/stationIdentification
              is_in: ["CQ082","QSF","DSTU1","CQ089","ITD22","E5POR","QHW","TVANT","CQ148","JHR","TBLEW","KFCT","TIM60","CQ071","PYRLK","TSHER","CMP12","IMBO","TSUMA","A28","TSUMT","TCAND","MNDN8","GERW","MSCM8","CQ062","WRUN","TCHEL","QB4","HFRNK","CQ160","TLAUR","FOGO","TEAST","LMS","AAWC1","LFPBO","TSELL","ODT06","DPG20","ITD33","TBAIN","K4S1","TWHIT","CLR18","UWASH","MLAM","TOYST","ODT54","E1BEN","E9GRA","TKNAP","COVM","AWSC1","ENUMU","HHAMR","MKAR","SIGM","CMP23","CQ112","WGHA3","LIDW","CQ084","MARC","SEEU1","CQ098","DPG23","CTFPE","GFRI","RICH","MSWN","CQ063","DYER","TANAC","UP104","RXGI","CTHLT","SDMGR","WHALE","UT26","UP439","CQ035","ITD27","QWJ","A30","UTGRS","POR","UP353","UP459","UT23","MRSO","MESX","ITD41","ACOC1","STG48","ITD42","HRHW","CTANT","GUNN","CQ133","SEABE","OPH","ODT36","CLR17","MLPS","LYN21","T130T","CQ136","CQ060","DRLM","PICI","DENI","UP143","UP417","MWQHR","CTFYP","TI182","HRSPG","PTRCA","SDPOY","ODT20","ODT62","HRING","DPG05","DPG18","UP222","SDAPN","DEABT","HWYEB","CQ158","ODT33","TWALK","KCWU1","ODT01","ONTO","TACLS","HARMY","UP007","LDDW1","FALN","UT12","PCS","CMP04","CMP16","H200W","LDSM8","LVHF","RRWO3","SDPMS","RPTI","MNNM","CQ106","MYRI1","UP073","TSAMI","CCD","QRMO3","DPG04","PEN","SDHTB","KBDN","SUNUT","RDN","DPG12","HEDNA","TMARY","KQML","QHV","CQ178","MALI","TBLAI","CTVOL","CTOMS","SNI","MYEP","DPG15","MHYH","LAK","PUYSO","DPG10","DSKMT","CQ067","TSOAP","CQ144","CLR10","UP028","DPG02","CQ103","WPSPT","TRJO","UP164","CLR15","K92S","QHG","CQ070","ODT18","CPC01","CQ097","ITD29","A44","KQPW","TMUKI","CMP24","GDNSP","CPC02","CTDUN","CQ068","TEN","CLR05","ODT42","SDTEC","QBV","HRICH","CMP19","DPG09","UP156","AGKO","GVLI1","PEM","LAYUT","LORO","LANL2","TSPA1","RTB","HSURF","CQ032","MYRB","E8KLA","SDTSR","MPND","DPG21","QWV","SEADU","UTSTV","TIMN2","KQWT","TUNIN","ODT08","UP138","HP002","CQ147","RDHMT","MWQAR","QBR","DPG11","MLEW","ITD09","UT7","CTBOG","FTHI","UP289","CQ087","HBVLY","GOLW","WRDO","ITD45","KQCI","RVF","CQ102","CLR14","TSILI","TDRYD","CQ042","CQ074","LGVI1","MRED","MSCO","LOFUT","COAM8","DPG14","MRVJH","ITD03","MLOS","CQ099","CQ164","MTH04","MDEN","DPG25","UT3","SPOFE","TBULL","FMP","E3POR","ODSW","UP385","SDMEA","UTR20","STCA3","DPG13","FLU","MWQMN","CRVO","HERO","E3HAL","H100A","GNI","UP053","NUNC2","WEHN2","CLR02","MWQKT","CQ096","SBE","MBRM","FAU","GRS","UP225","NIPM8","TRGW4","JPHN2","CFO","MHCA3","ODT41","CQ104","FAFI","UTPSH","SJS","QMG","THFM8","ODT66","TES","UP196","CTBBS","MFLT","TSATU","LANL1","STB49","ITD44","DPG06","ODT67","CQ140","MGAR","MSWC","TMANE","MBVR","CQ040","CQ077","CQ093","CQ143","TUM43","URM","CLR01","CPC03","CQ031","HPASC","CMP09","CQ134","MGRN","NAM04","CLR03","KNTJC","ODT24","CMP13","CQ041","MWQEE","SKY","MTSC2","UP286","ODT17","LANL4","LEGW","TWFI","HVERN","ITD31","CQ132","SSWN2","ITD28","CQ154","MGOV","MGSA3","H100K","ITD35","DPG03","UTWTV","CRL","GROBT","MCHA3","TELKH","H100F","DPG08","VIOM8","ITD40","H200E","HHMS","CPC05","CQ117","CQ075","CQ146","CRSM","CEN","HPFP","CQ083","RES","MWQCN","NBDNB","TMANS","CMP25","CQ126","SDUSS","CTAND","DPG07","DPG24","TACAL","FVVLY","BULLF","CQ054","BURMA","CQ090","CQ170","CISCO","CUR","VRN","UP006","MWQRU","T2195","HGABW","HVSTA","ITD34","E3CAR","TKEYS","RDBM","T144T","CPC04","HBENT","CQ159","PRP","UP263","UP358","TWARD","ITD25","UTWLD","KQLX","ODT10","MMON","CSNSK","TSOUT","CQ065","ITD48","A05","A46","A13","LANL5","TMEDI","CQ052","CQ061","CQ129","CQ142","BKVO","TRITZ","CMP02","CQ162","DPG19","ODT29","KFLW"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NDDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["ND008","ND023","ND012","ND003","ND020","ND019","ND010","ND007","ND021","ND018","ND011","ND002","ND009","ND004"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NEDOR"]
            - variable: MetaData/stationIdentification
              is_in: ["NE029","NE011","NE039","NE000","NE059","NE017","NE006","NE056","NE037","NE026","NE049","NE058","NE008","NE016","NE005","NE057","NE015","NE027","NE042","NE045","NE054","NE014","NE041","NE009","NE047","NE050","NE030","NE028"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NERRS"]
            - variable: MetaData/stationIdentification
              is_in: ["WEXM1","BSLM2","ELXC1","NIWS1","NAXR1","MAXT2","GTXF1","RKXF1","SAXG1","GDXM6","TIXC1"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NHDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["NHLRV","NHSFD"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NJWxNet"]
            - variable: MetaData/stationIdentification
              is_in: ["KQ11","KQ59","KQ58","KQ43","KQ56","USFS2","USFS1","KQ55","KQ48","KQ49","KQ51","KQ52"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["NonFedAWOS"]
            - variable: MetaData/stationIdentification
              is_in: ["KFPK","KS34","KMPR","KMYJ","K9S2","KHAE","KMAW","K78T","K2Q3","K6S8","KPYN","KN23","KUUV","KBTN","KTYQ","K1B1","K1D1","KCZG","KOIC","KHWQ","KTRK","KFSK","K97M","KSIK","KO70","KMBY","KX26","KEVU","KM75","KLRY"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["OHDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["OH105","OH039","OH160","OH165","OH055","OH064","OH062","OH101","OH154","OH027","OH044","OH040","OH164","OH115","OH124","OH036","OH090","OH014","OH162","OH106","OH126","OH050","OH011","OH076","OH096","OH163","OH158","OH060","OH148","OH107","OH116","OH135","OH109","OH140","OH147","OH117","OH097","OH150","OH034","OH023","OH159","OH032","OH142","OH111","OH083","OH030","OH166"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["RAWS"]
            - variable: MetaData/stationIdentification
              is_in: ["BBRC2","CCKT1","SRUC1","BVRC1","TS712","PRGV2","BFRI1","RSAC1","TS305","CBFI1","LCKI1","DUNN5","GRVN2","WFHC1","FADT2","UMTO3","LFFT1","DBYV1","NATW2","QPVA3","PRWF1","BMEC1","CPFO3","MCBT2","SSRT2","MILW1","LRLN7","ASTM2","ESPC2","LCLT1","FCRT1","BNTC1","CDHT2","GWRT2","OLFW1","DVLW4","OZNC1","MCLI1","MDHC1","BTRT2","NBKO3","HTSC1","ALRN2","SVNS1","CEKC2","RTGC1","BSAK2","CHRC2","SAWC2","GMTC1","RFPS2","COWW4","YEFO3","TS161","CNFO3","HDZC1","FMRM7","MAYW3","PIEM4","PLPW3","SEAM5","SRSS1","POEM8","RRAC1","BEFO3","ECSC1","MLLO3","TCRA3","WPKO3","TBSU1","MYFI1","TR490","CRKI1","MDRW1","OVLW1","CSTC1","KNNC1","TSOW1","SMFO3","HBFO3","MLKM8","TS395","RRDM8","GASI1","RRKN2","MRZW3","MTHI1","ALLN2","BCHN5","QSBA3","RANM4","TS211","BADU1","CISC1","BPYW4","QFSA3","SPMN2","WMTM4","BABC1","BMFW1","KRTC1","BGRM8","PIRC2","NHPC1","CHGG1","BQFO3","SPKW4","RPRT2","TS722","HBOM8","FHLC1","PKCC1","QMRA3","LDRC1","OJIC1","MRLV1","NPTN7","TR792","FFFO3","LDOI1","CICC1","PLIC1","BBYV2","CHEO1","LXFN7","GTGW4","TS583","AVLC1","HDRI3","LBLK2","POCN7","DKYC1","QENN5","GSCN5","RNFO3","CMRW4","BLAN4","GDSV2","HMEC2","TR272","CYFW1","GCRW4","CGLK1","LSNC1","PBUI1","MVVM7","SRYM8","CHFT1","NNHM6","FRNM5","TNBM1","LKRV2","GDRC2","TCKC1","TR192","RASW4","CIMN5","GALN2","KMFW1","TABC1","BRHC1","HHFO3","JAYC2","LVMC1","MIPC1","EDTF1","WLHS1","TR127","CAMW4","GMFW1","BBNL1","ARAU1","CDDT2","DNFI1","LRCM8","RHCM6","MPAM6","MWRM1","GLFM8","BNGC1","OTRU1","STKM8","FHFI1","JMRM5","LKNC1","MORN2","RLKN2","VENU1","BRUO3","OHOI1","SETC1","BIRM5","CITM7","FNWC1","GUML1","HBRM8","KTLW1","CMDT1","ESDA4","CPGT2","HPFI1","HSRU1","SADI1","SBWU1","CONM8","HYFO3","IVET2","KRBT2","EURM8","CLRW3","CUWN7","ELOM5","WNKN6","GPRM8","BENC1","VABC1","TS123","FLEI1","STGM8","FLSO3","CMAC1","NZAC1","CAZC1","KNXC1","MZHM5","MDEC1","ATNC1","CEKC1","CYFI1","FLFI1","JVLA4","BTTC1","EPKC1","LRRA4","PPRC1","BLDT1","HOBW4","MUDW4","WRRT2","BAFN8","DMMC2","FBFW1","OWFO3","LAUM6","LOLP1","SDFO1","WCAS2","TEXT2","TR543","SPGN2","BLCM6","SHPN6","NLHV1","CDFO3","RESN1","YLSU1","BYCU1","SDLC1","WTPC1","BATN5","MCDM8","BNRI1","CRGC1","FNWO3","SBFN1","GARL1","QBMA3","RNRM5","DOUW1","OBRC1","PCRW4","RSBU1","SYWC1","CTOC1","RDVC1","CPPN5","TR201","CKNT2","QFLA3","DVLO3","DARN7","RUTN7","TCCG1","TS199","CWLW2","ROCI1","BIGI3","SNDN5","QHQA3","TWBI1","MMRC2","IPFI1","WUEW3","MFCM6","SRRM8","TS698","MIGC1","SFAN6","FCHC1","MSAT2","QMLA3","PEEW3","TS350","MPAN5","SNGN8","MPRC2","TS623","HWDW3","REXM4","TS575","CRSN2","DRYW1","QUPA3","TR956","TS529","GSPC2","BHFA1","PYNC1","MSLM8","SKFI1","TS376","TS686","OVYC1","THRW4","ROVC1","BLNN6","HCOT1","LDRC2","NEFW1","INBS2","RBTN2","CSMN5","PSAT2","GNSC1","KOSW1","WMRO2","SDAM8","CPMG1","ESXV1","CGFW1","CUHC2","DEAI1","MGFO3","FMFO3","QSPA3","BPKC1","FIVU1","LAGO3","HAFW4","LSCU1","DEHI1","NCSW1","PANN2","HRDG1","LBHM8","ASYU1","WSFM8","KEHW3","MGST1","TS663","HIBW1","TS304","GRBO3","MOUC1","NUCI1","STMN2","NUCC2","RNDC1","RSPC1","AELG1","HFMN7","GCRN7","GFSK2","RFEC2","TR130","CDAW4","SLWC1","GUIN7","APBN6","PRID1","ZSFO1","BNHT2","PSTM8","AWWN8","PNRC2","SPAI1","LGNT2","TR269","TR007","JACN4","KOMK2","MAHN7","MMOM4","WOBN4","ARFO3","ERAW4","BLCN5","CHAC1","CHEA3","TS481","BLAU1","SMYI1","SHZM1","PAFO3","PLAG1","NATN7","SAMF1","LEFW1","MTZC1","NEHW3","TS545","DYLC1","MEGT2","LSRT2","FIEM8","PJNT2","PLEC1","TS674","TS720","BHRC2","KPRU1","HBYT2","MIRT2","WRRU1","CVEC1","SSMM8","ECRN1","BOLG1","FSTM6","GDNW3","MTIN7","HTVT2","CALN4","ATRC1","CAPT2","CVBC1","EVFO3","QRCA3","ABMN6","TS338","UTMN5","SMFW1","NBRN7","RRRC1","BEFM8","DENC1","OTOW1","PIBC1","TS631","LAHC1","RLAS2","RNEM6","RVZN7","TNFM6","SNYM4","WHBU1","TS429","SWNF1","EMTW1","LITM5","MPOC1","HTRC1","MIDW1","AGOW3","DSFI2","FVRV2","ISAM5","TAWW3","FBRN7","MATT2","TGSK1","VCRT2","BOOM8","NFFI1","CEEC1","HOTM8","BRSG1","SRON6","MKLN7","OKMA1","OPNA1","RKIF1","LACL1","DAFT1","PLAM8","PRFO3","PSGT2","RCPC1","WRSS2","BNFO3","SDMW1","WNTU1","NAOG1","SRVS1","JCKS1","MRRN5","TS726","TULG1","BYDW4","GDBT2","BAFO3","UINU1","POTI1","QISA3","TWRW1","EJAG1","JEFS1","TS682","CLHC1","PGRU1","RFTI1","JCRC2","TS164","EMRV1","RHOM6","BIIC1","FMRC1","DIAU1","COIN2","MSAC1","HUFW1","CYVC1","LPSA4","ORBM5","BHMM8","HCKC2","JVAU1","KYCN2","KCPT2","BPKN2","GELT2","STOC2","TR968","MPEC1","UNFN7","WSHW3","BRLW4","HBFI1","MIAC1","TS651","THKO2","BUFC1","TS341","ZNRN5","COWI2","GLMT2","QADW4","QCAC1","MRAG1","TS098","CLBC1","SAFO3","NINM8","CKST2","TMKO3","BYRG1","LBRM4","BUGC1","STVM8","TRDK1","KLOM8","HLKC1","LANS2","LICC1","STHC2","BUCO3","SNOW4","GRYT2","DRAC2","GMLN5","RSHC1","BDEM6","MTFG1","BXYG1","RMAM6","KNGS1","KLYW4","CVFO3","LRWT2","RONM8","SIAN2","SDRC1","WWDC1","YELK2","JONG1","DLSG1","RLFO3","TS724","LWDN8","TR297","KNMM5","TRMK2","BKBW1","RACF1","BLUM8","EGLW4","NPFO3","TS390","VLYC1","RLDM6","DFSM7","TS693","CHOM7","HDRT2","BKFS2","LOMN5","RHKW4","BFYI1","BRKO2","INDI1","QGTA3","FART2","TS619","FLSN2","PCKI1","SQSC1","OCOF1","BCFI1","BNVA4","CMMM7","DENT2","GINM8","QPFO3","RTCT2","RVZU1","SWLC1","KGWW2","LCFM8","BMJM5","LEVL1","KEEO3","STNI1","TROM8","PAMC1","TR285","IRFO3","ELRN7","FRCC1","SAUC1","PLTC1","HAYI1","SDNA4","SYNO3","LPOW1","THDC1","TR077","OLSF1","WHSF1","WINM6","TURN7","LPSN6","LPRC2","ELKW4","TS312","LSFC1","MSCN5","SLTO3","WKFM4","BLGT2","CSVC1","ENTU1","HIBM5","QTWA3","OKPC1","SUAM8","PRDM8","DESN2","HOHU1","SEVN5","TAYN7","LGRW2","BNDC1","LTJC1","OKSC1","TR369","TS689","MEAM5","TR532","VLCC1","WSRM8","EMRC1","MMTC1","GSNM8","AGZM5","GMFN6","WTHS1","TRII1","TS642","GNLW1","TLGC1","ACRI1","DHOC2","KBFO3","BKSC1","GRAI1","HHRW4","LCBC1","LNCM8","MDDC1","PEFW1","VRNL1","MRFC2","BKIN7","UPTW2","SAWW4","CLFU1","CTGC1","DLVC1","SRXC1","SVFO3","TR257","JSPU1","NSWI4","LFSM5","MLCN5","BENL1","IMWN2","MCKU1","SLKO3","BCHN6","NNAG1","KIGM8","TS690","TS718","WEFI1","BRNW3","LAAW3","STOM4","WMGI2","RMFN7","SMTM8","HSEC1","TS428","CMFW1","BHRO3","PRMS2","WISC1","LOHF1","SPLS1","LDYW3","LOUG1","BNYN7","SEEM8","GBON7","LPIF1","HOAC1","MSRU1","TS713","EGKO3","PHGM8","SHFO3","TMPT2","BATN2","PCLC1","CMLG1","GMWP1","BMOC2","RCRO3","COAT2","ADFW1","CQFO3","DEDN2","EFFM5","IMTW1","QGDA3","WHHM8","MMRO3","BBEC1","FISN2","SPLW4","PCFT1","JPRC1","WALC1","QHUA3","SIGU1","BOGC1","BFSF1","WHIN7","CSPC1","FBGG1","BFRW2","LPZC1","CACM8","RSCN2","BCNC1","ENFO3","ENNM8","RVYC1","MOWC1","RTFO3","SBFN6","TS556","FORN1","LGLA1","DOEM4","REDD1","DJTC2","TS659","CADT2","QLKA3","AMDN8","SRTC1","PARN8","MVAN6","FLRW2","SHLA1","TISM6","ATSC1","TCAC1","BLRA4","QSTA3","RBYC1","SFKO3","NATL1","NBRC1","APLT2","QNRK1","WSBO3","CGLN7","CLNC1","CYNC2","SLFC1","RYDM4","BTTM5","GSFO3","BIVU1"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["SAO"]
            - variable: MetaData/stationIdentification
              is_in: ["WLV","WSF","WUY","WQQ","WGN","WWN","WWP","WUT","WSU","WNC","WMI"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["SFWMD"]
            - variable: MetaData/stationIdentification
              is_in: ["S331W","BELLW","S7WX","S61W","ROTNW","SGGEW","WRWX","BCSI","LXWS","S78W"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["UDFCD"]
            - variable: MetaData/stationIdentification
              is_in: ["SAPC2","EBBC2"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["UrbaNet"]
            - variable: MetaData/stationIdentification
              is_in: ["LEMNT","PSCBH","CNNMN","EVRGR","LSV02","LSCRS","RSWLL","ALSTN","NWOCH","DRPRK","HNTRY","HARHN","LSVJC","PTOMC","STHGT","LVEGS","LSVRB","RVDAL","TKMPR","GLFPC","DRCUT","ADK15","WDSTC","A0022","STHTN","DGLSV","AMBLR","BNDVL","CRSRS","RPVRD","EVERT","MLTNO","DPTFR","RVRIL","MNTPR","DSNTN","MNSFL","BRNK5","DOVR1","IRVIG","SEUNI","LTTFA","BRON1","LSVGR","HENDR","NORRI","NWYK1","MSPTH","LNGBH","LSVG3","PHLDP","CLFFS","GLASB","PHLJW","PHILD","ALIVE","SPRMG","NWLNX","EWPLE","RDGFL","ALCES","CHCSS","CPTHT","MDLNL","LVGGH","CASLM","MLNPK","BLLMW","PS002","BRBNK","SHRNS","GORMS","LASVU","WBZT2","MESQT","HSTAS","REVER","PNSHH","LVGME","ATFR7","LNSDW","NRIST","LXVGS","ISVGS","HSTDW","GRMRC","WSHMG","HAKSK","LVGST","CMCRD","SCCSC","FXBRG","METRE","WNTHR","GMBRD","BRKYL","SGRLN","DWEBB","HNSPT","WSTNX","CALLS","LNBTW","HNFRS","DESOT","CLYMN","STNMO","EHDRS","AGTON","CHHCG","BLCKD","PASNA","CRLNG","NOLSV","JNBRO","YSNGL","NW7DC","OWYRK","WASDC","ARDMR","JNSYC","REGWD","NYSTS","PHL01","SLVSP","BTNRB","BTKLY","LVSVS","BX368","WHWKN","CHRCM","PHLD9","CRNYS","HDSMA","HSTWH","CHHRS","HSTNO","LVGMR","LVNGN","RTWYN","LASVG","LSVGV","LRLNL","LSNGH","DLCMC","JSBRO","LSVG6","LSVSA","PTRSN","NYSTH","LSVGS","PHLRH","MNDRS","MLVRM","HLLSD","CDRGR","TTTLT","PEPCO","NHCHL","ERNKL","PHIL2","LAVSS","BRCKT","ELZBS","NYPSW","BRX34","HNDLH","BLRNG","WDRDG","DLLS3","PHLD5","LSVG2","LSFGS","IRVNG","FRKHS","GRMKM","WSTOP","LVMJC","CINNM","BRKLA","STTCD","CANTO","NETWN","PHLDM","HSTCH","CRLTX","FSTRV","PHILA","GPRIE","CMCFD","BMILR","LNDNB","LOXES","WSING","HDSST","ADK14","BRDFR","LSVHH","ASTON","CHSTU","HVAND","LSVHF","HSTNU","LINCO","IRVIN","PRTHM","CJHCG","BTHWJ","HVRTW","ORNGM","FSTPR","ASTLL","PICYN","MOKEN","NWTVN","ADKL4","FRTWS","LSVG8","PHLDB","CHSBC","MLBRO","WRMIN","WSTKR","NBERG","SLDCS","TWKSB","WMARB","UMBC1","NEADC","ANDGL","GERTN","PHLCS","BNSLM","MS133","LWLLB","STTNL","LSV01","PS36K","SCKLV","REVSE","RCKWY","PHLDL","LTVGS","LSVG7","CNTNM","LSVCM","QNSFP","CHNOK","DLC01","CARHS","PHLD7","NRLNG","BRKLN","TCMFP","AWTY1","MCDON","ALVRD","PHLNE","CMDNN","KNTWH","GRLNC","READG","HNKES","WASTO","MCKLT","PS102","LAKMD","WTVNJ","AHSTN","BFDHQ","WLMNI","ECLFS","BKLIN","PHLDN","BRNXA","PLSDS","LFVGS","LOXLY","JMCST","BSTON","BRKAM","HSTN8","LSVGA","BROKL","PHLD3","FRTWY","NRRST","PHLD8","BRCMC","STINY","BRNSR","BRYNM","BRWYN","BLCKW","FRTWH","LSNDP","PHLPA","JNKNT","WHTMN","AWSHQ","USSAL","CRRBF","LVGRC","NWYR2","CURIE","WLLNG","PHLDO","CSVGS","PHLDY","BRST1","BRKTN","BYSD1","WSHDD","BRLNG","CHGMT","BFD32","CHHOS","NTHLV","NLMSF","HSTPN","EGLVL","LSNGN","HSGHC","BROOY","ELZBJ","HUNTI","ASNNU","ASVGS","TRRNC","FSLSS","LMBRT","CHESA","MTLR3","STHBH","HCKHL","BRKN3","LWELL","JRSYE","STPNS","BKBHS","BTRGB","DRXHL","CMDNC","BDRCT","LSVSS","HSHCH","NANDV","CHICG","MRLTN","KNRTB","MSFLD","GRMNW","LSNVT","DLLSL","LSVCT","HUTON","OKELS"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["VADOT"]
            - variable: MetaData/stationIdentification
              is_in: ["VA006","VA013","VA017","VA029","VA016","VA041","VA022","VA019","VA003","VA011","VA031","VA026","VA004","VA023","VA015","VA021","VA032","VA027","VA040"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["VTDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["VT002","VT001"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["WIDOT"]
            - variable: MetaData/stationIdentification
              is_in: ["EKNW3","WAKW3","WI054","HAUW3","PAKW3","HSNW3","MNRW3"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["WXforYou"]
            - variable: MetaData/stationIdentification
              is_in: ["H0269","H0313","H0300","H0080","H0346","H0164","H0005","H0177","H0041","H0498","H0338","H0062","H0244","H0203","H0237","H0030","H0322","H0560","H0140","H0447"]
          - filter: AcceptList  # accept back selected stations
-           apply at iterations: 0,1
            where:
            - variable: MetaData/dataProviderOrigin
              is_in: ["WYDOT"]
@@ -10093,7 +9980,6 @@ cost function:
 
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -10107,7 +9993,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10118,7 +10003,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -10262,6 +10146,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -10356,7 +10241,7 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/msonet_geovals_rrfs.nc4
+         #  filename: ./data/geovals/msonet_geovals_rrfs.nc
      - obs space:
          name: proflr_uv227
          distribution:
@@ -10365,13 +10250,14 @@ cost function:
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_proflr.nc
+             obsfile: "data/obs/ioda_proflr.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_proflr_uv227.nc
@@ -10388,7 +10274,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/windprof_geoval_2024052700.nc4"
+           #  filename: "obsout/windprof_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -10402,7 +10288,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -10410,7 +10296,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -10424,7 +10309,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10435,7 +10319,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -10712,22 +10595,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/proflr_geovals_rrfs.nc4
+         #  filename: ./data/geovals/proflr_geovals_rrfs.nc
      - obs space:
          name: rassda_t126
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_rassda.nc
+             obsfile: "data/obs/ioda_rassda.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_rassda_t126.nc
@@ -10744,7 +10628,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/rass_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/rass_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -10757,15 +10641,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # airTemperature (126)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -10778,7 +10661,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -10789,7 +10671,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -10885,6 +10766,9 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
+           action:
+             name: reduce obs space
 
          # Bounds Check (ObsValue)
          - filter: Bounds Check
@@ -10985,12 +10869,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/rassda_geovals_rrfs.nc4
+         #  filename: ./data/geovals/rassda_geovals_rrfs.nc
      - obs space:
          name: sfcshp_t180
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -11001,6 +10885,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t180.nc
@@ -11017,7 +10902,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -11030,7 +10915,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -11038,7 +10923,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: airTemperature
            where:
@@ -11051,7 +10935,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11062,7 +10945,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -11158,6 +11040,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -11260,12 +11143,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_t182
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -11276,6 +11159,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t182.nc
@@ -11292,7 +11176,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -11305,15 +11189,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # airTemperature (182)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -11326,7 +11209,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11337,7 +11219,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -11433,6 +11314,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -11535,12 +11417,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_t183
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -11552,6 +11434,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_t183.nc
@@ -11568,7 +11451,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: airTemperature
@@ -11581,15 +11464,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # airTemperature (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: airTemperature
            where:
@@ -11602,7 +11484,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11613,7 +11494,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: airTemperature
 #           min_spacing: PT90M
@@ -11709,6 +11589,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/airTemperature
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -11811,12 +11692,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_q180
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -11827,6 +11708,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q180.nc
@@ -11843,7 +11725,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -11856,7 +11738,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -11864,7 +11746,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: specificHumidity
            where:
@@ -11877,7 +11758,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -11888,7 +11768,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -11939,7 +11818,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -11985,6 +11863,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12087,12 +11966,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_q182
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -12103,6 +11982,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q182.nc
@@ -12119,7 +11999,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -12132,15 +12012,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # specificHumidity (182)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: specificHumidity
            where:
@@ -12153,7 +12032,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12164,7 +12042,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -12215,7 +12092,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -12261,6 +12137,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12363,12 +12240,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_q183
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -12380,6 +12257,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_q183.nc
@@ -12396,7 +12274,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: specificHumidity
@@ -12409,15 +12287,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # specificHumidity (183)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: specificHumidity
            where:
@@ -12430,7 +12307,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12441,7 +12317,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: specificHumidity
 #           min_spacing: PT90M
@@ -12492,7 +12367,6 @@ cost function:
                options:
                  variable: specificHumidity
                  inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: false
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -12538,6 +12412,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/specificHumidity
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12640,12 +12515,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_ps180
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -12656,6 +12531,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_ps180.nc
@@ -12678,7 +12554,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -12686,7 +12562,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: stationPressure
            where:
@@ -12699,7 +12574,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12710,7 +12584,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: stationPressure
 #           min_spacing: PT90M
@@ -12815,6 +12688,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -12917,12 +12791,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_uv280
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -12933,6 +12807,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv280.nc
@@ -12944,15 +12819,12 @@ cost function:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -12966,7 +12838,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -12974,7 +12846,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -12988,7 +12859,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -12999,11 +12869,10 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -13046,8 +12915,6 @@ cost function:
            where:
            - variable: ObsType/windEastward
              is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_not_in: 522, 523, 531
            action:
              name: inflate error
              inflation variable:
@@ -13066,8 +12933,6 @@ cost function:
            where:
            - variable: ObsType/windNorthward
              is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_not_in: 522, 523, 531
            action:
              name: inflate error
              inflation variable:
@@ -13078,46 +12943,6 @@ cost function:
                  SetSfcWndObsHeight: true
                  AddObsHeightToStationElevation: true
                  AssumedSfcWndObsHeight: 10
-
-#         # Error inflation (windEastward) based on pressure check (setupw.f90)
-#         - filter: Perform Action
-#           filter variables:
-#           - name: windEastward
-#           where:
-#           - variable: ObsType/windEastward
-#             is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_in: 522, 523, 531
-#           action:
-#             name: inflate error
-#             inflation variable:
-#               name: ObsFunction/ObsErrorFactorPressureCheck
-#               options:
-#                 variable: windEastward
-#                 inflation factor: 4.0
-#                 SetSfcWndObsHeight: true
-#                 AddObsHeightToStationElevation: false
-#                 AssumedSfcWndObsHeight: 20
-
-#         # Error inflation (windNorthward) based on pressure check (setupw.f90)
-#         - filter: Perform Action
-#           filter variables:
-#           - name: windNorthward
-#           where:
-#           - variable: ObsType/windNorthward
-#             is_in: 280
-#           - variable: MetaData/dumpReportType # variable not in GSI-IODA
-#             is_in: 522, 523, 531
-#           action:
-#             name: inflate error
-#             inflation variable:
-#               name: ObsFunction/ObsErrorFactorPressureCheck
-#               options:
-#                 variable: windNorthward
-#                 inflation factor: 4.0
-#                 SetSfcWndObsHeight: true
-#                 AddObsHeightToStationElevation: false
-#                 AssumedSfcWndObsHeight: 20
 
 #         # Error inflation (windEastward) based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -13187,6 +13012,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -13281,12 +13107,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_uv282
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -13297,6 +13123,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv282.nc
@@ -13308,15 +13135,12 @@ cost function:
 
        obs operator:
            name: VertInterp
-           hofx_scaling: true
-           hofx scaling field: wind_reduction_factor_at_10m
-           hofx scaling field group: GeoVaLs
            vertical coordinate: air_pressure
            observation vertical coordinate: pressure
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -13330,15 +13154,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # wind (282)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -13352,7 +13175,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -13363,11 +13185,10 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -13507,6 +13328,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -13601,12 +13423,12 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: sfcshp_uv284
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
@@ -13618,6 +13440,7 @@ cost function:
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_uv284.nc
@@ -13634,7 +13457,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -13648,15 +13471,14 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
          # wind (284)
          # ------------------
          # Reject all obs with QualityMarker > 3
-         - filter: Perform Action
-           apply at iterations: 0,1
+         - filter: RejectList
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -13670,7 +13492,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -13681,11 +13502,10 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
-#           min_spacing: PT60M
+#           min_spacing: PT90M
 #           tolerance: PT0H
 #           seed_time: "@analysisDate@"
 #           category_variable:
@@ -13825,6 +13645,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
            action:
              name: reduce obs space
 
@@ -13919,22 +13740,23 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc
      - obs space:
          name: vadwnd_uv224
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_vadwnd.nc
+             obsfile: "data/obs/ioda_vadwnd.nc"
              missing file action: "warn"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_vadwnd_uv224.nc
@@ -13951,7 +13773,7 @@ cost function:
            observation vertical coordinate group: MetaData
            interpolation method: log-linear
            #gsi geovals:
-           #  filename: "obsout/vadwind_geoval_2024052700.nc4"
+           #  filename: "obsout/vadwind_geoval_2024052700.nc"
            #  levels_are_top_down: False
            variables:
            - name: windEastward
@@ -13965,7 +13787,7 @@ cost function:
 
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs filters:
          # ------------------
@@ -13973,7 +13795,6 @@ cost function:
          # ------------------
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
-           apply at iterations: 0,1
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -13987,7 +13808,6 @@ cost function:
 
          # Time window filter
          - filter: Domain Check
-           apply at iterations: 0,1
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
@@ -13998,7 +13818,6 @@ cost function:
 
          # Duplicate Check
 #         - filter: Temporal Thinning
-#           apply at iterations: 0,1
 #           filter variables:
 #           - name: windEastward
 #           - name: windNorthward
@@ -14136,6 +13955,7 @@ cost function:
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
+           maxvalue: 1000
 
          # Bounds Check (ObsValue)
          - filter: Bounds Check
@@ -14282,29 +14102,38 @@ cost function:
            defer to post: true
 
          #- filter: GOMsaver
-         #  filename: ./data/geovals/vadwnd_geovals_rrfs.nc4
+         #  filename: ./data/geovals/vadwnd_geovals_rrfs.nc
      - obs space:
          name: amsua_n19
+         _anchor_channels: &amsua_n19_channels 1-15
+         _anchor_use_flag: &amsua_n19_use_flag [ 1,  1,  1,  1,  1, 1, -1, -1,  1,  1, -1,  -1,  -1,  1,  1 ]
+         _anchor_error: &amsua_n19_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
+         _anchor_obserr_bound_max: &amsua_n19_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_amsua_n19.nc
+             obsfile: "data/obs/ioda_amsua_n19.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_amsua_n19.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &amsua_n19_channels 1-15
+         channels: *amsua_n19_channels
        obs operator:
          name: CRTM
-         Absorbers: [H2O,O3]
+         Absorbers: [H2O,O3,CO2]
          SurfaceWindGeoVars: uv
          Clouds: [Water, Ice]
+         Cloud_Seeding: true
          Cloud_Fraction: 1.0
          obs options:
            Sensor_ID: amsua_n19
@@ -14315,7 +14144,7 @@ cost function:
            Absorbers: [H2O, O3]
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
        obs bias:
          input file: data/satbias_in/amsua_n19.satbias.nc
          output file: data/satbias_out/amsua_n19.satbias.nc
@@ -14346,7 +14175,31 @@ cost function:
                ratio: 1.1
                ratio for small dataset: 2.0
            output file: data/satbias_out/amsua_n19.satbias_cov.nc
-       obs filters:
+       obs pre filters:
+       # Regional domain check to remove data outside of model domain
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_n19_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+        #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_n19_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *amsua_n19_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
        - filter: BlackList
          filter variables:
          - name: brightnessTemperature
@@ -14414,9 +14267,7 @@ cost function:
            channels: *amsua_n19_channels
            options:
              channels: *amsua_n19_channels
-             obserr_clearsky: [ 2.500, 2.200, 2.000, 0.550, 0.300,
-                                0.230, 0.230, 0.250, 0.250, 0.350,
-                                0.400, 0.550, 0.800, 3.000, 3.500]
+             obserr_clearsky: *amsua_n19_error
              clwret_function:
                name: ObsFunction/CLWRetMW
                options:
@@ -14568,9 +14419,7 @@ cost function:
                    err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                             0.300,  0.230,  0.250,  0.250,  0.350,
                             0.400,  0.550,  0.800,  3.000, 18.000]
-               obserr_clearsky: [2.500, 2.200, 2.000, 0.550, 0.300,
-                                  0.230, 0.230, 0.250, 0.250, 0.350,
-                                  0.400, 0.550, 0.800, 3.000, 3.500]
+               obserr_clearsky: *amsua_n19_error
        #  Gross check
        - filter: Background Check
          filter variables:
@@ -14621,9 +14470,7 @@ cost function:
                  err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                           0.300,  0.230,  0.250,  0.250,  0.350,
                           0.400,  0.550,  0.800,  3.000, 18.000]
-             obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
-                                2.0, 2.0, 2.0, 2.0, 2.0,
-                                2.5, 3.5, 4.5, 4.5, 4.5]
+             obserr_bound_max: *amsua_n19_obserr_bound_max
          action:
            name: reject
        #  Inter-channel check
@@ -14637,9 +14484,7 @@ cost function:
            options:
              channels: *amsua_n19_channels
              sensor: amsua_n19
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1, -1, -1,  1,  1,
-                         1,  1,  1, -1,  1 ]
+             use_flag: *amsua_n19_use_flag
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -14654,29 +14499,47 @@ cost function:
            options:
              sensor: amsua_n19
              channels: *amsua_n19_channels
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1, -1, -1,  1,  1,
-                         1,  1,  1, -1,  1 ]
+             use_flag: *amsua_n19_use_flag
          minvalue: 1.0e-12
          action:
            name: reject
      - obs space:
-         name: amsua_n20
+         name: atms_n20
+         _anchor_channels: &atms_n20_channels 1-22
+         _anchor_use_flag: &atms_n20_use_flag
+             [ 1,  1,  1,  1,  1,
+               1,  1,  1,  1,  1,
+               1,  1,  1, -1, -1,
+               1,  1,  1,  1,  1,
+               1,  1]
+         _anchor_error: &atms_n20_error [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000]
+         _anchor_obserr_bound_max: &atms_n20_obserr_bound_max
+             [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_amsua_n20.nc
+             obsfile: "data/obs/ioda_atms_n20.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
-             obsfile: jdiag_amsua_n20.nc
+             obsfile: jdiag_atms_n20.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &amsua_n20_channels 1-22
+         channels: *atms_n20_channels
        obs operator:
            name: CRTM
            Absorbers: [H2O,O3,CO2]
@@ -14685,7 +14548,7 @@ cost function:
            Cloud_Seeding: true
            SurfaceWindGeoVars: uv
            obs options:
-             Sensor_ID: amsua_n20
+             Sensor_ID: atms_n20
              EndianType: little_endian
              CoefficientPath: data/crtm/
              IRVISlandCoeff: IGBP
@@ -14693,18 +14556,18 @@ cost function:
              Absorbers: [H2O, O3]
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
        obs bias:
-         input file:  data/satbias_in/amsua_n20.satbias.nc
-         output file: data/satbias_out/amsua_n20.satbias.nc
+         input file:  data/satbias_in/atms_n20.satbias.nc
+         output file: data/satbias_out/atms_n20.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &amsua_n20_tlapse  data/satbias_in/amsua_n20.tlapse.txt
+             tlapse: &atms_n20_tlapse  data/satbias_in/atms_n20.tlapse.txt
            - name: lapseRate
-             tlapse: *amsua_n20_tlapse
+             tlapse: *atms_n20_tlapse
            - name: emissivityJacobian
            - name: sensorScanAngle
              order: 4
@@ -14719,58 +14582,13 @@ cost function:
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/satbias_in/amsua_n20.satbias_cov.nc
+             input file: data/satbias_in/atms_n20.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: data/satbias_out/amsua_n20.satbias_cov.nc
+           output file: data/satbias_out/atms_n20.satbias_cov.nc
 
        obs pre filters:
-       # Step 0-A: Create Diagnostic Flags
-       - filter: Create Diagnostic Flags
-         filter variables:
-         - name: brightnessTemperature
-           channels: *amsua_n20_channels
-         flags:
-         - name: ScanEdgeRemoval
-           initial value: false
-           force reinitialization: false
-         - name: Thinning
-           initial value: false
-           force reinitialization: false
-         - name: CLWRetrievalCheck
-           initial value: false
-           force reinitialization: false
-         - name: WindowChannelExtremeResidual
-           initial value: false
-           force reinitialization: false
-         - name: HydrometeorCheck
-           initial value: false
-           force reinitialization: false
-         - name: GrossCheck
-           initial value: false
-           force reinitialization: false
-         - name: InterChannelConsistency
-           initial value: false
-           force reinitialization: false
-         - name: UseflagCheck
-           initial value: false
-           force reinitialization: false
-
-       obs post filters:
-       # Step 0-B: Calculate derived variables
-       # Calculate CLW retrieved from observation
-       - filter: Variable Assignment
-         assignments:
-         - name: CLWRetFromObs@DerivedMetaData
-           type: float
-           function:
-             name: CLWRetMW@ObsFunction
-             options:
-               clwret_ch238: 1
-               clwret_ch314: 2
-               clwret_types: [ObsValue]
-
        # Calculate CLW retrieved from observation
        - filter: Variable Assignment
          assignments:
@@ -14829,13 +14647,13 @@ cost function:
        - filter: Variable Assignment
          assignments:
          - name: CLWMatchIndex@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: CLWMatchIndexMW@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
+               channels: *atms_n20_channels
                clwobs_function:
                  name: CLWRetFromObs@DerivedMetaData
                clwbkg_function:
@@ -14850,13 +14668,13 @@ cost function:
        - filter: Variable Assignment
          assignments:
          - name: InitialObsError@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorModelRamp@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
+               channels: *atms_n20_channels
                xvar:
                  name: CLWRetSymmetric@DerivedMetaData
                x0:    [ 0.030,  0.030,  0.030,  0.020,  0.030,
@@ -14884,26 +14702,31 @@ cost function:
        - filter: Variable Assignment
          assignments:
          - name: Innovation@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsFunction/Arithmetic
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
                variables:
                - name: brightnessTemperature@ObsValue
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                - name: brightnessTemperature@HofX
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+        # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
-           channels: *amsua_n20_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         - name: brightnessTemperature
+           channels: *atms_n20_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_n20_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -14911,7 +14734,7 @@ cost function:
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: GeoVaLs/observable_domain_mask
            flag all filter variables if any test variable is out of bounds: true
@@ -14922,12 +14745,12 @@ cost function:
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: assign error
            error function:
              name: InitialObsError@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 1: Remove Observations from the Edge of the Scan
        - filter: Domain Check
@@ -15002,31 +14825,27 @@ cost function:
        - filter: Variable Assignment
          assignments:
          - name: DerivedMetaData/HydrometeorCheckATMS
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: HydrometeorCheckATMS@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               channels: *atms_n20_channels
+               obserr_clearsky: *atms_n20_error
                clwret_function:
                  name: CLWRetFromObs@DerivedMetaData
                obserr_function:
                  name: InitialObsError@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
 
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: DerivedMetaData/HydrometeorCheckATMS
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          maxvalue: 0.0
          actions:
            - name: set
@@ -15038,84 +14857,84 @@ cost function:
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorTopo@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorTopoRad@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorTopo@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 7: Obs Error Inflation based on TOA Transmittancec Check
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorTransmitTop@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorTransmitTopRad@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               channels: *amsua_n20_channels
+               channels: *atms_n20_channels
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorTransmitTop@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 8: Observation Error Inflation based on Surface Jacobian Check
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorSurfJacobian@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorSurfJacobianRad@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
                obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
                obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorSurfJacobian@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 9: Situation Dependent Check
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorFactorSituDepend@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorFactorSituDependMW@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
                clwbkg_function:
                  name: CLWRetFromBkg@DerivedMetaData
                clwobs_function:
@@ -15124,25 +14943,21 @@ cost function:
                  name: SIRetFromObs@DerivedMetaData
                clwmatchidx_function:
                  name: CLWMatchIndex@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                obserr_function:
                  name: InitialObsError@DerivedMetaData
-                 channels: *amsua_n20_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+                 channels: *atms_n20_channels
+               obserr_clearsky: *atms_n20_error
 
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          action:
            name: inflate error
            inflation variable:
              name: ObsErrorFactorSituDepend@DerivedMetaData
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
 
        # Step 10: Gross check
        # Remove data if abs(Obs-HofX) > absolute threhold
@@ -15158,41 +14973,37 @@ cost function:
        - filter: Variable Assignment
          assignments:
          - name: ObsErrorBound@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            type: float
            function:
              name: ObsErrorBoundMW@ObsFunction
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              options:
-               sensor: amsua_n20
-               channels: *amsua_n20_channels
+               sensor: atms_n20
+               channels: *atms_n20_channels
                obserr_bound_latitude:
                  name: ObsErrorFactorLat@DerivedMetaData
                obserr_bound_transmittop:
                  name: ObsErrorFactorTransmitTop@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                  options:
-                   channels: *amsua_n20_channels
+                   channels: *atms_n20_channels
                obserr_bound_topo:
                  name: ObsErrorFactorTopo@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                obserr_function:
                  name: InitialObsError@DerivedMetaData
-                 channels: *amsua_n20_channels
+                 channels: *atms_n20_channels
                  threhold: 3
-               obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
-                                  1.0, 1.0, 1.0, 1.0, 1.0,
-                                  1.0, 1.0, 1.0, 2.0, 4.5,
-                                  4.5, 2.0, 2.0, 2.0, 2.0,
-                                  2.0, 2.0]
+               obserr_bound_max: *atms_n20_obserr_bound_max
 
        - filter: Background Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          function absolute threshold:
          - name: ObsErrorBound@DerivedMetaData
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          actions:
            - name: set
              flag: GrossCheck
@@ -15203,19 +15014,15 @@ cost function:
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: InterChannelConsistencyCheck@ObsFunction
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            options:
-             channels: *amsua_n20_channels
+             channels: *atms_n20_channels
              use passive_bc: true
-             sensor: amsua_n20
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
+             sensor: atms_n20
+             use_flag: *atms_n20_use_flag
          maxvalue: 1.0e-12
          actions:
            - name: set
@@ -15227,17 +15034,13 @@ cost function:
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
          test variables:
          - name: ObsFunction/ChannelUseflagCheckRad
-           channels: *amsua_n20_channels
+           channels: *atms_n20_channels
            options:
-             channels: *amsua_n20_channels
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
+             channels: *atms_n20_channels
+             use_flag: *atms_n20_use_flag
          minvalue: 1.0e-12
          actions:
            - name: set
@@ -15246,21 +15049,41 @@ cost function:
            - name: reject
      - obs space:
          name: atms_npp
+         _anchor_channels: &atms_npp_channels 1-22
+         _anchor_use_flag: &atms_npp_use_flag
+             [ 1,  1,  1,  1,  1,
+               1,  1,  1,  1,  1,
+               1,  1,  1, -1, -1,
+               1,  1,  1,  1,  1,
+               1,  1]
+         _anchor_error: &atms_npp_error [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000]
+         _anchor_obserr_bound_max: &atms_npp_obserr_bound_max
+             [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_atms_npp.nc
+             obsfile: "data/obs/ioda_atms_npp.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_atms_npp.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &atms_npp_channels 1-22
+         channels: *atms_npp_channels
        obs operator:
            name: CRTM
            Absorbers: [H2O,O3,CO2]
@@ -15277,7 +15100,7 @@ cost function:
              Absorbers: [H2O, O3]
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
        obs bias:
          input file:  data/satbias_in/atms_npp.satbias.nc
@@ -15311,51 +15134,6 @@ cost function:
            output file: data/satbias_out/atms_npp.satbias_cov.nc
 
        obs pre filters:
-       # Step 0-A: Create Diagnostic Flags
-       - filter: Create Diagnostic Flags
-         filter variables:
-         - name: brightnessTemperature
-           channels: *atms_npp_channels
-         flags:
-         - name: ScanEdgeRemoval
-           initial value: false
-           force reinitialization: false
-         - name: Thinning
-           initial value: false
-           force reinitialization: false
-         - name: CLWRetrievalCheck
-           initial value: false
-           force reinitialization: false
-         - name: WindowChannelExtremeResidual
-           initial value: false
-           force reinitialization: false
-         - name: HydrometeorCheck
-           initial value: false
-           force reinitialization: false
-         - name: GrossCheck
-           initial value: false
-           force reinitialization: false
-         - name: InterChannelConsistency
-           initial value: false
-           force reinitialization: false
-         - name: UseflagCheck
-           initial value: false
-           force reinitialization: false
-
-       obs post filters:
-       # Step 0-B: Calculate derived variables
-       # Calculate CLW retrieved from observation
-       - filter: Variable Assignment
-         assignments:
-         - name: CLWRetFromObs@DerivedMetaData
-           type: float
-           function:
-             name: CLWRetMW@ObsFunction
-             options:
-               clwret_ch238: 1
-               clwret_ch314: 2
-               clwret_types: [ObsValue]
-
        # Calculate CLW retrieved from observation
        - filter: Variable Assignment
          assignments:
@@ -15482,13 +15260,18 @@ cost function:
                  channels: *atms_npp_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+       # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
+         - name: brightnessTemperature
            channels: *atms_npp_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_npp_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -15594,11 +15377,7 @@ cost function:
              channels: *atms_npp_channels
              options:
                channels: *atms_npp_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_npp_error
                clwret_function:
                  name: CLWRetFromObs@DerivedMetaData
                obserr_function:
@@ -15713,11 +15492,7 @@ cost function:
                obserr_function:
                  name: InitialObsError@DerivedMetaData
                  channels: *atms_npp_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_npp_error
 
        - filter: Perform Action
          filter variables:
@@ -15765,11 +15540,7 @@ cost function:
                  name: InitialObsError@DerivedMetaData
                  channels: *atms_npp_channels
                  threhold: 3
-               obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
-                                  1.0, 1.0, 1.0, 1.0, 1.0,
-                                  1.0, 1.0, 1.0, 2.0, 4.5,
-                                  4.5, 2.0, 2.0, 2.0, 2.0,
-                                  2.0, 2.0]
+               obserr_bound_max: *atms_npp_obserr_bound_max
 
        - filter: Background Check
          filter variables:
@@ -15796,12 +15567,7 @@ cost function:
              channels: *atms_npp_channels
              use passive_bc: true
              sensor: atms_npp
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
-         maxvalue: 1.0e-12
+             use_flag: *atms_npp_use_flag
          actions:
            - name: set
              flag: InterChannelConsistency
@@ -15818,11 +15584,7 @@ cost function:
            channels: *atms_npp_channels
            options:
              channels: *atms_npp_channels
-             use_flag: [ 1,  1,  1,  1,  1,
-                         1,  1,  1,  1,  1,
-                         1,  1,  1, -1, -1,
-                         1,  1,  1,  1,  1,
-                         1,  1]
+             use_flag: *atms_npp_use_flag
          minvalue: 1.0e-12
          actions:
            - name: set
@@ -15833,15 +15595,21 @@ cost function:
   # -----------------------
      - obs space:
          name: abi_g16
+         _anchor_channels: &abi_g16_channels 7-16
+         _anchor_use_flag: &abi_g16_use_flag [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+         _anchor_use_flag_clddet: &abi_g16_use_flag_clddet [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+         _anchor_error: &abi_g16_error [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+         _anchor_obserr_bound_max: &abi_g16_obserr_bound_max [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_abi_g16.nc
+             obsfile: "data/obs/ioda_abi_g16.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_abi_g16.nc
@@ -15849,7 +15617,7 @@ cost function:
            max pool size: 1
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &abi_g16_channels 7-16
+         channels: *abi_g16_channels
 
   # Observation Operator
   # --------------------
@@ -15868,7 +15636,8 @@ cost function:
            Absorbers: [H2O, O3]
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
+
   # Observation Bias Correction (VarBC)
   # -----------------------------------
        obs bias:
@@ -15908,6 +15677,35 @@ cost function:
 
   # Observation Filters (QC)
   # ------------------------
+       obs pre filters:
+       # from read_abi: Reject when cloud fraction is more than 30
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         where:
+         - variable:
+             name: MetaData/cloudAmount
+             channels: 8
+           maxvalue: 30.
+         action:
+           name: reduce obs space
+
+       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         where:
+         - variable:
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8-10
+           maxvalue: 1.3
+           max_exclusive: true
+         action:
+           name: reduce obs space
+
+
        obs prior filters:
        # Initial obs error assignment
        - filter: Perform Action
@@ -15916,7 +15714,7 @@ cost function:
            channels: *abi_g16_channels
          action:
            name: assign error
-           error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+           error parameter vector: *abi_g16_error
 
        # Surface flag assignment from geoval
        - filter: Variable Assignment
@@ -15982,33 +15780,6 @@ cost function:
                    minvalue: 0.99
                  value: 15
 
-       # Criteria assignment for Thinning
-       - filter: Variable Assignment
-         assignments:
-         - name: DerivedMetaData/thinningCriteria
-           type: int
-           function:
-             name: IntObsFunction/Arithmetic
-             options:
-               variables:
-               - name: DerivedMetaData/surfaceParam
-               coefs: [1]
-
-       # Thinning
-       - filter: Gaussian Thinning
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         horizontal_mesh: 60
-         use_reduced_horizontal_grid: true
-         distance_norm: maximum
-         time_mesh: 'PT06H'
-         time_min: '2024-05-26T22:30:00Z'
-         time_max: '2024-05-27T01:30:00Z'
-         priority_variable: DerivedMetaData/thinningCriteria
-         action:
-           name: reject
-
        obs post filters:
        # Regional domain check to remove data outside of model domain
        - filter: Bounds Check
@@ -16021,42 +15792,23 @@ cost function:
            minvalue: 0.0
            maxvalue: 0.5
 
-       # Satellite Zenith Angle Check
-       - filter: Bounds Check
+       #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g16_channels
-         test variables:
-         - name: MetaData/sensorZenithAngle
-         maxvalue: 65.
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *abi_g16_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
-       # from read_abi: Reject when cloud fraction is more than 30
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         where:
-         - variable:
-             name: MetaData/cloudAmount
-             channels: 8
-           maxvalue: 30.
-
-       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         where:
-         - variable:
-             name: ClearSkyStdDev/brightnessTemperature
-             channels: 8-10
-           maxvalue: 1.3
-           max_exclusive: true
-
        # Surface type check
-       # Toss channels 7, 11-16 over land
+       # Toss channels 7,11-16 over land
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -16142,10 +15894,10 @@ cost function:
            channels: *abi_g16_channels
            options:
              channels: *abi_g16_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
-             use_flag_clddet: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+             use_flag: *abi_g16_use_flag
+             use_flag_clddet: *abi_g16_use_flag_clddet
              obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             error parameter vector: *abi_g16_error
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16230,7 +15982,7 @@ cost function:
            channels: *abi_g16_channels
            options:
              channels: *abi_g16_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+             use_flag: *abi_g16_use_flag
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16316,23 +16068,29 @@ cost function:
                channels: *abi_g16_channels
                options:
                  channels: *abi_g16_channels
-             obserr_bound_max: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             obserr_bound_max: *abi_g16_obserr_bound_max
+             error parameter vector: *abi_g16_error
          action:
            name: reject
   # Observation Space (I/O)
   # -----------------------
      - obs space:
          name: abi_g18
+         _anchor_channels: &abi_g18_channels 7-16
+         _anchor_use_flag: &abi_g18_use_flag [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+         _anchor_use_flag_clddet: &abi_g18_use_flag_clddet [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+         _anchor_error: &abi_g18_error [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+         _anchor_obserr_bound_max: &abi_g18_obserr_bound_max [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
          distribution:
            name: "RoundRobin"
-           halo size: 300e3
+           halo size: 500e3
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_abi_g18.nc
+             obsfile: "data/obs/ioda_abi_g18.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_abi_g18.nc
@@ -16340,7 +16098,7 @@ cost function:
            max pool size: 1
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
-         channels: &abi_g18_channels 7-16
+         channels: *abi_g18_channels
 
   # Observation Operator
   # --------------------
@@ -16359,7 +16117,7 @@ cost function:
            Absorbers: [H2O, O3]
        obs localizations:
          - localization method: Horizontal Gaspari-Cohn
-           lengthscale: 300e3 # orig
+           lengthscale: 200e3 # orig
 
   # Observation Bias Correction (VarBC)
   # -----------------------------------
@@ -16400,6 +16158,34 @@ cost function:
 
   # Observation Filters (QC)
   # ------------------------
+       obs pre filters:
+       # from read_abi: Reject when cloud fraction is more than 30
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         where:
+         - variable:
+             name: MetaData/cloudAmount
+             channels: 8
+           maxvalue: 30.
+         action:
+           name: reduce obs space
+
+       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         where:
+         - variable:
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8-10
+           maxvalue: 1.3
+           max_exclusive: true
+         action:
+           name: reduce obs space
+
        obs prior filters:
        # Initial obs error assignment
        - filter: Perform Action
@@ -16408,7 +16194,7 @@ cost function:
            channels: *abi_g18_channels
          action:
            name: assign error
-           error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+           error parameter vector: *abi_g18_error
 
        # Surface flag assignment from geoval
        - filter: Variable Assignment
@@ -16474,33 +16260,6 @@ cost function:
                    minvalue: 0.99
                  value: 15
 
-       # Criteria assignment for Thinning
-       - filter: Variable Assignment
-         assignments:
-         - name: DerivedMetaData/thinningCriteria
-           type: int
-           function:
-             name: IntObsFunction/Arithmetic
-             options:
-               variables:
-               - name: DerivedMetaData/surfaceParam
-               coefs: [1]
-
-       # Thinning
-       - filter: Gaussian Thinning
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         horizontal_mesh: 60
-         use_reduced_horizontal_grid: true
-         distance_norm: maximum
-         time_mesh: 'PT06H'
-         time_min: '2024-05-26T22:30:00Z'
-         time_max: '2024-05-27T01:30:00Z'
-         priority_variable: DerivedMetaData/thinningCriteria
-         action:
-           name: reject
-
        obs post filters:
        # Regional domain check to remove data outside of model domain
        - filter: Bounds Check
@@ -16513,39 +16272,20 @@ cost function:
            minvalue: 0.0
            maxvalue: 0.5
 
-       # Satellite Zenith Angle Check
-       - filter: Bounds Check
+       # Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g18_channels
-         test variables:
-         - name: MetaData/sensorZenithAngle
-         maxvalue: 65.
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *abi_g18_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
-
-       # from read_abi: Reject when cloud fraction is more than 30
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         where:
-         - variable:
-             name: MetaData/cloudAmount
-             channels: 8
-           maxvalue: 30.
-
-       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         where:
-         - variable:
-             name: ClearSkyStdDev/brightnessTemperature
-             channels: 8-10
-           maxvalue: 1.3
-           max_exclusive: true
 
        # Surface type check
        # Toss channels 7,11-16 over land
@@ -16634,10 +16374,10 @@ cost function:
            channels: *abi_g18_channels
            options:
              channels: *abi_g18_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
-             use_flag_clddet: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+             use_flag: *abi_g18_use_flag
+             use_flag_clddet: *abi_g18_use_flag_clddet
              obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             error parameter vector: *abi_g18_error
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16722,7 +16462,7 @@ cost function:
            channels: *abi_g18_channels
            options:
              channels: *abi_g18_channels
-             use_flag: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+             use_flag: *abi_g18_use_flag
          maxvalue: 1.0e-12
          action:
            name: reject
@@ -16776,6 +16516,7 @@ cost function:
                  channels: 14
                coefs: [1, -1, 1, -1, 1, -1]
 
+       # Use split window chns to remove opaque clouds
        # Toss Channels 7, 10-16, when OmFNBC < -0.75
        - filter: Domain Check
          filter variables:
@@ -16807,7 +16548,1354 @@ cost function:
                channels: *abi_g18_channels
                options:
                  channels: *abi_g18_channels
-             obserr_bound_max: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
-             error parameter vector: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+             obserr_bound_max: *abi_g18_obserr_bound_max
+             error parameter vector: *abi_g18_error
+         action:
+           name: reject
+     - obs space:
+         name: atms_n21
+         _anchor_channels: &atms_n21_channels 1-22
+         _anchor_use_flag: &atms_n21_use_flag
+             [ 1,  1,  1,  1,  1,
+               1,  1,  1,  1,  1,
+               1,  1,  1, -1, -1,
+               1,  1,  1,  1,  1,
+               1,  1]
+         _anchor_obserr_bound_max: &atms_n21_obserr_bound_max
+             [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
+         _anchor_error: &atms_n21_error
+             [ 4.500,  4.500,  4.500,  2.500,  0.550,
+               0.300,  0.300,  0.400,  0.400,  0.400,
+               0.450,  0.450,  0.550,  0.800,  4.000,
+               4.000,  4.000,  3.500,  3.000,  3.000,
+               3.000,  3.000]
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_atms_n21.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "skip output"
+           engine:
+             type: H5File
+             obsfile: jdiag_atms_n21.nc
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: *atms_n21_channels
+       obs operator:
+           name: CRTM
+           Absorbers: [H2O,O3,CO2]
+           Clouds: [Water, Ice]
+           Cloud_Fraction: 1.0
+           Cloud_Seeding: true
+           SurfaceWindGeoVars: uv
+           obs options:
+             Sensor_ID: atms_n21
+             EndianType: little_endian
+             CoefficientPath: data/crtm/
+             IRVISlandCoeff: IGBP
+           linear obs operator:
+             Absorbers: [H2O, O3]
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
+       obs bias:
+         input file:  data/satbias_in/atms_n21.satbias.nc
+         output file: data/satbias_out/atms_n21.satbias.nc
+         variational bc:
+           predictors:
+           - name: constant
+           - name: lapseRate
+             order: 2
+             tlapse: &atms_n21_tlapse  data/satbias_in/atms_n21.tlapse.txt
+           - name: lapseRate
+             tlapse: *atms_n21_tlapse
+           - name: emissivityJacobian
+           - name: sensorScanAngle
+             order: 4
+           - name: sensorScanAngle
+             order: 3
+           - name: sensorScanAngle
+             order: 2
+           - name: sensorScanAngle
+         covariance:
+           minimal required obs number: 20
+           variance range: [1.0e-6, 10.0]
+           step size: 1.0e-4
+           largest analysis variance: 10000.0
+           prior:
+             input file: data/satbias_in/atms_n21.satbias_cov.nc
+             inflation:
+               ratio: 1.1
+               ratio for small dataset: 2.0
+           output file: data/satbias_out/atms_n21.satbias_cov.nc
+
+       obs pre filters:
+       # Calculate CLW retrieved from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetFromBkg@DerivedMetaData
+           type: float
+           function:
+             name: CLWRetMW@ObsFunction
+             options:
+               clwret_ch238: 1
+               clwret_ch314: 2
+               clwret_types: [HofX]
+
+       # Calculate symmetric retrieved CLW
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetSymmetric@DerivedMetaData
+           type: float
+           value: 1000.0
+
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: CLWRetFromObs@DerivedMetaData
+           minvalue:   0.
+           maxvalue: 999.
+         - variable:
+             name: CLWRetFromBkg@DerivedMetaData
+           minvalue:   0.
+           maxvalue: 999.
+         where operator: and
+         assignments:
+         - name: CLWRetSymmetric@DerivedMetaData
+           type: float
+           function:
+             name: Arithmetic@ObsFunction
+             options:
+               variables:
+               - name: CLWRetFromObs@DerivedMetaData
+               - name: CLWRetFromBkg@DerivedMetaData
+               total coefficient: 0.5
+
+       # Calculate scattering index from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: SIRetFromObs@DerivedMetaData
+           type: float
+           function:
+             name: SCATRetMW@ObsFunction
+             options:
+               scatret_ch238: 1
+               scatret_ch314: 2
+               scatret_ch890: 16
+               scatret_types: [ObsValue]
+
+       # Calculate CLW obs/bkg match index
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWMatchIndex@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: CLWMatchIndexMW@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+               clwobs_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               clwbkg_function:
+                 name: CLWRetFromBkg@DerivedMetaData
+               clwret_clearsky: [ 0.030,  0.030,  0.030,  0.020,  0.030,
+                                  0.080,  0.150,  0.000,  0.000,  0.000,
+                                  0.000,  0.000,  0.000,  0.000,  0.000,
+                                  0.020,  0.030,  0.030,  0.030,  0.030,
+                                  0.050,  0.100]
+
+       # Calculate symmetric observation error
+       - filter: Variable Assignment
+         assignments:
+         - name: InitialObsError@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorModelRamp@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+               xvar:
+                 name: CLWRetSymmetric@DerivedMetaData
+               x0:    [ 0.030,  0.030,  0.030,  0.020,  0.030,
+                        0.080,  0.150,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.000,
+                        0.020,  0.030,  0.030,  0.030,  0.030,
+                        0.050,  0.100]
+               x1:    [ 0.350,  0.380,  0.400,  0.450,  0.500,
+                        1.000,  1.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.000,
+                        0.350,  0.500,  0.500,  0.500,  0.500,
+                        0.500,  0.500]
+               err0:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
+                        0.300,  0.300,  0.400,  0.400,  0.400,
+                        0.450,  0.450,  0.550,  0.800,  4.000,
+                        4.000,  4.000,  3.500,  3.000,  3.000,
+                        3.000,  3.000]
+               err1:  [20.000, 25.000, 12.000,  7.000,  3.500,
+                        3.000,  0.800,  0.400,  0.400,  0.400,
+                        0.450,  0.450,  0.550,  0.800,  4.000,
+                       19.000, 30.000, 25.000, 16.500, 12.000,
+                        9.000,  6.500]
+
+       # Calculate Innovation@DerivedMetaData
+       - filter: Variable Assignment
+         assignments:
+         - name: Innovation@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsFunction/Arithmetic
+             channels: *atms_n21_channels
+             options:
+               variables:
+               - name: brightnessTemperature@ObsValue
+                 channels: *atms_n21_channels
+               - name: brightnessTemperature@HofX
+                 channels: *atms_n21_channels
+               coefs: [1, -1]
+
+       # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_n21_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
+
+       # Regional Domain Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+
+       # Step 0-C: Assign Initial All-Sky Observation Error
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: assign error
+           error function:
+             name: InitialObsError@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 1: Remove Observations from the Edge of the Scan
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-22
+         where:
+         - variable:
+             name: MetaData/sensorScanPosition
+           is_in: 7-90
+         actions:
+           - name: set
+             flag: ScanEdgeRemoval
+           - name: reject
+
+       # Step 2: data Thinning
+       - filter: Gaussian Thinning
+         #horizontal_mesh: 145
+         horizontal_mesh: 60
+         use_reduced_horizontal_grid: true
+         distance_norm: geodesic
+       #  round_horizontal_bin_count_to_nearest: true
+       #  partition_longitude_bins_using_mesh: true
+         actions:
+           - name: set
+             flag: Thinning
+           - name: reject
+
+       # Step 3A: CLW Retrieval Check (observation_based)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16-22
+         test variables:
+         - name: CLWRetFromObs@DerivedMetaData
+         maxvalue: 999.0
+         actions:
+           - name: set
+             flag: CLWRetrievalCheck
+           - name: reject
+
+       # Step 3B: CLW Retrieval Check (background_based)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16-22
+         test variables:
+         - name: CLWRetFromBkg@DerivedMetaData
+         maxvalue: 999.0
+         actions:
+           - name: set
+             flag: CLWRetrievalCheck
+           - name: reject
+
+       # Step 4: Window Channel Sanity Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16, 17-22
+         test variables:
+         - name: Innovation@DerivedMetaData
+           channels: 1, 2, 5-7, 16
+         maxvalue: 200.0
+         minvalue: -200.0
+         flag all filter variables if any test variable is out of bounds: true
+         actions:
+           - name: set
+             flag: WindowChannelExtremeResidual
+           - name: reject
+
+       # Step 5: Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/HydrometeorCheckATMS
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: HydrometeorCheckATMS@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+               obserr_clearsky: *atms_n21_error
+               clwret_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_n21_channels
+
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: DerivedMetaData/HydrometeorCheckATMS
+           channels: *atms_n21_channels
+         maxvalue: 0.0
+         actions:
+           - name: set
+             flag: HydrometeorCheck
+             ignore: rejected observations
+           - name: reject
+
+       # Step 6: Observation Error Inflation based on Topography Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorTopo@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorTopoRad@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorTopo@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 7: Obs Error Inflation based on TOA Transmittancec Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorTransmitTop@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorTransmitTopRad@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               channels: *atms_n21_channels
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorTransmitTop@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 8: Observation Error Inflation based on Surface Jacobian Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorSurfJacobian@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorSurfJacobianRad@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorSurfJacobian@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 9: Situation Dependent Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorSituDepend@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorFactorSituDependMW@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+               clwbkg_function:
+                 name: CLWRetFromBkg@DerivedMetaData
+               clwobs_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               scatobs_function:
+                 name: SIRetFromObs@DerivedMetaData
+               clwmatchidx_function:
+                 name: CLWMatchIndex@DerivedMetaData
+                 channels: *atms_n21_channels
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_n21_channels
+               obserr_clearsky: *atms_n21_error
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorSituDepend@DerivedMetaData
+             channels: *atms_n21_channels
+
+       # Step 10: Gross check
+       # Remove data if abs(Obs-HofX) > absolute threhold
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorLat@DerivedMetaData
+           type: float
+           function:
+             name: ObsErrorFactorLatRad@ObsFunction
+             options:
+               latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorBound@DerivedMetaData
+           channels: *atms_n21_channels
+           type: float
+           function:
+             name: ObsErrorBoundMW@ObsFunction
+             channels: *atms_n21_channels
+             options:
+               sensor: atms_n21
+               channels: *atms_n21_channels
+               obserr_bound_latitude:
+                 name: ObsErrorFactorLat@DerivedMetaData
+               obserr_bound_transmittop:
+                 name: ObsErrorFactorTransmitTop@DerivedMetaData
+                 channels: *atms_n21_channels
+                 options:
+                   channels: *atms_n21_channels
+               obserr_bound_topo:
+                 name: ObsErrorFactorTopo@DerivedMetaData
+                 channels: *atms_n21_channels
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_n21_channels
+                 threhold: 3
+               obserr_bound_max: *atms_n21_obserr_bound_max
+
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         function absolute threshold:
+         - name: ObsErrorBound@DerivedMetaData
+           channels: *atms_n21_channels
+         actions:
+           - name: set
+             flag: GrossCheck
+             ignore: rejected observations
+           - name: reject
+
+       # Step 11: Inter-Channel Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: InterChannelConsistencyCheck@ObsFunction
+           channels: *atms_n21_channels
+           options:
+             channels: *atms_n21_channels
+             use passive_bc: true
+             sensor: atms_n21
+             use_flag: *atms_n21_use_flag
+         maxvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: InterChannelConsistency
+             ignore: rejected observations
+           - name: reject
+
+       # Step 12: Useflag Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n21_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *atms_n21_channels
+           options:
+             channels: *atms_n21_channels
+             use_flag: *atms_n21_use_flag
+         minvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: UseflagCheck
+             ignore: rejected observations
+           - name: reject
+
+     - obs space:
+         name: amsua_metop-b
+         _anchor_channels: &amsua_metop-b_channels 1-15
+         _anchor_use_flag: &amsua_metop-b_use_flag [ -1,  -1,  -1,  -1,  -1, -1, -1,  1,  1,  1,  -1,   -1,   -1, -1,  -1 ]
+         _anchor_error: &amsua_metop-b_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
+         _anchor_obserr_bound_max: &amsua_metop-b_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_amsua_metop-b.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "skip output"
+           engine:
+             type: H5File
+             obsfile: jdiag_amsua_metop-b.nc
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: *amsua_metop-b_channels
+       obs operator:
+         name: CRTM
+         Absorbers: [H2O,O3,CO2]
+         SurfaceWindGeoVars: uv
+         Clouds: [Water, Ice]
+         Cloud_Seeding: true
+         Cloud_Fraction: 1.0
+         obs options:
+           Sensor_ID: amsua_metop-b
+           EndianType: little_endian
+           CoefficientPath: data/crtm/
+           IRVISlandCoeff: IGBP
+         linear obs operator:
+           Absorbers: [H2O, O3]
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
+       obs bias:
+         input file: data/satbias_in/amsua_metop-b.satbias.nc
+         output file: data/satbias_out/amsua_metop-b.satbias.nc
+         variational bc:
+           predictors:
+           - name: constant
+           - name: lapseRate
+             order: 2
+             tlapse: &amsua_metop-b_tlapse data/satbias_in/amsua_metop-b.tlapse.txt
+           - name: lapseRate
+             tlapse: *amsua_metop-b_tlapse
+           - name: emissivityJacobian
+           - name: sensorScanAngle
+             order: 4
+           - name: sensorScanAngle
+             order: 3
+           - name: sensorScanAngle
+             order: 2
+           - name: sensorScanAngle
+         covariance:
+           minimal required obs number: 20
+           variance range: [1.0e-6, 10.0]
+           step size: 1.0e-4
+           largest analysis variance: 10000.0
+           prior:
+             input file: data/satbias_in/amsua_metop-b.satbias_cov.nc
+             inflation:
+               ratio: 1.1
+               ratio for small dataset: 2.0
+           output file: data/satbias_out/amsua_metop-b.satbias_cov.nc
+       obs pre filters:
+       # Regional domain check to remove data outside of model domain
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+        #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *amsua_metop-b_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: assign error
+           error function:
+             name: ObsFunction/ObsErrorModelRamp
+             channels: *amsua_metop-b_channels
+             options:
+               channels: *amsua_metop-b_channels
+               xvar:
+                 name: ObsFunction/CLWRetSymmetricMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue, HofX]
+               x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                        0.100,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.030]
+               x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                        1.500,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.200]
+               err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                        0.230,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000,  3.500]
+               err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                        0.300,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000, 18.000]
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [ObsValue]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [HofX]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: ObsFunction/HydrometeorCheckAMSUA
+           channels: *amsua_metop-b_channels
+           options:
+             channels: *amsua_metop-b_channels
+             obserr_clearsky: *amsua_metop-b_error
+             clwret_function:
+               name: ObsFunction/CLWRetMW
+               options:
+                 clwret_ch238: 1
+                 clwret_ch314: 2
+                 clwret_types: [ObsValue]
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                         0.300,  0.230,  0.250,  0.250,  0.350,
+                         0.400,  0.550,  0.800,  3.000, 18.000]
+         maxvalue: 0.0
+         action:
+           name: reject
+       #  Topography check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTopoRad
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+       #  Transmittnace Top Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTransmitTopRad
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+       #  Surface Jacobian check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSurfJacobianRad
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+       #  Situation dependent Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSituDependMW
+             channels: *amsua_metop-b_channels
+             options:
+               sensor: amsua_metop-b
+               channels: *amsua_metop-b_channels
+               clwobs_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue]
+               clwbkg_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [HofX]
+                   bias_application: HofX
+               scatobs_function:
+                 name: ObsFunction/SCATRetMW
+                 options:
+                   scatret_ch238: 1
+                   scatret_ch314: 2
+                   scatret_ch890: 15
+                   scatret_types: [ObsValue]
+                   bias_application: HofX
+               clwmatchidx_function:
+                 name: ObsFunction/CLWMatchIndexMW
+                 channels: *amsua_metop-b_channels
+                 options:
+                   channels: *amsua_metop-b_channels
+                   clwobs_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue]
+                   clwbkg_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [HofX]
+                       bias_application: HofX
+                   clwret_clearsky: [0.050, 0.030, 0.030, 0.020, 0.000,
+                                     0.100, 0.000, 0.000, 0.000, 0.000,
+                                     0.000, 0.000, 0.000, 0.000, 0.030]
+               obserr_function:
+                 name: ObsFunction/ObsErrorModelRamp
+                 channels: *amsua_metop-b_channels
+                 options:
+                   channels: *amsua_metop-b_channels
+                   xvar:
+                     name: ObsFunction/CLWRetSymmetricMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue, HofX]
+                   x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                            0.100,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.030]
+                   x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                            1.500,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.200]
+                   err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                            0.230,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000,  3.500]
+                   err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                            0.300,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000, 18.000]
+               obserr_clearsky: *amsua_metop-b_error
+
+       #  Gross check
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         function absolute threshold:
+         - name: ObsFunction/ObsErrorBoundMW
+           channels: *amsua_metop-b_channels
+           options:
+             sensor: amsua_metop-b
+             channels: *amsua_metop-b_channels
+             obserr_bound_latitude:
+               name: ObsFunction/ObsErrorFactorLatRad
+               options:
+                 latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+             obserr_bound_transmittop:
+               name: ObsFunction/ObsErrorFactorTransmitTopRad
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+             obserr_bound_topo:
+               name: ObsFunction/ObsErrorFactorTopoRad
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+                 sensor: amsua_metop-b
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-b_channels
+               options:
+                 channels: *amsua_metop-b_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                     bias_application: HofX
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                          0.300,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000, 18.000]
+             obserr_bound_max: *amsua_metop-b_obserr_bound_max
+         action:
+           name: reject
+       #  Inter-channel check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: ObsFunction/InterChannelConsistencyCheck
+           channels: *amsua_metop-b_channels
+           options:
+             channels: *amsua_metop-b_channels
+             sensor: amsua_metop-b
+             use_flag: *amsua_metop-b_use_flag
+         maxvalue: 1.0e-12
+         action:
+           name: reject
+       #  Useflag check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-b_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *amsua_metop-b_channels
+           options:
+             sensor: amsua_metop-b
+             channels: *amsua_metop-b_channels
+             use_flag: *amsua_metop-b_use_flag
+         minvalue: 1.0e-12
+         action:
+           name: reject
+     - obs space:
+         name: amsua_metop-c
+         _anchor_channels: &amsua_metop-c_channels 1-15
+         _anchor_use_flag: &amsua_metop-c_use_flag [ 1,  1,  1,  1,  1, 1, 1,  1,  1,  1, -1,  -1,  -1, 1,  1 ]
+         _anchor_error: &amsua_metop-c_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
+         _anchor_obserr_bound_max: &amsua_metop-c_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
+         distribution:
+           name: "RoundRobin"
+           halo size: 500e3
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_amsua_metop-c.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "skip output"
+           engine:
+             type: H5File
+             obsfile: jdiag_amsua_metop-c.nc
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: *amsua_metop-c_channels
+       obs operator:
+         name: CRTM
+         Absorbers: [H2O,O3,CO2]
+         SurfaceWindGeoVars: uv
+         Clouds: [Water, Ice]
+         Cloud_Seeding: true
+         Cloud_Fraction: 1.0
+         obs options:
+           Sensor_ID: amsua_metop-c
+           EndianType: little_endian
+           CoefficientPath: data/crtm/
+           IRVISlandCoeff: IGBP
+         linear obs operator:
+           Absorbers: [H2O, O3]
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 200e3 # orig
+       obs bias:
+         input file: data/satbias_in/amsua_metop-c.satbias.nc
+         output file: data/satbias_out/amsua_metop-c.satbias.nc
+         variational bc:
+           predictors:
+           - name: constant
+           - name: lapseRate
+             order: 2
+             tlapse: &amsua_metop-c_tlapse data/satbias_in/amsua_metop-c.tlapse.txt
+           - name: lapseRate
+             tlapse: *amsua_metop-c_tlapse
+           - name: emissivityJacobian
+           - name: sensorScanAngle
+             order: 4
+           - name: sensorScanAngle
+             order: 3
+           - name: sensorScanAngle
+             order: 2
+           - name: sensorScanAngle
+         covariance:
+           minimal required obs number: 20
+           variance range: [1.0e-6, 10.0]
+           step size: 1.0e-4
+           largest analysis variance: 10000.0
+           prior:
+             input file: data/satbias_in/amsua_metop-c.satbias_cov.nc
+             inflation:
+               ratio: 1.1
+               ratio for small dataset: 2.0
+           output file: data/satbias_out/amsua_metop-c.satbias_cov.nc
+       obs pre filters:
+       # Regional domain check to remove data outside of model domain
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+        #Toss data if the hofx is missing or outside of range
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *amsua_metop-c_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
+         action:
+           name: reject
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: assign error
+           error function:
+             name: ObsFunction/ObsErrorModelRamp
+             channels: *amsua_metop-c_channels
+             options:
+               channels: *amsua_metop-c_channels
+               xvar:
+                 name: ObsFunction/CLWRetSymmetricMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue, HofX]
+               x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                        0.100,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.030]
+               x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                        1.500,  0.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.200]
+               err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                        0.230,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000,  3.500]
+               err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                        0.300,  0.230,  0.250,  0.250,  0.350,
+                        0.400,  0.550,  0.800,  3.000, 18.000]
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [ObsValue]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  CLW Retrieval Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-6, 15
+         test variables:
+         - name: ObsFunction/CLWRetMW
+           options:
+             clwret_ch238: 1
+             clwret_ch314: 2
+             clwret_types: [HofX]
+         maxvalue: 999.0
+         action:
+           name: reject
+       #  Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: ObsFunction/HydrometeorCheckAMSUA
+           channels: *amsua_metop-c_channels
+           options:
+             channels: *amsua_metop-c_channels
+             obserr_clearsky: *amsua_metop-c_error
+             clwret_function:
+               name: ObsFunction/CLWRetMW
+               options:
+                 clwret_ch238: 1
+                 clwret_ch314: 2
+                 clwret_types: [ObsValue]
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                         0.300,  0.230,  0.250,  0.250,  0.350,
+                         0.400,  0.550,  0.800,  3.000, 18.000]
+         maxvalue: 0.0
+         action:
+           name: reject
+       #  Topography check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTopoRad
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+       #  Transmittnace Top Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorTransmitTopRad
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+       #  Surface Jacobian check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSurfJacobianRad
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+       #  Situation dependent Check
+       - filter: BlackList
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSituDependMW
+             channels: *amsua_metop-c_channels
+             options:
+               sensor: amsua_metop-c
+               channels: *amsua_metop-c_channels
+               clwobs_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [ObsValue]
+               clwbkg_function:
+                 name: ObsFunction/CLWRetMW
+                 options:
+                   clwret_ch238: 1
+                   clwret_ch314: 2
+                   clwret_types: [HofX]
+                   bias_application: HofX
+               scatobs_function:
+                 name: ObsFunction/SCATRetMW
+                 options:
+                   scatret_ch238: 1
+                   scatret_ch314: 2
+                   scatret_ch890: 15
+                   scatret_types: [ObsValue]
+                   bias_application: HofX
+               clwmatchidx_function:
+                 name: ObsFunction/CLWMatchIndexMW
+                 channels: *amsua_metop-c_channels
+                 options:
+                   channels: *amsua_metop-c_channels
+                   clwobs_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue]
+                   clwbkg_function:
+                     name: ObsFunction/CLWRetMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [HofX]
+                       bias_application: HofX
+                   clwret_clearsky: [0.050, 0.030, 0.030, 0.020, 0.000,
+                                     0.100, 0.000, 0.000, 0.000, 0.000,
+                                     0.000, 0.000, 0.000, 0.000, 0.030]
+               obserr_function:
+                 name: ObsFunction/ObsErrorModelRamp
+                 channels: *amsua_metop-c_channels
+                 options:
+                   channels: *amsua_metop-c_channels
+                   xvar:
+                     name: ObsFunction/CLWRetSymmetricMW
+                     options:
+                       clwret_ch238: 1
+                       clwret_ch314: 2
+                       clwret_types: [ObsValue, HofX]
+                   x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                            0.100,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.030]
+                   x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                            1.500,  0.000,  0.000,  0.000,  0.000,
+                            0.000,  0.000,  0.000,  0.000,  0.200]
+                   err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                            0.230,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000,  3.500]
+                   err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                            0.300,  0.230,  0.250,  0.250,  0.350,
+                            0.400,  0.550,  0.800,  3.000, 18.000]
+               obserr_clearsky: *amsua_metop-c_error
+
+       #  Gross check
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         function absolute threshold:
+         - name: ObsFunction/ObsErrorBoundMW
+           channels: *amsua_metop-c_channels
+           options:
+             sensor: amsua_metop-c
+             channels: *amsua_metop-c_channels
+             obserr_bound_latitude:
+               name: ObsFunction/ObsErrorFactorLatRad
+               options:
+                 latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+             obserr_bound_transmittop:
+               name: ObsFunction/ObsErrorFactorTransmitTopRad
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+             obserr_bound_topo:
+               name: ObsFunction/ObsErrorFactorTopoRad
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+                 sensor: amsua_metop-c
+             obserr_function:
+               name: ObsFunction/ObsErrorModelRamp
+               channels: *amsua_metop-c_channels
+               options:
+                 channels: *amsua_metop-c_channels
+                 xvar:
+                   name: ObsFunction/CLWRetSymmetricMW
+                   options:
+                     clwret_ch238: 1
+                     clwret_ch314: 2
+                     clwret_types: [ObsValue, HofX]
+                     bias_application: HofX
+                 x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                          0.100,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.030]
+                 x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                          1.500,  0.000,  0.000,  0.000,  0.000,
+                          0.000,  0.000,  0.000,  0.000,  0.200]
+                 err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                          0.230,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000,  3.500]
+                 err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                          0.300,  0.230,  0.250,  0.250,  0.350,
+                          0.400,  0.550,  0.800,  3.000, 18.000]
+             obserr_bound_max: *amsua_metop-c_obserr_bound_max
+         action:
+           name: reject
+       #  Inter-channel check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: ObsFunction/InterChannelConsistencyCheck
+           channels: *amsua_metop-c_channels
+           options:
+             channels: *amsua_metop-c_channels
+             sensor: amsua_metop-c
+             use_flag: *amsua_metop-c_use_flag
+         maxvalue: 1.0e-12
+         action:
+           name: reject
+       #  Useflag check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *amsua_metop-c_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *amsua_metop-c_channels
+           options:
+             sensor: amsua_metop-c
+             channels: *amsua_metop-c_channels
+             use_flag: *amsua_metop-c_use_flag
+         minvalue: 1.0e-12
          action:
            name: reject

--- a/ush/yaml_finalize
+++ b/ush/yaml_finalize
@@ -21,6 +21,8 @@ HYB_WGT_ENS = os.getenv("HYB_WGT_ENS", "0.5")
 start_type = os.getenv("start_type", "start_type_NOT_DEFINED")
 GETKF_TYPE = os.getenv("GETKF_TYPE", "TYPE_NOT_DEFINED")
 use_conv_sat_info = (os.getenv("USE_CONV_SAT_INFO", "True").upper() != "FALSE")
+emptyObsSpaceAction = os.getenv("EMPTY_OBS_SPACE_ACTION", "skip output")
+
 STATIC_BEC_MODEL = os.getenv("STATIC_BEC_MODEL", "GSIBEC")
 GSIBEC_X = os.getenv("GSIBEC_X", "10")
 GSIBEC_Y = os.getenv("GSIBEC_Y", "8")
@@ -39,6 +41,7 @@ replacements = {
     "beginDate": f"{beginDate}",
     "HYB_WGT_STATIC": f"{HYB_WGT_STATIC}",
     "HYB_WGT_ENS": f"{HYB_WGT_ENS}",
+    "emptyObsSpaceAction": f"{emptyObsSpaceAction}",
     "GSIBEC_X": f"{GSIBEC_X}",
     "GSIBEC_Y": f"{GSIBEC_Y}",
     "GSIBEC_NLAT": f"{GSIBEC_NLAT}",

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -21,6 +21,7 @@ export PHYSICS_SUITE=${PHYSICS_SUITE:-"convection_permitting"} # mesoscale_refer
 export KEEPDATA=${KEEPDATA:-"NO"}
 export MPI_RUN_CMD=${MPI_RUN_CMD:-"srun"}
 export USE_CONV_SAT_INFO=${USE_CONV_SAT_INFO:-true}
+export EMPTY_OBS_SPACE_ACTION=${EMPTY_OBS_SPACE_ACTION:-"skip output"}
 
 # PREP_LBC_LOOK_BACK_HRS
 if ${REALTIME:-false}; then

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -21,6 +21,7 @@ def getkf(xmlFile, expdir, taskType):
         'ENS_SIZE': os.getenv("ENS_SIZE", '5'),
         'GETKF_TYPE': taskType.lower(),
         'USE_CONV_SAT_INFO': os.getenv('USE_CONV_SAT_INFO', 'true'),
+        'EMPTY_OBS_SPACE_ACTION': os.getenv('EMPTY_OBS_SPACE_ACTION', 'skip output'),
     }
     if taskType.upper() == "OBSERVER":
         task_id = "getkf_observer"

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -35,6 +35,7 @@ def jedivar(xmlFile, expdir, do_spinup=False):
         'HYB_ENS_PATH': os.getenv('HYB_ENS_PATH', ''),
         'ENS_BEC_LOOK_BACK_HRS': f'{ens_bec_look_back_hrs}',
         'USE_CONV_SAT_INFO': os.getenv('USE_CONV_SAT_INFO', 'true'),
+        'EMPTY_OBS_SPACE_ACTION': os.getenv('EMPTY_OBS_SPACE_ACTION', 'skip output'),
         'STATIC_BEC_MODEL': os.getenv('STATIC_BEC_MODEL', 'GSIBEC'),
         'GSIBEC_X': os.getenv('GSIBEC_X', '10'),
         'GSIBEC_Y': os.getenv('GSIBEC_Y', '8'),


### PR DESCRIPTION
The `jedivar.yaml` and `getkf.yaml` files in rrfs-workflow have fall behind the latest changes in RDASApp (although no scientific changes). This PR syncs them with the latest RDASApp.

Tested a few retro runs on Gaea and everything worked as expected.