### PR TITLE
[dev-sci] Change from error to warning if subset is missing for `bufr2ioda.x`

### DIFF
--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -196,7 +196,7 @@ for yamlfile in "${yaml_list[@]}"; do
     export err=$?
     if [ $err -ne 0 ]; then
       if grep -qF "No valid BUFR subsets were found" errfile; then
-        echo "WARN: ${message_type}: no valid BUFR subsets in input. Skipping this type." >> "${pgmout}"
+        echo "WARNING: ${message_type}: no valid BUFR subsets in input. Skipping this type." >> "${pgmout}"
         export err=0
       fi
     fi


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

After cycling the dev-sci simplified workflow, we found that the `ioda_bufr_prod` task can crash when a particular prepbufr subset is missing. In these cases, `bufr2ioda.x` throws the following error:

```
PRE-MAIN-ERROR Exception: BadValue: No valid BUFR subsets were found from your queries! Please make sure you are querying for valid subsets that exist in ./prepbufr. Otherwise there might be a problem with the BUFR file (no subsets). 
----- contents of errfile -----
terminate called after throwing an instance of 'eckit::BadValue'
  what():  BadValue: No valid BUFR subsets were found from your queries! Please make sure you are querying for valid subsets that exist in ./prepbufr. Otherwise there might be a problem with the BUFR file (no subsets).
```

This was observed sporadically when the `ascatw` subset was absent from the prepbufr file.

Since a missing subset is not a true processing failure, it is preferable to treat it as a warning and produce an empty IODA file rather than aborting the task. 

This PR updates `exrrfs_ioda_bufr.sh` to detect the "No valid BUFR subsets were found" message in the errfile output from `bufr2ioda.x` and reset the return code accordingly, allowing the workflow to continue while logging a warning.

## TESTS CONDUCTED: 
Tested this change by running the `ioda_bufr_prod` task on both cycles where this crash was originally found and cycles where the task completed successfully. Both tests were successful. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

## CONTRIBUTORS (optional): 
@delippi 

