### PR TITLE
[main] Restores change to 12 nodes for EnKF forecast

### DIFF
--- a/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_ensinit_master.ecf
+++ b/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_ensinit_master.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
-#PBS -l place=vscatter:excl,select=13:mpiprocs=64:ompthreads=2:ncpus=128:mem=500G
+#PBS -l walltime=00:33:00
+#PBS -l place=vscatter:excl,select=12:mpiprocs=64:ompthreads=2:ncpus=128:mem=500G
 #PBS -l debug=true
 
 model=rrfs

--- a/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_long_master.ecf
+++ b/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_long_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=04:45:00
-#PBS -l place=vscatter:excl,select=13:ncpus=128:ompthreads=2:mem=500G
+#PBS -l place=vscatter:excl,select=12:ncpus=128:ompthreads=2:mem=500G
 #PBS -l debug=true
 
 model=rrfs

--- a/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_master.ecf
+++ b/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_master.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
-#PBS -l place=vscatter:excl,select=13:ncpus=128:ompthreads=2:mem=500G
+#PBS -l walltime=00:33:00
+#PBS -l place=vscatter:excl,select=12:ncpus=128:ompthreads=2:mem=500G
 #PBS -l debug=true
 
 model=rrfs

--- a/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_spinup_master.ecf
+++ b/ecf/scripts/forecast/enkf/jrrfs_enkf_forecast_spinup_master.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
-#PBS -l place=vscatter:excl,select=13:mpiprocs=64:ompthreads=2:ncpus=128:mem=500GB
+#PBS -l walltime=00:33:00
+#PBS -l place=vscatter:excl,select=12:mpiprocs=64:ompthreads=2:ncpus=128:mem=500GB
 #PBS -l debug=true
 
 model=rrfs

--- a/parm/config/enkf/input.nml
+++ b/parm/config/enkf/input.nml
@@ -102,7 +102,7 @@
     kord_tm = -9
     kord_tr = 9
     kord_wz = 9
-    layout = 16, 48
+    layout = 16, 44
     make_nh = .true.
     mountain = .false.
     n_split = 5

--- a/parm/config/enkf/input.nml_restart
+++ b/parm/config/enkf/input.nml_restart
@@ -102,7 +102,7 @@
     kord_tm = -9
     kord_tr = 9
     kord_wz = 9
-    layout = 16, 48
+    layout = 16, 44
     make_nh = .false.
     mountain = .true.
     n_split = 5

--- a/parm/config/enkf/input.nml_restart_spinupcyc
+++ b/parm/config/enkf/input.nml_restart_spinupcyc
@@ -102,7 +102,7 @@
     kord_tm = -9
     kord_tr = 9
     kord_wz = 9
-    layout = 16, 48
+    layout = 16, 44
     make_nh = .false.
     mountain = .true.
     n_split = 5

--- a/parm/config/enkf/input.nml_spinupcyc
+++ b/parm/config/enkf/input.nml_spinupcyc
@@ -102,7 +102,7 @@
     kord_tm = -9
     kord_tr = 9
     kord_wz = 9
-    layout = 16, 48
+    layout = 16, 44
     make_nh = .true.
     mountain = .false.
     n_split = 5


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Drops node usage by the EnKF forecast from 13 to 12 (saving 30 total nodes across the DA ensemble).
- This PR modifies the ecf scripts and enkf input.nml parm files.
- Not changed at this stage, but which needs to be done to make this switch is to modify the layout in in the EnKF workflow.conf fix file. Have it on dogwood as /lfs/h2/emc/lam/noscrub/emc.lam/rrfs/para/packages/fix_rrfs_20250623/workflow/enkf/workflow.conf-matt

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- Made offline runs to confirm that things ran properly with new 16 x 44 + 64 layout. Timing results on dev-WCOSS were inconsistent, but best guess is that it will be about 1 minute slower than the 13 node configuration on average.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

