### PR TITLE
Allows each task to define its own `KEEPDATA` value

### DIFF
--- a/workflow/rocoto_funcs/ensmean.py
+++ b/workflow/rocoto_funcs/ensmean.py
@@ -40,7 +40,7 @@ def ensmean(xmlFile, expdir):
     meta_end = f'</metatask>\n'
     task_id = f'{meta_id}_g#group_index#'
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -65,7 +65,7 @@ def fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
 </metatask>\n'
         ensindexstr = "_m#ens_index#"
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -30,7 +30,7 @@ def getkf(xmlFile, expdir, taskType):
     elif taskType.upper() == "POST":
         task_id = "getkf_post"
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/ic.py
+++ b/workflow/rocoto_funcs/ic.py
@@ -35,7 +35,7 @@ def ic(xmlFile, expdir, do_ensemble=False):
 </metatask>\n'
         ensindexstr = "_m#ens_index#"
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/ioda_bufr.py
+++ b/workflow/rocoto_funcs/ioda_bufr.py
@@ -23,7 +23,7 @@ def ioda_bufr(xmlFile, expdir):
         'OBSPATH': f'{OBSPATH}'
     }
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     fpath = f'{OBSPATH}/@Y@m@d@H.rap.t@Hz.prepbufr.tm00'
 

--- a/workflow/rocoto_funcs/ioda_mrms_refl.py
+++ b/workflow/rocoto_funcs/ioda_mrms_refl.py
@@ -24,7 +24,7 @@ def ioda_mrms_refl(xmlFile, expdir):
         'RADARREFL_TIMELEVEL': f'{RADARREFL_TIMELEVEL}'
     }
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -51,7 +51,7 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     if do_spinup:
         dcTaskEnv['DO_SPINUP'] = 'TRUE'
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/lbc.py
+++ b/workflow/rocoto_funcs/lbc.py
@@ -54,7 +54,7 @@ def lbc(xmlFile, expdir, do_ensemble=False):
         dcTaskEnv['ENS_INDEX'] = "#ens_index#"
         ensindexstr = "_m#ens_index#"
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -76,7 +76,7 @@ def mpassit(xmlFile, expdir, do_ensemble=False, do_ensmean_post=False):
             memdir = "/ensmean"
 
     dcTaskEnv['MEMDIR'] = f'{memdir}'
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -68,7 +68,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     if PREP_IC_TYPE == "jedivar" or PREP_IC_TYPE == "getkf":
         dcTaskEnv['USE_THE_LATEST_SATBIAS'] = os.getenv("USE_THE_LATEST_SATBIAS", "FALSE").upper()
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     coldhrs = coldhrs.split(' ')
     streqs = ""

--- a/workflow/rocoto_funcs/prep_lbc.py
+++ b/workflow/rocoto_funcs/prep_lbc.py
@@ -47,7 +47,7 @@ def prep_lbc(xmlFile, expdir, do_ensemble=False):
 </metatask>\n'
         ensindexstr = "_m#ens_index#"
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/recenter.py
+++ b/workflow/rocoto_funcs/recenter.py
@@ -16,7 +16,7 @@ def recenter(xmlFile, expdir):
         'RECENTER_CYCS': f'{recenter_cycs}',
     }
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/save_fcst.py
+++ b/workflow/rocoto_funcs/save_fcst.py
@@ -47,7 +47,7 @@ def save_fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
 </metatask>\n'
         ensdirstr = "/mem#ens_index#"
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     if do_spinup:
         datadep = f'''<datadep age="00:01:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_fcst_spinup_@H_&rrfs_ver;/&WGF;{ensdirstr}/fcst_spinup_@H/diag.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'''

--- a/workflow/rocoto_funcs/ungrib_ic.py
+++ b/workflow/rocoto_funcs/ungrib_ic.py
@@ -41,7 +41,7 @@ def ungrib_ic(xmlFile, expdir, do_ensemble=False):
 <var name="gmem">{gmems}</var>'''
         meta_end = f'</metatask>\n'
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     if extrn_mdl_source == "GFS_NCO":
         COMINgfs = os.getenv("COMINgfs", 'COMINgfs_not_defined')

--- a/workflow/rocoto_funcs/ungrib_lbc.py
+++ b/workflow/rocoto_funcs/ungrib_lbc.py
@@ -59,7 +59,7 @@ def ungrib_lbc(xmlFile, expdir, do_ensemble=False):
     dcTaskEnv['GROUP_INDEX'] = f'#group_index#'
     dcTaskEnv['GROUP_TOTAL_NUM'] = f'{lbc_ungrib_group_total_num}'
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     if extrn_mdl_source == "GFS_NCO":
         COMINgfs = os.getenv("COMINgfs", 'COMINgfs_not_defined')

--- a/workflow/rocoto_funcs/upp.py
+++ b/workflow/rocoto_funcs/upp.py
@@ -70,7 +70,7 @@ def upp(xmlFile, expdir, do_ensemble=False, do_ensmean_post=False):
 
     dcTaskEnv['MEMDIR'] = f'{memdir}'
 
-    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper())
+    dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")


### PR DESCRIPTION
In retro experiments, especially in testing, one may want to keep the `DATA` directories of some specific tasks for further closer examination, with other `DATA` directories still purged in order to save disk space.
  
For example, one would like to keep the `jedivar` `DATA` directory for debugging while it is okay to purge the `DATA` directories of other tasks upon completion.

This PR allows each task to define its own `KEEPDATA` value to meet the above needs.
One can set `KEEPDATA[_TASKID]` variables as needed in the exp setup files.

A few setting examples:
1. If one does NOT need to keep any `DATA` directories, set as follows:
```
KEEPDATA=NO
``` 
&emsp;This is the default setting.    

2. If one wants to keep all `DATA` directories, set as follows:
```
KEEPDATA=YES
``` 
&emsp;This will consume lots of disk space and hence not recommended.

3. If one wants to purge the `DATA` directories for all tasks except the `jedivar` and `ic` tasks , set as follows:
```
KEEPDATA=NO
KEEPDATA_JEDIVAR=YES
KEEPDATA_IC=YES
```
4. If one want to keep all `DATA` directories except the `MPASSIT` and `UPP` tasks, set as follows:
```
KEEPDATA=YES
KEEPDATA_MPASSIT=NO
KEEPDATA_UPP=NO
```

