### PR TITLE
Add NBMFLD GRIB2 files, move firewx fix files to firewx_input

### DIFF
--- a/jobs/JRRFS_MAKE_GRID
+++ b/jobs/JRRFS_MAKE_GRID
@@ -78,9 +78,9 @@ This is the J-job script for the task that generates grid files.
 #-----------------------------------------------------------------------
 # Define COM directories
 #-----------------------------------------------------------------------
-# Send fix files to COMOUT
-export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}"
-mkdir -p "${COMOUT}" "${COMOUT}/fix"
+# Send fix files to COM
+export firewx_input_dir="${COMrrfs}/firewx_input"
+mkdir -p "${firewx_input_dir}"
 
 # Fire weather nest location from NAM
 export COMINnam=${COMINnam:-$(compath.py nam/${nam_ver})}

--- a/jobs/JRRFS_MAKE_ICS
+++ b/jobs/JRRFS_MAKE_ICS
@@ -109,9 +109,8 @@ for the RRFS (in NetCDF format).
 #### export COMINgfs=${COMINgfs:-$(compath.py gfs/${gfs_ver})}
 
 if [ ${WGF} = "firewx" ]; then
-# Path to fix files in COMOUT
-  export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}"
-  mkdir -p "${COMOUT}" "${COMOUT}/fix"
+# Path to fix files in COM
+  export firewx_input_dir="${COMrrfs}/firewx_input"
 
 # Fire weather nest location from NAM
   export COMINnam=${COMINnam:-$(compath.py nam/${nam_ver})}

--- a/jobs/JRRFS_MAKE_LBCS
+++ b/jobs/JRRFS_MAKE_LBCS
@@ -93,7 +93,7 @@ if [ $WGF = "enkf" ] || [ $WGF = "ensf" ]; then
 elif [ $WGF = "firewx" ]; then
   export ENSMEM_INDX=""
   export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}/lbcs)}"
-
+  export firewx_input_dir="${COMrrfs}/firewx_input"
 # Fire weather nest location from NAM
   export COMINnam=${COMINnam:-$(compath.py nam/${nam_ver})}
 

--- a/jobs/JRRFS_MAKE_OROG
+++ b/jobs/JRRFS_MAKE_OROG
@@ -78,9 +78,9 @@ This is the J-job script for the task that generates orography files.
 #-----------------------------------------------------------------------
 # Define COM directories
 #-----------------------------------------------------------------------
-# Send fix files to COMOUT
-export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}"
-mkdir -p "${COMOUT}" "${COMOUT}/fix"
+# Send fix files to COM
+export firewx_input_dir="${COMrrfs}/firewx_input"
+mkdir -p "${firewx_input_dir}"
 
 # Fire weather nest location from NAM
 export COMINnam=${COMINnam:-$(compath.py nam/${nam_ver})}

--- a/jobs/JRRFS_MAKE_SFC_CLIMO
+++ b/jobs/JRRFS_MAKE_SFC_CLIMO
@@ -80,9 +80,9 @@ climatology.
 #-----------------------------------------------------------------------
 # Define COM directories
 #-----------------------------------------------------------------------
-# Send fix files to COMOUT
-export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}"
-mkdir -p "${COMOUT}" "${COMOUT}/fix"
+# Send fix files to COM
+export firewx_input_dir="${COMrrfs}/firewx_input"
+mkdir -p "${firewx_input_dir}"
 
 # Fire weather nest location from NAM
 export COMINnam=${COMINnam:-$(compath.py nam/${nam_ver})}

--- a/scripts/exrrfs_make_grid.sh
+++ b/scripts/exrrfs_make_grid.sh
@@ -221,14 +221,14 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Copy the grid file from the run directory (DATA) to COMOUT directory. 
+# Copy the grid file from the run directory (DATA) to COM. 
 # In the process, rename it such that its name includes CRES and the halo width.
 #
 #-----------------------------------------------------------------------
 #
 grid_fp_orig="${grid_fp}"
 grid_fn="${CRES}${DOT_OR_USCORE}grid.tile${TILE_RGNL}.halo${NHW}.nc"
-grid_fp="${COMOUT}/fix/${grid_fn}"
+grid_fp="${firewx_input_dir}/${PDY}${cyc}/${grid_fn}"
 cpreq -p "${grid_fp_orig}" "${grid_fn}"
 cpreq -p "${grid_fn}" "${grid_fp}"
 #
@@ -284,7 +284,7 @@ for halo_num in "${halo_num_list[@]}"; do
   $APRUN ${EXECrrfs}/$pgm < ${nml_fn} >>$pgmout 2>${DATA}/errfile
   export err=$?; err_chk
   mv ${DATA}/errfile ${DATA}/errfile_shave_nh${halo_num}
-  cpreq -p ${shaved_fp} ${COMOUT}/fix
+  cpreq -p ${shaved_fp} ${firewx_input_dir}/${PDY}${cyc}
 done
 #
 #-----------------------------------------------------------------------
@@ -299,9 +299,9 @@ halo_num_list[${#halo_num_list[@]}]="${NHW}"
 for halo_num in "${halo_num_list[@]}"; do
   print_info_msg "Creating grid mosaic file with ${halo_num}-cell-wide halo..."  
   grid_fn="${CRES}${DOT_OR_USCORE}grid.tile${TILE_RGNL}.halo${halo_num}.nc"
-  grid_fp="${COMOUT}/fix/${grid_fn}"
+  grid_fp="${firewx_input_dir}/${PDY}${cyc}/${grid_fn}"
   mosaic_fn="${CRES}${DOT_OR_USCORE}mosaic.halo${halo_num}.nc"
-  mosaic_fp="${COMOUT}/fix/${mosaic_fn}"
+  mosaic_fp="${firewx_input_dir}/${PDY}${cyc}/${mosaic_fn}"
   mosaic_fp_prefix="${mosaic_fp%.*}"
 
   . prep_step

--- a/scripts/exrrfs_make_ics.sh
+++ b/scripts/exrrfs_make_ics.sh
@@ -179,7 +179,7 @@ case "$MACHINE" in
 esac
 
 if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
-  export FIXLAM=${COMOUT}/fix
+  export FIXLAM=${firewx_input_dir}/${PDY}${cyc}
 else
   export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
 fi

--- a/scripts/exrrfs_make_lbcs.sh
+++ b/scripts/exrrfs_make_lbcs.sh
@@ -223,7 +223,7 @@ case "$MACHINE" in
 esac
 
 if [ ${WGF} = "firewx" ]; then
-  export FIXLAM=${COMOUT}/../fix
+  export FIXLAM=${firewx_input_dir}/${PDY}${cyc}
 else
   export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
 fi

--- a/scripts/exrrfs_make_orog.sh
+++ b/scripts/exrrfs_make_orog.sh
@@ -109,12 +109,12 @@ cpreq -p ${TOPO_DIR}/gmted2010.30sec.int fort.235
 #
 #-----------------------------------------------------------------------
 #
-# Set the maximum value of halos in COMOUT
+# Set the maximum value of halos in COM
 mosaic_fn="${CRES}${DOT_OR_USCORE}mosaic.halo${NHW}.nc"
-mosaic_fp="${COMOUT}/fix/${mosaic_fn}"
+mosaic_fp="${firewx_input_dir}/${PDY}${cyc}/${mosaic_fn}"
 
 grid_fn=$( get_charvar_from_netcdf "${mosaic_fp}" "gridfiles" )
-grid_fp="${COMOUT}/fix/${grid_fn}"
+grid_fp="${firewx_input_dir}/${PDY}${cyc}/${grid_fn}"
 #
 #-----------------------------------------------------------------------
 #
@@ -160,7 +160,7 @@ cat "${input_redirect_fn}"
 #
 #   oro.${CRES}.tile7.nc
 #
-# and will place it in COMOUT.  Note that this file will include
+# and will place it in COM.  Note that this file will include
 # orography for a wide NHW cells around tile 7 (regional domain).
 #
 #-----------------------------------------------------------------------
@@ -202,13 +202,13 @@ suites=( "FV3_RAP" "FV3_HRRR" "FV3_HRRR_gf" "FV3_GFS_v15_thompson_mynn_lam3km" "
 if [[ ${suites[@]} =~ "${CCPP_PHYS_SUITE}" ]] ; then
   cd ${DATA}/temp_orog_data
   mosaic_fn_gwd="${CRES}${DOT_OR_USCORE}mosaic.halo${NH4}.nc"
-  mosaic_fp_gwd="${COMOUT}/fix/${mosaic_fn_gwd}"
+  mosaic_fp_gwd="${firewx_input_dir}/${PDY}${cyc}/${mosaic_fn_gwd}"
   grid_fn_gwd=$( get_charvar_from_netcdf "${mosaic_fp_gwd}" "gridfiles" )
   export err=$?
   if [ $err -ne 0 ]; then
     err_exit "get_charvar_from_netcdf function failed."
   fi
-  grid_fp_gwd="${COMOUT}/fix/${grid_fn_gwd}"
+  grid_fp_gwd="${firewx_input_dir}/${PDY}${cyc}/${grid_fn_gwd}"
   ls_fn="geo_em.d01.lat-lon.2.5m.HGT_M.nc"
   ss_fn="HGT.Beljaars_filtered.lat-lon.30s_res.nc"
   create_symlink_to_file target="${grid_fp_gwd}" symlink="${DATA}/temp_orog_data/${grid_fn_gwd}" relative="FALSE"
@@ -233,7 +233,7 @@ EOF
 
   cpreq -p "${CRES}${DOT_OR_USCORE}oro_data_ss.tile${TILE_RGNL}.halo${NH0}.nc" \
            "${CRES}${DOT_OR_USCORE}oro_data_ls.tile${TILE_RGNL}.halo${NH0}.nc" \
-           "${COMOUT}/fix"
+           "${firewx_input_dir}/${PDY}${cyc}"
 fi
 #
 #-----------------------------------------------------------------------
@@ -371,7 +371,7 @@ filtered_orog_fn_orig=$( basename "${filtered_orog_fp}" )
 filtered_orog_fn="${filtered_orog_fn_prefix}.${fn_suffix_with_halo}"
 filtered_orog_fp=$( dirname "${filtered_orog_fp}" )"/${filtered_orog_fn}"
 mv "${filtered_orog_fn_orig}" "${filtered_orog_fn}"
-cpreq -p "${filtered_orog_fp}" "${COMOUT}/fix/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NHW}.nc"
+cpreq -p "${filtered_orog_fp}" "${firewx_input_dir}/${PDY}${cyc}/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NHW}.nc"
 
 cd ${DATA}
 
@@ -395,7 +395,7 @@ print_info_msg "Filtering of orography complete."
 unshaved_fp="${filtered_orog_fp}"
 #
 # We perform the work in shave_dir, so change location to that directory.
-# Once it is complete, we move the resultant file from shave_dir to COMOUT.
+# Once it is complete, we move the resultant file from shave_dir to COM.
 #
 cd "${DATA}/shave_tmp"
 #
@@ -420,7 +420,7 @@ for halo_num in "${halo_num_list[@]}"; do
   $APRUN ${EXECrrfs}/$pgm < ${nml_fn} >>$pgmout 2>${DATA}/raw_topo/tmp/errfile
   export err=$?; err_chk
   mv ${DATA}/raw_topo/tmp/errfile ${DATA}/raw_topo/tmp/errfile_shave_${halo_num}
-  cpreq -p ${shaved_fp} ${COMOUT}/fix
+  cpreq -p ${shaved_fp} ${firewx_input_dir}/${PDY}${cyc}
 done
 
 cd ${DATA}

--- a/scripts/exrrfs_make_sfc_climo.sh
+++ b/scripts/exrrfs_make_sfc_climo.sh
@@ -92,8 +92,8 @@ input_slope_type_file="${SFC_CLIMO_INPUT_DIR}/slope_type.1.0.nc"
 input_soil_type_file="${input_soil_type_file}"
 input_vegetation_type_file="${input_vegetation_type_file}"
 input_vegetation_greenness_file="${SFC_CLIMO_INPUT_DIR}/vegetation_greenness.0.144.nc"
-mosaic_file_mdl="${COMOUT}/fix/${CRES}${DOT_OR_USCORE}mosaic.halo${NH4}.nc"
-orog_dir_mdl="${COMOUT}/fix"
+mosaic_file_mdl="${firewx_input_dir}/${PDY}${cyc}/${CRES}${DOT_OR_USCORE}mosaic.halo${NH4}.nc"
+orog_dir_mdl="${firewx_input_dir}/${PDY}${cyc}"
 orog_files_mdl="${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH4}.nc"
 halo=${NH4}
 maximum_snow_albedo_method="bilinear"
@@ -167,13 +167,13 @@ case "$GTYPE" in
 #
 "global" | "stretch" | "nested")
 #
-# Move all files ending with ".nc" to the COMOUT directory.
+# Move all files ending with ".nc" to the COM directory.
 # In the process, rename them so that the file names start with the C-
 # resolution (followed by an underscore).
 #
   for fn in *.nc; do
     if [[ -f $fn ]]; then
-      cpreq -p $fn ${COMOUT}/fix/${CRES}_${fn}
+      cpreq -p $fn ${firewx_input_dir}/${PDY}${cyc}/${CRES}_${fn}
     fi
   done
   ;;
@@ -192,12 +192,12 @@ case "$GTYPE" in
   for fn in *.halo.nc; do
     if [ -f $fn ]; then
       bn="${fn%.halo.nc}"
-      cpreq -p $fn ${COMOUT}/fix/${CRES}.${bn}.halo${NH4}.nc
+      cpreq -p $fn ${firewx_input_dir}/${PDY}${cyc}/${CRES}.${bn}.halo${NH4}.nc
     fi
   done
 #
 # Move all remaining files ending with ".nc" (which are the files for a
-# grid that doesn't include a halo) to the COMOUT directory.
+# grid that doesn't include a halo) to the COM directory.
 # In the process, rename them so that the file names start with the C-
 # resolution (followed by a dot) and contain the string "halo0" to indi-
 # cate that the grids in these files do not contain a halo.
@@ -205,7 +205,7 @@ case "$GTYPE" in
   for fn in *.nc; do
     if [ -f $fn ]; then
       bn="${fn%.nc}"
-      cpreq -p $fn ${COMOUT}/fix/${CRES}.${bn}.halo${NH0}.nc
+      cpreq -p $fn ${firewx_input_dir}/${PDY}${cyc}/${CRES}.${bn}.halo${NH0}.nc
     fi
   done
   ;;
@@ -220,18 +220,18 @@ esac
 #-----------------------------------------------------------------------
 #
 if [ $vegsoilt_frac = .true. ]; then
-  ncrename -d nx,lon -d ny,lat ${COMOUT}/fix/${CRES}.soil_type.tile7.halo0.nc
-  ncrename -d nx,lon -d ny,lat ${COMOUT}/fix/${CRES}.soil_type.tile7.halo4.nc
-  ncrename -d nx,lon -d ny,lat ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo0.nc
-  ncrename -d nx,lon -d ny,lat ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo4.nc
-  ncrename -d num_categories,num_veg_cat ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo0.nc
-  ncrename -d num_categories,num_veg_cat ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo4.nc
-  ncrename -d num_categories,num_soil_cat ${COMOUT}/fix/${CRES}.soil_type.tile7.halo0.nc
-  ncrename -d num_categories,num_soil_cat ${COMOUT}/fix/${CRES}.soil_type.tile7.halo4.nc
-  ncks -v vegetation_type_pct ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo0.nc -A ${COMOUT}/fix/${CRES}_oro_data.tile7.halo0.nc
-  ncks -v vegetation_type_pct ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo4.nc -A ${COMOUT}/fix/${CRES}_oro_data.tile7.halo4.nc
-  ncks -v soil_type_pct ${COMOUT}/fix/${CRES}.soil_type.tile7.halo0.nc -A ${COMOUT}/fix/${CRES}_oro_data.tile7.halo0.nc
-  ncks -v soil_type_pct ${COMOUT}/fix/${CRES}.soil_type.tile7.halo4.nc -A ${COMOUT}/fix/${CRES}_oro_data.tile7.halo4.nc
+  ncrename -d nx,lon -d ny,lat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo0.nc
+  ncrename -d nx,lon -d ny,lat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo4.nc
+  ncrename -d nx,lon -d ny,lat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo0.nc
+  ncrename -d nx,lon -d ny,lat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo4.nc
+  ncrename -d num_categories,num_veg_cat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo0.nc
+  ncrename -d num_categories,num_veg_cat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo4.nc
+  ncrename -d num_categories,num_soil_cat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo0.nc
+  ncrename -d num_categories,num_soil_cat ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo4.nc
+  ncks -v vegetation_type_pct ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo0.nc -A ${firewx_input_dir}/${PDY}${cyc}/${CRES}_oro_data.tile7.halo0.nc
+  ncks -v vegetation_type_pct ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo4.nc -A ${firewx_input_dir}/${PDY}${cyc}/${CRES}_oro_data.tile7.halo4.nc
+  ncks -v soil_type_pct ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo0.nc -A ${firewx_input_dir}/${PDY}${cyc}/${CRES}_oro_data.tile7.halo0.nc
+  ncks -v soil_type_pct ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo4.nc -A ${firewx_input_dir}/${PDY}${cyc}/${CRES}_oro_data.tile7.halo4.nc
 fi
 #
 #-----------------------------------------------------------------------
@@ -241,14 +241,14 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-cpreq -p ${COMOUT}/fix/${CRES}.facsf.tile7.halo4.nc ${COMOUT}/fix/${CRES}.facsf.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.maximum_snow_albedo.tile7.halo4.nc ${COMOUT}/fix/${CRES}.maximum_snow_albedo.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.slope_type.tile7.halo4.nc ${COMOUT}/fix/${CRES}.slope_type.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.snowfree_albedo.tile7.halo4.nc ${COMOUT}/fix/${CRES}.snowfree_albedo.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.soil_type.tile7.halo4.nc ${COMOUT}/fix/${CRES}.soil_type.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.substrate_temperature.tile7.halo4.nc ${COMOUT}/fix/${CRES}.substrate_temperature.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.vegetation_greenness.tile7.halo4.nc ${COMOUT}/fix/${CRES}.vegetation_greenness.tile7.nc
-cpreq -p ${COMOUT}/fix/${CRES}.vegetation_type.tile7.halo4.nc ${COMOUT}/fix/${CRES}.vegetation_type.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.facsf.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.facsf.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.maximum_snow_albedo.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.maximum_snow_albedo.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.slope_type.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.slope_type.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.snowfree_albedo.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.snowfree_albedo.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.soil_type.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.substrate_temperature.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.substrate_temperature.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_greenness.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_greenness.tile7.nc
+cpreq -p ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.halo4.nc ${firewx_input_dir}/${PDY}${cyc}/${CRES}.vegetation_type.tile7.nc
 
 #
 #-----------------------------------------------------------------------

--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -168,22 +168,30 @@ EOF
 
 #-----------------------------------------------------------------------
 #
-# GTG_rrfs config file in UPP source code sub directory
-#
-#-----------------------------------------------------------------------
-
-cp ${UPP_DIR}/sorc/ncep_post.fd/post_gtg.fd/gtg.config.rrfs ./gtg.config.rrfs
-cp ${UPP_DIR}/sorc/ncep_post.fd/post_gtg.fd/gtg.input.rrfs ./gtg.input.rrfs
-
-#-----------------------------------------------------------------------
-#
 # stage necessary files in run directory.
 #
 #-----------------------------------------------------------------------
 #
 cpreq -p ${UPP_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
 
-ln -snf ${FIX_UPP_CRTM}/*bin ./
+# get crtm fix files
+for what in "amsre_aqua" "imgr_g11" "imgr_g12" "imgr_g13" \
+    "imgr_g15" "imgr_mt1r" "imgr_mt2" "seviri_m10" \
+    "ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16" \
+    "ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" \
+    "tmi_trmm" "v.seviri_m10" "imgr_insat3d" "abi_gr" \
+    "ahi_himawari8" ; do
+    ln -s "${FIX_UPP_CRTM}/${what}.TauCoeff.bin" .
+    ln -s "${FIX_UPP_CRTM}/${what}.SpcCoeff.bin" .
+done
+
+for what in 'Aerosol' 'Cloud' ; do
+    ln -s "${FIX_UPP_CRTM}/${what}Coeff.bin" .
+done
+
+for what in  ${FIX_UPP_CRTM}/*Emis* ; do
+   ln -s $what .
+done
 
 if [ ${USE_CUSTOM_POST_CONFIG_FILE} = "TRUE" ]; then
 # For RRFS: use special postcntrl for fhr=0,1 to eliminate duplicate 
@@ -385,9 +393,11 @@ net4=$(echo ${NET:0:4} | tr '[:upper:]' '[:lower:]')
 if [ ${DO_ENSFCST} = "TRUE" ]; then
   prslev=${DATA}/${net4}.t${cyc}z.${mem_num}.prslev.${gridspacing}.f${fhr}.${gridname}.grib2
   natlev=${DATA}/${net4}.t${cyc}z.${mem_num}.natlev.${gridspacing}.f${fhr}.${gridname}.grib2
+  nbmfld=${DATA}/${net4}.t${cyc}z.${mem_num}.nbmfld.${gridspacing}.f${fhr}.${gridname}.grib2
 else
   prslev=${DATA}/${net4}.t${cyc}z.prslev.${gridspacing}.f${fhr}.${gridname}.grib2
   natlev=${DATA}/${net4}.t${cyc}z.natlev.${gridspacing}.f${fhr}.${gridname}.grib2
+  nbmfld=${DATA}/${net4}.t${cyc}z.nbmfld.${gridspacing}.f${fhr}.${gridname}.grib2
 fi
 
 if [ -f PRSLEV.GrbF${post_fhr} ]; then
@@ -449,6 +459,10 @@ fi # PRSLEV test
 if [ -f NATLEV.GrbF${post_fhr} ]; then
   wgrib2 NATLEV.GrbF${post_fhr} -set center 7 -grib ${natlev} >>$pgmout 2>>errfile
 fi
+
+if [ -f NBMFLD.GrbF${post_fhr} ]; then
+  wgrib2 NBMFLD.GrbF${post_fhr} -set center 7 -grib ${nbmfld} >>$pgmout 2>>errfile
+fi
 #
 #-----------------------------------------------------------------------
 #   copy post-processed grib2 files to COMOUT
@@ -459,6 +473,11 @@ cpreq -p ${prslev} ${COMOUT}
 if [[ -f ${natlev} ]]; then
   cpreq -p ${natlev} ${COMOUT}
 fi
+# NBMFLD file is only generated for RRFS and REFS
+if [[ -f ${nbmfld} ]]; then
+  cpreq -p ${nbmfld} ${COMOUT}
+fi
+
 # Only one latlons_corners file per cycle is needed in COMOUT - make this change later
 if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
   cpreq -p latlons_corners.txt.f${fhr} ${COMOUT}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The following changes are included in this PR: 
- The NBMFLD GRIB2 files are added for RRFS and REFS.  These files contain VVEL on isobaric levels, which are needed for NBM.
- The grid, orography, and surface climatology fix files for the fire weather nest have been relocated to COMrrfs/firewx_input/$PDY$cyc directories.  
- The removal of the GTG files from exrrfs_post.sh.  They are no longer needed since we are not generating the aviation products.
- Reducing the number of CRTM linked files from 1524 to 60 in exrrfs_post.sh.  The code I added is standard and used by other operational modeling systems (e.g. GFS).

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
These changes are staged in rrfs/para/packages/rrfs.v1.0 on Cactus so they will need to be tested.  Will coordinate the testing with @lgannoaa once he is finished with his current round of EE2 tests.  So don't merge this PR yet until the changes can be tested.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Resolves issues #1006 and #1030 
