### PR TITLE
update the outdated usage information for herbie_get_*_from_aws utilities

### DIFF
--- a/workflow/ush/herbie_get_GEFS_from_aws
+++ b/workflow/ush/herbie_get_GEFS_from_aws
@@ -13,7 +13,7 @@ nargs = len(args) - 1
 if nargs < 2:
     print(f"{args[0]} YYYYMMDD-YYYYMMDD fhr-fhr\n")
     print(f'  the first parameter specifies the date range with date2 larger than or equal to date1')
-    print(f'  the second parameter specifies the fhr range,example: 0-70')
+    print(f'  the second parameter specifies the fhr range, example: 0-70')
     exit()
 
 date_range = args[1]

--- a/workflow/ush/herbie_get_GFS_from_aws
+++ b/workflow/ush/herbie_get_GFS_from_aws
@@ -13,7 +13,7 @@ nargs = len(args) - 1
 if nargs < 2:
     print(f"{args[0]} YYYYMMDD-YYYYMMDD fhr-fhr\n")
     print(f'  the first parameter specifies the date range with date2 larger than or equal to date1')
-    print(f'  the second parameter specifies the fhr range,example: 0-70')
+    print(f'  the second parameter specifies the fhr range, example: 0-70')
     exit()
 
 date_range = args[1]

--- a/workflow/ush/herbie_get_RAP_from_aws
+++ b/workflow/ush/herbie_get_RAP_from_aws
@@ -13,7 +13,7 @@ nargs = len(args) - 1
 if nargs < 2:
     print(f"{args[0]} YYYYMMDD-YYYYMMDD fhr-fhr\n")
     print(f'  the first parameter specifies the date range with date2 larger than or equal to date1')
-    print(f'  the second parameter specifies the fhr range,example: 0-70')
+    print(f'  the second parameter specifies the fhr range, example: 0-70')
     exit()
 
 date_range = args[1]


### PR DESCRIPTION
Users reported that the usage information is not correct for the latest `herbie_get_*_from_aws` utilities.
This PR updates them with correct information