### PR TITLE
[rrfs-mpas-jedi] Prevent crash in `offline_domain_check_satrad.py` when no obs are inside the domain

### DIFF
--- a/ush/offline_domain_check_satrad.py
+++ b/ush/offline_domain_check_satrad.py
@@ -14,7 +14,6 @@ import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.ticker as mticker
 from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
-from operator import itemgetter
 import shapely.speedups
 
 shapely.speedups.enable()


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR follows from #1072 to fix a crash in the offline domain check that can occur if there are no radiance obs inside the MPAS model domain. We now generate a warning message if no obs are found inside the domain. 

Note: the end result of this change will be the same in that only an empty IODA file gets created. But there will no longer be a confusing error and crash in the python code. 

## TESTS CONDUCTED: 
I tested this using some input IODA files from @keenaneure's retro case. I confirmed that the domain check no longer crashes on when run on `ioda_atms_n20.nc` and instead outputs the warning message. I also tested this on `ioda_abi_g16.nc` to confirm that it matches the domain checked file generated by the original version of the code.  

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [x] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [x] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
#1072 

## CONTRIBUTORS (optional): 
@keenaneure

