### PR TITLE
[rrfs-nco] fix link target args in scripts/setup_ecf_links.sh

### DIFF
--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -46,15 +46,15 @@ cd ${ECF_DIR}/../fix/workflow/
 echo "point at proper workflow.conf version..."
   rm -f ./det/workflow.conf ./enkf/workflow.conf ./ensf/workflow.conf ./firewx/workflow.conf
 if [ ${resource_config} == "NCO" ]; then
-  ln -s ./det/workflow.conf_prod ./det/workflow.conf
-  ln -s ./enkf/workflow.conf_prod ./enkf/workflow.conf
-  ln -s ./ensf/workflow.conf_prod ./ensf/workflow.conf
-  ln -s ./firewx/workflow.conf_prod ./firewx/workflow.conf
+  ln -s ./workflow.conf_prod ./det/workflow.conf
+  ln -s ./workflow.conf_prod ./enkf/workflow.conf
+  ln -s ./workflow.conf_prod ./ensf/workflow.conf
+  ln -s ./workflow.conf_prod ./firewx/workflow.conf
 else
-  ln -s ./det/workflow.conf_dev ./det/workflow.conf
-  ln -s ./enkf/workflow.conf_dev ./enkf/workflow.conf
-  ln -s ./ensf/workflow.conf_dev ./ensf/workflow.conf
-  ln -s ./firewx/workflow.conf_dev ./firewx/workflow.conf
+  ln -s ./workflow.conf_dev ./det/workflow.conf
+  ln -s ./workflow.conf_dev ./enkf/workflow.conf
+  ln -s ./workflow.conf_dev ./ensf/workflow.conf
+  ln -s ./workflow.conf_dev ./firewx/workflow.conf
 fi
 
 # det prdgen files


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- fixed scripts/setup_ecf_links.sh to no longer create broken links to workflow.conf_{dev,prod} files.
  - relative paths used in link commands (`ln TARGET LINK_NAME`) are counterintuitive and the target argument is relative to the location where the link name will be created. 
  - existing script has targets defined as relative to working directory, but targets need to be changed to be in the same directory as the link name (i.e., no subdirectory).
- @lgannoaa Should confirm.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others:
  - Ops environment; jobs won't run without being able to locate workflow.conf

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

