### PR TITLE
[rrfs-mpas-jedi] change the NODES settings for the JEDIVAR and GETKF tasks on Ursa and Gaea

### DIFF
--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -103,6 +103,7 @@ case ${MACHINE} in
     export ACCOUNT="wrfruc"
     export QUEUE="batch"
     export PARTITION="u1-compute"
+    export NODES_JEDIVAR="<nodes>20:ppn=40</nodes>"
     ;;
   "jet")
     export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GFS"
@@ -132,6 +133,7 @@ case ${MACHINE} in
     export QUEUE="normal"
     export PARTITION="batch"
     export CLUSTER="c6"
+    export NODES_JEDIVAR="<nodes>20:ppn=40</nodes>"
     ;;
   "wcoss2")
     export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GFS"

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -93,6 +93,7 @@ case ${MACHINE} in
     export ACCOUNT="wrfruc"
     export QUEUE="batch"
     export PARTITION="u1-compute"
+    export NODES_GETKF="<nodes>20:ppn=40</nodes>"
     ;;
   "jet")
     export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GEFS"
@@ -122,6 +123,7 @@ case ${MACHINE} in
     export QUEUE="normal"
     export PARTITION="batch"
     export CLUSTER="c6"
+    export NODES_GETKF="<nodes>20:ppn=40</nodes>"
     ;;
   "wcoss2")
     export IC_EXTRN_MDL_BASEDIR="/lfs/h2/emc/lam/noscrub/RRFS2_RETRO_DATA/May2024/GEFS"


### PR DESCRIPTION
Here is a summary of node memory and cores of rrfs-workflow-supported platforms:
```
Gaea: 384GB, 192 core AMD EPYC Zen4 CPU
Ursa: 384GB, 192 core AMD Genoa 9654 CPU
Hera: 96GB,  40 core Intel SkyLake CPU 
kJet: 96GB,  40 core Intel SkyLake CPU

Orion:    192GB, 40 core Xeon Gold CPU
Hercules: 256GB, 80 core Xeon Platinum CPU
Derecho:  256GB, 128 core AMD EPYC Milan CPU
```
In the early stage, to make JEDI runs on Jet/Hera, we need to use a node setting of `80:ppn=10` to avoid OOM.
However, Gaea/Ursa node has 4 times memory than Jet/Hera, so we don't need 80 nodes to run JEDI tasks.
This PR changes the node settings to `20:ppn=40` for JEDI tasks on Gaea/Ursa to get better use of computing resources.

