### PR TITLE
[dev-sci] Update RDASApp to PR474 and workflow managed JCB files

### DIFF
--- a/parm/rdas-atmosphere-templates-fv3_c13.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13.yaml
@@ -20,9 +20,7 @@ background_error_file: atmosphere_background_error_3dvar_gsibec
 
 # Global analysis things
 # ----------------------
-window_begin: @WINDOW_BEGIN@
-window_end: @WINDOW_END@
-window_length: PT3H
+window_length: PT6H
 bound_to_include: begin
 minimizer: DRPCG
 final_diagnostics_departures: oman
@@ -124,6 +122,42 @@ rain_number_concentration: rain_nc
 upward_air_velocity: W
 
 abi_simulated_channels: 7-16
+abi_active_channels: [-1, 1, 1, 1, -1, -1, -1, -1, -1, -1]
+abi_use_flag_clddet: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2]
+abi_obs_error: [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
+abi_obserr_bound_max: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+
+amsua_simulated_channels: 1-15
+amsua_obs_error: [2.500, 2.200, 2.000, 0.550, 0.300,
+                  0.230, 0.230, 0.250, 0.250, 0.350,
+                  0.400, 0.550, 0.800, 3.000, 3.500]
+amsua_obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
+
+amsua_n19_use_flag: [ 1,  1,  1,  1,  1, 1, -1, -1,  1,  1, -1,  -1,  -1,  1,  1 ]
+
+amsua_metop_b_use_flag: [ -1,  -1,  -1,  -1,  -1, -1, -1,  1,  1,  1,  -1,   -1,   -1, -1,  -1 ]
+
+amsua_metop_c_use_flag: [ 1,  1,  1,  1,  1, 1, 1,  1,  1,  1, -1,  -1,  -1, 1,  1 ]
+
+atms_simulated_channels: 1-22
+atms_obs_error: [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000 ]
+
+atms_obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
+              1.0, 1.0, 1.0, 1.0, 1.0,
+              1.0, 1.0, 1.0, 2.0, 4.5,
+              4.5, 2.0, 2.0, 2.0, 2.0,
+              2.0, 2.0]
+
+atms_npp_use_flag: [ 1,  1,  1,  1,  1, 1,  1,  1,  1,  1, 1,  1,  1, -1, -1, 1,  1,  1,  1,  1, 1,  1]
+
+atms_n20_use_flag: [ 1,  1,  1,  1,  1, 1,  1,  1,  1,  1, 1,  1,  1, -1, -1, 1,  1,  1,  1,  1, 1,  1]
+
+atms_n21_use_flag: [ 1,  1,  1,  1,  1, 1,  1,  1,  1,  1, 1,  1,  1, -1, -1, 1,  1,  1,  1,  1, 1,  1]
 
 # Background error
 atmosphere_bump_data_directory: DATA/berror
@@ -139,7 +173,7 @@ north_pole_lat: 51.499998
 north_pole_lon: 82.500018
 
 # Forecasting
-atmosphere_forecast_length: PT3H
+atmosphere_forecast_length: PT6H
 atmosphere_forecast_timestep: PT1H
 
 # Write final increment on Gaussian grid in variational
@@ -212,6 +246,13 @@ observations:
 
 # SatRad
 #- abi_g16
+#- abi_g18
+#- amsua_n19
+#- amsua_metop-b
+#- amsua_metop-c
+#- atms_npp
+#- atms_n20
+#- atms_n21
 
 # Analysis iuse flag (default: passivate)
 # Upper-air conventional
@@ -277,6 +318,13 @@ iuse_satwnd_winds_245_272: accept
 
 # SatRad
 iuse_abi_g16: accept
+iuse_abi_g18: accept
+iuse_amsua_n19: accept
+iuse_amsua_metop-b: accept
+iuse_amsua_metop-c: accept
+iuse_atms_npp: accept
+iuse_atms_n20: accept
+iuse_atms_n21: accept
 
 crtm_coefficient_path: "Data/crtm"
 

--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -332,8 +332,6 @@ cp ${PARMdir}/rdas-atmosphere-templates-fv3_c13.yaml .
 cp ${USHdir}/run_jcb.py .
 
 #sed - rdas-atmosphere-templates.yaml
-WIN_BEG=$(date -u -d "${YYYY}-${MM}-${DD} ${HH}:00:00 UTC -1 hour -30 minutes" +"%Y-%m-%dT%H:%M:%SZ")
-WIN_END=$(date -u -d "${YYYY}-${MM}-${DD} ${HH}:00:00 UTC +1 hour +30 minutes" +"%Y-%m-%dT%H:%M:%SZ")
 # set other placeholders
 WIN_ISO="${YYYY}-${MM}-${DD}T${HH}:00:00Z"
 WIN_PREFIX="${YYYY}${MM}${DD}.${HH}0000."
@@ -343,8 +341,6 @@ jedi_yaml="jedivar.yaml"
 
 # do replacements
 sed -i \
-  -e "s|@WINDOW_BEGIN@|'${WIN_BEG}'|" \
-  -e "s|@WINDOW_END@|'${WIN_END}'|" \
   -e "s|@ATMOSPHERE_BACKGROUND_TIME_ISO@|'${WIN_ISO}'|" \
   -e "s|@ATMOSPHERE_BACKGROUND_TIME_PREFIX@|'${WIN_PREFIX}'|" \
   -e "s|@SUFFIX@|${SUFFIX}|g" \
@@ -580,9 +576,6 @@ cp analysis_jedi.fv_tracer.res.nc   ${bkpath}/fv_tracer.res.tile1.nc
 #cp analysis_jedi.sfc_data.nc        ${bkpath}/sfc_data.nc
 #cp analysis_jedi.phy_data.nc        ${bkpath}/phy_data.nc
 #cp analysis_jedi.coupler.res        ${bkpath}/coupler.res
-
-# Temporary solution: Use sfc from gsi. Likely just need to add more state vars to jedi.
-cp ${bkpath}/../INPUT.gsi/sfc_data.nc ${bkpath}/sfc_data.nc
 
 # touch a file in INPUT.jedi its clear if jedi/gsi analysis restarts were used
 touch ${bkpath}/jedi

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -68,7 +68,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/RDASApp
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = bb61962
+hash = 58b6b5a
 local_path = RDASApp
 required = True
 

--- a/ush/run_jcb.py
+++ b/ush/run_jcb.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import yaml
+import re
 from datetime import datetime, timedelta
 from jcb import render
 from wxflow import parse_j2yaml
@@ -13,9 +14,17 @@ def update_cycle_times(config, cycle_str):
     iso_str = cycle_time.strftime("%Y-%m-%dT%H:%M:%SZ")
     prefix_str = cycle_time.strftime("%Y%m%d.%H%M%S.")
 
+    # Extract numeric value from window_length (default to 6 if missing)
+    window_len_str = config.get("window_length", "PT6H")
+    match = re.search(r"PT(\d+)H", window_len_str)
+    window_len_hrs = int(match.group(1)) if match else 6
+
+    # Divide by 2 for symmetric window around the cycle
+    half_window = window_len_hrs / 2
+
     # Example: window_begin is 3h before cycle
-    config["window_begin"] = (cycle_time - timedelta(hours=1.5)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    config["window_end"] = (cycle_time + timedelta(hours=1.5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    config["window_begin"] = (cycle_time - timedelta(hours=half_window)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    config["window_end"] = (cycle_time + timedelta(hours=half_window)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return config
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Update the RDASApp hash to [58b6b5a](https://github.com/NOAA-EMC/RDASApp/commit/58b6b5a01d485151af5dca451c651797f21d6a66) which added additional satrad *.j2 obs space yaml templates.
- Updated the `run_jcb.py` and `rdas-atmosphere-templates-fv3_c13.yaml` maintained in the workflow to match the updates in that PR.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

