### PR TITLE
add `build.all noda` to skip building RDASApp for model-only experiments

### DIFF
--- a/sorc/build.all
+++ b/sorc/build.all
@@ -16,10 +16,13 @@ trap cleanup SIGINT SIGTERM
 echo "building all components, it may take more than one hour..."
 ./build.wps  &> ./log.build.wps  2>&1 &
 ./build.mpas &> ./log.build.mpas 2>&1 &
-./build.rdas &> ./log.build.rdas 2>&1 &
 ./build.upp  &> ./log.build.upp  2>&1 &
 ./build.mpassit  &> ./log.build.mpassit  2>&1 &
 ./build.utils  &> ./log.build.utils  2>&1 &
+
+if [[ "$1" != "noda" ]] && [[ "$1" != "NODA" ]] && [[ "$1" != "noDA" ]]; then
+  ./build.rdas &> ./log.build.rdas 2>&1 &
+fi
 
 wait
 nEXEC=$(find ../exec/* | wc -l)


### PR DESCRIPTION
Model-only experiments (including smoke and dust experiments) don't need to build RDASApp.
Currently lots of users manually run each build script except `build.rdas`. 
This PR adds an command line option `noda` to make the build process much more convenient for users who only run models (i.e. without DA).
