### PR TITLE
add three slurm job checking utilities

### DIFF
--- a/workflow/ush/qrocoto/sc
+++ b/workflow/ush/qrocoto/sc
@@ -1,0 +1,9 @@
+#!/bin/bash
+# shellcheck disable=all
+# by Guoqing.Ge, May 2019
+if (( $# < 1)); then
+  echo "Usage: sc <jobid>"
+  exit 1
+fi
+
+scontrol show -d job $1

--- a/workflow/ush/qrocoto/sq
+++ b/workflow/ush/qrocoto/sq
@@ -1,0 +1,37 @@
+#!/bin/bash
+# shellcheck disable=all
+# by Guoqing.Ge, May 2019
+maxjoblength=40
+myuser=$(echo $USER)
+jobid=""
+
+for arg in "$@"; do
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    if (( arg <= 99 )); then
+      maxjoblength="$arg"
+    elif (( arg >= 100 )); then
+      jobid="$arg"
+    fi
+  else
+    myuser="$arg"
+  fi
+done
+
+if [[ "${myuser}" == "all" ]]; then
+  usrlen=22
+else
+  usrlen=${#myuser}
+fi
+outformat="%.10i %.7P %.7q %.8v %.${maxjoblength}j %.8T %.9M %.9l %.${usrlen}u %.8a %.5D %40R"
+if [[ -z $jobid ]]; then
+  if [[ "${myuser}" == "all" ]]; then
+    output=$(squeue -o "$outformat")
+  else
+    output=$(squeue -u $myuser -o "$outformat")
+  fi
+else
+  output=$(squeue -o "$outformat" -j $jobid)
+fi
+firstline=$(echo "$output"|head -n 1)
+echo -e "$output"
+echo -e "$firstline"

--- a/workflow/ush/qrocoto/sqq
+++ b/workflow/ush/qrocoto/sqq
@@ -1,0 +1,27 @@
+#!/bin/bash
+# shellcheck disable=all
+# by Guoqing.Ge, May 2019
+maxjoblength=40
+myuser=$(echo $USER)
+jobid=""
+interval=30  # refresh every 30 seconds
+
+for arg in "$@"; do
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    if (( arg <= 99 )); then
+      maxjoblength="$arg"
+    elif (( arg >= 100 )); then
+      jobid="$arg"
+    fi
+  else
+    myuser="$arg"
+  fi
+done
+
+usrlen=${#myuser}
+outformat="%.10i %.7P %.7q %.8v %.${maxjoblength}j %.8T %.9M %.9l %.${usrlen}u %.8a %.5D %40R"
+if [[ -z $jobid ]]; then
+  squeue -u $myuser -o "$outformat" -i $interval
+else
+  squeue -o "$outformat" -j $jobid -i $interval
+fi


### PR DESCRIPTION
As we know, the default `squeue` output cannot show long job names, which is not convenient when monitoring slurm jobs in retro or realtime experiments. A few users have feedbacked whether we may do something in rrfs-workflow.

This PR adds three utilities facilitating checking Slurm jobs easily ( I have been using them since 2019 when NOAA RDHPCS adopted Slurm).

1. The usage of `sq` is: `sq [username|all] [jobid] [maxjoblen]`
```
sq       # show my current jobs, using a 40-character width to show long job names
sq 70773126          # show a job with id=70773126
sq Guoqing.Ge       # show jobs running by user Guoqing.Ge
sq  66                     # show my current jobs, using a 66-character width to show long job names
sq all                       # show all jobs in a HPC, using a 40-character width to show long job names
```
2. `sqq` is to run `sq` every 30 seconds,  usage: `sqq [username] [jobid] [maxjoblen]`
```
sqq
sqq 70773126
sqq Guoqing.Ge
sqq 66
```
4. `sc` is a wrapper to `scontrol show -d job $1`, which can check detailed information of a job. Usage `sc <jobid>`
```
sc 70773126
```