### PR TITLE
hotfix the build failure on orion

### DIFF
--- a/modulefiles/rrfs/orion.intel.lua
+++ b/modulefiles/rrfs/orion.intel.lua
@@ -3,22 +3,21 @@ This module loads libraries for rrfs-workflow
 ]])
 
 whatis([===[Loads libraries for rrfs-workflow ]===])
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
-load("stack-intel/2021.9.0")
-load("stack-intel-oneapi-mpi/2021.9.0")
-load("intel-oneapi-compilers/2023.1.0")
-load("intel-oneapi-mpi/2021.9.0")
-load("cmake/3.23.1")
-load("parallel-netcdf/1.12.2")
-load("parallelio/2.5.10")
+load("stack-oneapi/2024.2.1")
+load("stack-intel-oneapi-mpi/2021.13")
+load("cmake/3.27.9")
+load("parallel-netcdf/1.12.3")
+load("parallelio/2.6.2")
 load("jasper/2.0.32")
+load("libpng/1.6.37")
 
 if mode() == "load" then
-  setenv("PIO", os.getenv("parallelio_ROOT"))
+  setenv("PNETCDF", os.getenv("parallel_netcdf_ROOT"))
 end
 if mode() == "unload" then
-  unsetenv("PIO")
+  unsetenv("PNETCDF")
 end
 
 setenv("CMAKE_C_COMPILER", "mpiicc")

--- a/sorc/build.mpas
+++ b/sorc/build.mpas
@@ -12,19 +12,28 @@ EXEC="${HOMErrfs}/sorc/MPAS-Model/init_atmosphere_model"
 EXEC2="${HOMErrfs}/sorc/MPAS-Model/atmosphere_model"
 
 compiler_str="intel-mpi"
-if [[ "${MACHINE}" == "wcoss2" ]]; then
-  BUILD_VERSION_FILE="${HOMErrfs}/versions/build.ver"
-  if [[ -f "${BUILD_VERSION_FILE}" ]]; then
-    source "${BUILD_VERSION_FILE}"
-  fi
-  compiler_str="ftn-wcoss2"
-elif [[ "${MACHINE}" == "derecho" ]]; then
-  compiler_str="ifort"
-elif [[ "${MACHINE}" == "gaea" ]]; then
-  compiler_str="ifort_icx"
-elif [[ "${MACHINE}" == "ursa" ]]; then
-  compiler_str="intel-mpi-ursa"
-fi
+case "${MACHINE}" in
+  wcoss2)
+    BUILD_VERSION_FILE="${HOMErrfs}/versions/build.ver"
+    if [[ -f "${BUILD_VERSION_FILE}" ]]; then
+      source "${BUILD_VERSION_FILE}"
+    fi
+    compiler_str="ftn-wcoss2"
+    ;;
+  derecho)
+    compiler_str="ifort"
+    ;;
+  ursa|orion|hercules)
+    compiler_str="intel-mpi-ursa"
+    ;;
+  gaea)
+    compiler_str="ifort_icx"
+    ;;
+  *)
+    echo "unsupported platforms: ${MACHINE}"
+    exit 1
+    ;;
+esac
 
 module purge                      
 module use "${HOMErrfs}/modulefiles"


### PR DESCRIPTION
`build.mpas` fails on Orion.
This PR provides a hotfix to this issue by updating the spack-stack to v1.9.3