### PR TITLE
hotfix: skip JCB in build.rdas for rrfs.v2

### DIFF
--- a/sorc/build.rdas
+++ b/sorc/build.rdas
@@ -70,7 +70,7 @@ cp ../_workaround_/RDASApp/saber/GSIParameters.h sorc/saber/src/saber/gsi/utils/
 cp ../_workaround_/RDASApp/saber/Geometry.cc sorc/saber/src/saber/interpolation/Geometry.cc
 
 rm -rf build/
-./build.sh -m MPAS -t NO -w NO
+./build.sh -m MPAS -t NO -w NO -b NO
 
 mkdir -p "${HOMErrfs}/exec"
 echo "copy ${EXEC} to ../exec/mpasjedi_variational.x"


### PR DESCRIPTION
This PR changes the settings in build.rdas. By default, skip building JCB in rrfs.v2. 