### PR TITLE
[main] trigger ensf recenter after det_analysis_nonvarcld

### DIFF
--- a/ecf/defs/rrfs_prod.def
+++ b/ecf/defs/rrfs_prod.def
@@ -2443,7 +2443,7 @@ suite rrfs_dev
               family ensf
                 edit WGF 'ensf'
                 task jrrfs_ensf_recenter
-                  trigger ../../forecast/det/jrrfs_det_save_restart_long_1==complete and ../../prep/ensf==complete
+                  trigger ../det/jrrfs_det_analysis_nonvarcld==complete and ../../prep/ensf==complete
                 task jrrfs_ensf_save_da_output_mem001
                   edit CYCLE_TYPE 'enfcst'
                   edit MEMBER_NAME '001'
@@ -13869,7 +13869,7 @@ suite rrfs_dev
               family ensf
                 edit WGF 'ensf'
                 task jrrfs_ensf_recenter
-                  trigger ../../forecast/det/jrrfs_det_save_restart_long_1==complete and ../../prep/ensf==complete
+                  trigger ../det/jrrfs_det_analysis_nonvarcld==complete and ../../prep/ensf==complete
                 task jrrfs_ensf_save_da_output_mem001
                   edit CYCLE_TYPE 'enfcst'
                   edit MEMBER_NAME '001'
@@ -25654,7 +25654,7 @@ suite rrfs_dev
               family ensf 
                 edit WGF 'ensf'
                 task jrrfs_ensf_recenter
-                  trigger ../../forecast/det/jrrfs_det_save_restart_long_1==complete and ../../prep/ensf==complete
+                  trigger ../det/jrrfs_det_analysis_nonvarcld==complete and ../../prep/ensf==complete
                 task jrrfs_ensf_save_da_output_mem001
                   edit CYCLE_TYPE 'enfcst'
                   edit MEMBER_NAME '001'
@@ -37083,7 +37083,7 @@ suite rrfs_dev
               family ensf 
                 edit WGF 'ensf'
                 task jrrfs_ensf_recenter
-                  trigger ../../forecast/det/jrrfs_det_save_restart_long_1==complete and ../../prep/ensf==complete
+                  trigger ../det/jrrfs_det_analysis_nonvarcld==complete and ../../prep/ensf==complete
                 task jrrfs_ensf_save_da_output_mem001
                   edit CYCLE_TYPE 'enfcst'
                   edit MEMBER_NAME '001'


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- ensf recenter job should begin after det_analysis_nonvarcld, it doesn't need to wait for the the complete status of 1h forecast from DET cycle.
- it is expected to submit the ensf forecast job about 10 minutes earlier.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
There is NO test for this modification because the rrfs workflow on CACTUS might not be able to catch up in real time.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #980

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

