### PR TITLE
[main] Defines the varmap file to be from PARMrrfs

### DIFF
--- a/scripts/exrrfs_make_ics.sh
+++ b/scripts/exrrfs_make_ics.sh
@@ -629,7 +629,7 @@ settings="
  'orog_dir_target_grid': ${FIXLAM},
  'orog_files_target_grid': ${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo$((10#${NH4})).nc,
  'vcoord_file_target_grid': ${FIXam}/${VCOORD_FILE},
- 'varmap_file': ${UFS_UTILS_DIR}/parm/varmap_tables/${varmap_file},
+ 'varmap_file': ${PARMrrfs}/${varmap_file},
  'data_dir_input_grid': ${extrn_mdl_staging_dir},
  'atm_files_input_grid': ${fn_atm},
  'sfc_files_input_grid': ${fn_sfc},


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- One line change so the exrrfs_make_ics.sh points to the copy in PARMrrfs.  The exrrfs_make_lbcs.sh already was doing this.  The PARMrrfs and sorc directory copies are identical

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- None yet, but can test in real-time RRFS once can coordinate the change.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #923 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

