### PR TITLE
Hotfix - change FCST_DT from 20s to 15s for conus3km to resolve MPAS integration instability

### DIFF
--- a/workflow/config_resources/config.meshdep
+++ b/workflow/config_resources/config.meshdep
@@ -20,7 +20,7 @@ if [[ ${MESH_NAME} == "conus12km" ]]; then
   export MPASSIT_REF_LON=-97.5
 
 elif [[ ${MESH_NAME} == "conus3km" ]]; then
-  export FCST_DT=20
+  export FCST_DT=15
   export FCST_SUBSTEPS=4
   export FCST_RADT=15
   export FCST_PIO_NUM_IOTASKS=40


### PR DESCRIPTION
As documented in https://github.com/ufs-community/MPAS-Model/issues/178, MPAS-Model crashes when running conus3km forecasts. Changing dt from 20s to 15s solved the crashes.

A few users have also reported conus3k crashes in their retros. This PR is a hotfix for this issue.

@Junjun-NOAA and @chunhuazhou have conducted extensive retros and confirmed that dt=15s is a good solution to move forward.