### PR TITLE
hotfix - update getkf.yaml to be consistent with the latest JEDI

### DIFF
--- a/parm/getkf.yaml
+++ b/parm/getkf.yaml
@@ -19,6 +19,8 @@ _member: &memberConfig
   - isltyp
   - snowh
   - vegetation_area_fraction
+  - air_temperature_at_2m
+  - water_vapor_mixing_ratio_wrt_moist_air_at_2m
   - eastward_wind_at_10m
   - northward_wind_at_10m
   - lai
@@ -42,7 +44,7 @@ output mean prior:
   filename: ./prior_mean.nc
   stream name: background
 
-output: # for outputting mean posterior
+output:
   filename: ./data/ens/mem%{member}%.nc
   stream name: analysis
 
@@ -695,16 +697,19 @@ observations:
          simulated variables: [airTemperature]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
-           variables:
-           - name: airTemperature
+         name: SfcCorrected
+         correction scheme to use: GSL
+         gsl parameters:
+           temperature lapse rate option: Local
+           temperature local lapse rate level: 10
+           temperature lapse rate threshold: true
+           min threshold: 0.5
+           max threshold: 10.0
+         variables:
+         - name: airTemperature
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -740,16 +745,16 @@ observations:
              name: reduce obs space
 
          # Duplicate Check
-#         - filter: Temporal Thinning
-#           filter variables:
-#           - name: airTemperature
-#           min_spacing: PT90M
-#           tolerance: PT0H
-#           seed_time: "@analysisDate@"
-#           category_variable:
-#             name: MetaData/longitude_latitude_pressure
-#           action:
-#             name: reduce obs space
+         - filter: Temporal Thinning
+           filter variables:
+           - name: airTemperature
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "@analysisDate@"
+           category_variable:
+             name: MetaData/stationIdentification
+           action:
+             name: reduce obs space
 
          # Online regional domain check
          - filter: Bounds Check
@@ -777,24 +782,24 @@ observations:
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585, 2.2585]
 
-         # Error inflation based on pressure check (setupt.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: airTemperature
-           where:
-           - variable: ObsType/airTemperature
-             is_in: 187
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: airTemperature
-                 inflation factor: 8.0
-                 # The new feature "surface observation error ramp"
-                 # needs to be added to UFO to align with the ramp
-                 # options for temperature and humidity in GSI.
-                 surface observation error ramp: true
+#         # Error inflation based on pressure check (setupt.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: airTemperature
+#           where:
+#           - variable: ObsType/airTemperature
+#             is_in: 187
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorPressureCheck
+#               options:
+#                 variable: airTemperature
+#                 inflation factor: 8.0
+#                 # The new feature "surface observation error ramp"
+#                 # needs to be added to UFO to align with the ramp
+#                 # options for temperature and humidity in GSI.
+#                 surface observation error ramp: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -1519,16 +1524,13 @@ observations:
          simulated variables: [specificHumidity]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
-           variables:
-           - name: specificHumidity
+         name: SfcCorrected
+         correction scheme to use: GSL
+         variables:
+         - name: specificHumidity
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -1564,16 +1566,16 @@ observations:
              name: reduce obs space
 
          # Duplicate Check
-#         - filter: Temporal Thinning
-#           filter variables:
-#           - name: specificHumidity
-#           min_spacing: PT90M
-#           tolerance: PT0H
-#           seed_time: "@analysisDate@"
-#           category_variable:
-#             name: MetaData/longitude_latitude_pressure
-#           action:
-#             name: reduce obs space
+         - filter: Temporal Thinning
+           filter variables:
+           - name: specificHumidity
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "@analysisDate@"
+           category_variable:
+             name: MetaData/stationIdentification
+           action:
+             name: reduce obs space
 
          # Online regional domain check
          - filter: Bounds Check
@@ -1594,31 +1596,31 @@ observations:
            action:
              name: assign error
              error function:
-               name: ObsFunction/ObsErrorModelStepwiseLinear
+               name: ObsFunction/ObsErrorModelHumidity
                options:
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 187
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 # The new feature "surface observation error ramp"
-                 # needs to be added to UFO to align with the ramp
-                 # options for temperature and humidity in GSI.
-                 #surface observation error ramp: true
+#         # Error inflation based on pressure check (setupq.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: specificHumidity
+#           where:
+#           - variable: ObsType/specificHumidity
+#             is_in: 187
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorPressureCheck
+#               options:
+#                 variable: specificHumidity
+#                 inflation factor: 8.0
+#                 # The new feature "surface observation error ramp"
+#                 # needs to be added to UFO to align with the ramp
+#                 # options for temperature and humidity in GSI.
+#                 #surface observation error ramp: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action
@@ -2062,10 +2064,13 @@ observations:
          simulated variables: [stationPressure]
 
        obs operator:
-         name: SfcPCorrected
-         da_psfc_scheme: GSI
+         name: SfcCorrected
+         correction scheme to use: GSL
          geovar_sfc_geomz: geopotential_height_at_surface
          geovar_geomz: geopotential_height
+         variables:
+         - name: stationPressure
+
        linear obs operator:
          name: Identity
 
@@ -2103,16 +2108,16 @@ observations:
              name: reduce obs space
 
          # Duplicate Check
-#         - filter: Temporal Thinning
-#           filter variables:
-#           - name: stationPressure
-#           min_spacing: PT90M
-#           tolerance: PT0H
-#           seed_time: "@analysisDate@"
-#           category_variable:
-#             name: MetaData/longitude_latitude_pressure
-#           action:
-#             name: reduce obs space
+         - filter: Temporal Thinning
+           filter variables:
+           - name: stationPressure
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "@analysisDate@"
+           category_variable:
+             name: MetaData/stationIdentification
+           action:
+             name: reduce obs space
 
          # Online regional domain check
          - filter: Bounds Check
@@ -2963,17 +2968,14 @@ observations:
          simulated variables: [windEastward, windNorthward]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
-           variables:
-           - name: windEastward
-           - name: windNorthward
+         name: SfcCorrected
+         correction scheme to use: GSL
+         variables:
+         - name: windEastward
+         - name: windNorthward
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -3010,17 +3012,17 @@ observations:
              name: reduce obs space
 
          # Duplicate Check
-#         - filter: Temporal Thinning
-#           filter variables:
-#           - name: windEastward
-#           - name: windNorthward
-#           min_spacing: PT90M
-#           tolerance: PT0H
-#           seed_time: "@analysisDate@"
-#           category_variable:
-#             name: MetaData/longitude_latitude_pressure
-#           action:
-#             name: reduce obs space
+         - filter: Temporal Thinning
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "@analysisDate@"
+           category_variable:
+             name: MetaData/stationIdentification
+           action:
+             name: reduce obs space
 
          # Online domain check
          - filter: Bounds Check
@@ -3050,41 +3052,41 @@ observations:
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874, 1.5874]
 
-         # Error inflation (windEastward) based on pressure check (setupw.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: windEastward
-           where:
-           - variable: ObsType/windEastward
-             is_in: 287
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: windEastward
-                 inflation factor: 4.0
-                 SetSfcWndObsHeight: true
-                 AddObsHeightToStationElevation: true
-                 AssumedSfcWndObsHeight: 10
+#         # Error inflation (windEastward) based on pressure check (setupw.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: windEastward
+#           where:
+#           - variable: ObsType/windEastward
+#             is_in: 287
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorPressureCheck
+#               options:
+#                 variable: windEastward
+#                 inflation factor: 4.0
+#                 SetSfcWndObsHeight: true
+#                 AddObsHeightToStationElevation: true
+#                 AssumedSfcWndObsHeight: 10
 
-         # Error inflation (windNorthward) based on pressure check (setupw.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: windNorthward
-           where:
-           - variable: ObsType/windNorthward
-             is_in: 287
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: windNorthward
-                 inflation factor: 4.0
-                 SetSfcWndObsHeight: true
-                 AddObsHeightToStationElevation: true
-                 AssumedSfcWndObsHeight: 10
+#         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: windNorthward
+#           where:
+#           - variable: ObsType/windNorthward
+#             is_in: 287
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorPressureCheck
+#               options:
+#                 variable: windNorthward
+#                 inflation factor: 4.0
+#                 SetSfcWndObsHeight: true
+#                 AddObsHeightToStationElevation: true
+#                 AssumedSfcWndObsHeight: 10
 
 #         # Error inflation (windEastward) based on errormod (qcmod.f90)
 #         - filter: Perform Action


### PR DESCRIPTION
The latest rrfs-workflow will crash at conus12km getkf cycling with the following error message:
```
OOPS_STATS LocalEnsembleDA after solver             - Runtime:     55.21 sec,  Memory: total:  2747.57 Gb, per task: min =     3.27 Gb, max =     3.83 Gb
   self%get_data: field not present, air_temperature_at_2m
   self%get_data: field not present, air_temperature_at_2m
  MPICH ERROR [Rank 362] [job id 211820719.0] [Wed Oct 22 14:00:12 2025] [c6n0818] - Abort(1) (rank 362 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, 1) - process 362

  aborting job:
```

This PR updates `getkf.yaml` to be consistent with the latest JEDI and solves the crash.