### PR TITLE
move the config sourcing to setup_rocoto.py

### DIFF
--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 #
 import os
-import shutil
 import stat
-from rocoto_funcs.base import header_begin, header_entities, header_end, source, \
+from rocoto_funcs.base import header_begin, header_entities, header_end, \
     wflow_begin, wflow_log, wflow_cycledefs, wflow_end
 from rocoto_funcs.smart_cycledefs import smart_cycledefs
 from rocoto_funcs.ungrib_ic import ungrib_ic

--- a/workflow/setup_rocoto.py
+++ b/workflow/setup_rocoto.py
@@ -36,7 +36,6 @@ if os.getenv('REALTIME', 'false').upper() == "TRUE":
     source(f"{HOMErrfs}/workflow/config_resources/config.realtime")
 if os.getenv("DO_CHEMISTRY", "FALSE").upper() == "TRUE":
     source(f"{HOMErrfs}/workflow/config_resources/config.chemistry")
-    shutil.copy(f'{HOMErrfs}/workflow/config_resources/config.chemistry', f'{expdir}/config/config.chemistry')  # save a copy for reference
     if "smoke" in os.getenv('CHEM_GROUPS', 'smoke'):
         CHEM_INPUT = os.getenv('CHEM_INPUT', 'CHEM_INPUT_undefined')
         COMROOT = os.getenv('COMROOT', 'COMROOT_undefined')


### PR DESCRIPTION
Things have changed from the early design and it is now a more natural choice and more reasonable to source the config files in the `setup_rocoto.py` step. 