### PR TITLE
FIX CDATE assignment issue with blend_ics job

### DIFF
--- a/scripts/exrrfs_blend_ics.sh
+++ b/scripts/exrrfs_blend_ics.sh
@@ -46,7 +46,7 @@ NUM_ENS_MEMBERS=${NUM_ENS_MEMBERS:-0}
 #
 #-----------------------------------------------------------------------
 #
-cdate_crnt_fhr="${cdate}"
+cdate_crnt_fhr="${CDATE}"
 #
 # Get the month, day, and hour corresponding to the current forecast time
 # of the the external model.


### PR DESCRIPTION
The cdate assignment in blend_ics job need to be fixed with CDATE which is assigned from the j-job.