### PR TITLE
Fix EXTRN_MDL_CDATE in blend_ics job

### DIFF
--- a/scripts/exrrfs_blend_ics.sh
+++ b/scripts/exrrfs_blend_ics.sh
@@ -46,13 +46,7 @@ NUM_ENS_MEMBERS=${NUM_ENS_MEMBERS:-0}
 #
 #-----------------------------------------------------------------------
 #
-yyyymmdd="${EXTRN_MDL_CDATE:0:8}"
-mm="${EXTRN_MDL_CDATE:4:2}"
-dd="${EXTRN_MDL_CDATE:6:2}"
-hh="${EXTRN_MDL_CDATE:8:2}"
-
-fhr="${EXTRN_MDL_ICS_OFFSET_HRS}"
-cdate_crnt_fhr=$( date --utc --date "${yyyymmdd} ${hh} UTC + ${fhr} hours" "+%Y%m%d%H" )
+cdate_crnt_fhr=="${cdate}"
 #
 # Get the month, day, and hour corresponding to the current forecast time
 # of the the external model.


### PR DESCRIPTION
Bring back the change to fix the issue with EXTRN_MDL_CDATE variable assignment.
