### PR TITLE
[rrfs-mpas-jedi] Fix download time out in offline domain check in ioda_bufr

### DIFF
--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -118,7 +118,7 @@ for ioda_file in ioda*nc; do
   #if [[ "${ioda_file}" == *abi* || "${ioda_file}" == *atms* || "${ioda_file}" == *cris* ]]; then
   if [[ "${ioda_file}" == *abi* ]]; then
     echo " ${ioda_file} ioda file detected: running offline_domain_check_satrad.py"
-    ./offline_domain_check_satrad.py -o "${ioda_file}" -g "${grid_file}" -f -s 0.005
+    ./offline_domain_check_satrad.py -o "${ioda_file}" -g "${grid_file}" -s 0.005
     base_name=$(basename "$ioda_file" .nc)
     mv  "${base_name}_dc.nc" "${base_name}.nc"
   elif [[ "${ioda_file}" == *atms* || "${ioda_file}" == *cris* ]]; then


### PR DESCRIPTION
This PR is in response to a previous issue (https://github.com/NOAA-EMC/rrfs-workflow/issues/987) following comments from @SamuelDegelia-NOAA. 

## TESTS CONDUCTED: 
Machines/Platforms: Gaea C6
Test cases: 
A. 2024050700 - 2024050800 hourly for 12km GSIBEC 3dvar
Results: ioda_bufr run time reduced from ~40 min (2024050700-2024050705) to ~3 min (2024050706-2024050800). 

B. 2024050700 - 2024050706 hourly for 3km GSIBEC 3dvar (intended for the same 25 cycles, but fcst crashed at 2024050704)
Results: fixed time out crashes of ioda_bufr with run time ~23 min (2024050700-2024050706).

## ISSUE: 
- Fixes the issue(s) mentioned in #987 . 

## Participants
@SamuelDegelia-NOAA @guoqing-noaa 