### PR TITLE
[dev-sci] Load specific python version on wcoss2 in `app_build.sh`

### DIFF
--- a/sorc/app_build.sh
+++ b/sorc/app_build.sh
@@ -301,7 +301,11 @@ if [ "${EXTRN}" = true ]; then
   # run check-out
   python --version 1>/dev/null 2>/dev/null
   if [[ $? -ne 0 ]]; then
-       module load python
+       if [ "${PLATFORM}" = "wcoss2" ]; then
+         module load cray-python/3.11.7
+       else
+         module load python
+       fi
   fi
   printf "... checking out external components ...\n"
   ./manage_externals/checkout_externals


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

The `app_build.sh` script tries to load a python module if none is currently active. This is needed to run the `sorc/manage_externals/checkout_externals` tool. However, simply running `module load python` produces an error on WCOSS2: 

```
[samuel.degelia@clogin02 sorc] $ module load python
Lmod has detected the following error:  These module(s) or extension(s) exist but cannot be loaded as requested: "python"
   Try: "module spider python" to see how to load the module(s).
```

The best way to solve this is to specify a version of python to load. Here we update `app_build.sh` to load `cray-python/3.11.7` on WCOSS2. 

## TESTS CONDUCTED: 
Tested building `dev-sci` branch with no modules loaded by default. Everything built successfully. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

## CONTRIBUTORS (optional): 
Thanks to @HuiLiu-NOAA for finding this problem and testing the solution. 

