### PR TITLE
Use one getkf.yaml in setup_rocoto.py

### DIFF
--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -72,8 +72,7 @@ if os.getenv("DO_JEDI", 'false').upper() == "TRUE":
         shutil.copy('satinfo', f'{exp_configdir}/satinfo')
     # copy jedivar.yaml or getkf yamls to exp_configdir
     if os.getenv('DO_ENSEMBLE', 'FALSE').upper() == "TRUE":
-        shutil.copy(f'{HOMErrfs}/parm/getkf_observer.yaml', f'{exp_configdir}/getkf_observer.yaml')
-        shutil.copy(f'{HOMErrfs}/parm/getkf_solver.yaml', f'{exp_configdir}/getkf_solver.yaml')
+        shutil.copy(f'{HOMErrfs}/parm/getkf.yaml', f'{exp_configdir}/getkf.yaml')
     else:
         shutil.copy(f'{HOMErrfs}/parm/jedivar.yaml', f'{exp_configdir}/jedivar.yaml')
         shutil.copy(f'{HOMErrfs}/parm/bec_bump.yaml', f'{exp_configdir}/bec_bump.yaml')


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Hotfix to copy getkf.yaml instead of getkf_observer.yaml and getkf_solver.yaml in setup_rocoto.py

## TESTS CONDUCTED: 
Tested on Jet

## CONTRIBUTORS (optional): 
@guoqing-noaa Thanks for the quick fix!

