### PR TITLE
remove the hardcoded use of the `intel` compilers

### DIFF
--- a/sorc/build.mpas
+++ b/sorc/build.mpas
@@ -4,6 +4,7 @@ set -x
 date
 rundir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 HOMErrfs="$(dirname "$rundir")"
+COMPILER=${COMPILER:-intel}
 
 source "${HOMErrfs}/workflow/tools/detect_machine.sh"
 source "${HOMErrfs}/workflow/tools/init.sh"
@@ -33,7 +34,7 @@ esac
 
 module purge                      
 module use "${HOMErrfs}/modulefiles"
-module load "rrfs/${MACHINE}.intel"
+module load "rrfs/${MACHINE}.${COMPILER}"
 module list
 
 cd "${HOMErrfs}/sorc/MPAS-Model" || exit 1

--- a/sorc/build.rank_run
+++ b/sorc/build.rank_run
@@ -4,6 +4,7 @@ set -x
 date
 rundir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 HOMErrfs="$(dirname "$rundir")"
+COMPILER=${COMPILER:-intel}
 
 source "${HOMErrfs}/workflow/tools/detect_machine.sh"
 source "${HOMErrfs}/workflow/tools/init.sh"
@@ -13,7 +14,7 @@ EXEC="${HOMErrfs}/sorc/rank_run/build/rank_run.x"
 set +x
 module purge
 module use "${HOMErrfs}/modulefiles"
-module load "rrfs/${MACHINE}.intel"
+module load "rrfs/${MACHINE}.${COMPILER}"
 module list
 set -x
 

--- a/sorc/build.wps
+++ b/sorc/build.wps
@@ -4,6 +4,7 @@ set -x
 date
 rundir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 HOMErrfs="$(dirname "$rundir")"
+COMPILER=${COMPILER:-intel}
 
 source "${HOMErrfs}/workflow/tools/detect_machine.sh"
 source "${HOMErrfs}/workflow/tools/init.sh"
@@ -20,7 +21,7 @@ fi
 set +x
 module purge                      
 module use "${HOMErrfs}/modulefiles"
-module load "rrfs/${MACHINE}.intel"
+module load "rrfs/${MACHINE}.${COMPILER}"
 module load netcdf
 module list
 set -x

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -5,7 +5,7 @@
 declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]: '
 set -x
 #
-#source ${EXPDIR}/exp.setup
+COMPILER=${COMPILER:-intel}
 # tweaks for non-NCO runs
 COMMAND=$1  #get the J-JOB name
 task_id=${COMMAND#*_} # remove the "JRRFS_" part
@@ -39,7 +39,7 @@ case ${task_id} in
   ioda_bufr)
     module purge
     module use "${HOMErrfs}/sorc/RDASApp/modulefiles"
-    module load "RDAS/${MACHINE}.intel"
+    module load "RDAS/${MACHINE}.${COMPILER}"
     if [[ ${MACHINE} == "wcoss2" ]]; then
       # spack-stack does not include these python modules on wcoss2
       # so we use a workaround of loading an existing python virtual environment
@@ -52,30 +52,30 @@ case ${task_id} in
     ;;
   ungrib)
     module purge
-    module load "rrfs/${MACHINE}.intel"
+    module load "rrfs/${MACHINE}.${COMPILER}"
     module load wgrib2
     ;;
   prep_ic)
     module purge
-    module load "rrfs/${MACHINE}.intel"
+    module load "rrfs/${MACHINE}.${COMPILER}"
     module load nco
     ;;
   jedivar|getkf*)
     module purge
     module use "${HOMErrfs}/sorc/RDASApp/modulefiles"
-    module load "RDAS/${MACHINE}.intel"
+    module load "RDAS/${MACHINE}.${COMPILER}"
     export LD_LIBRARY_PATH=${HOMErrfs}/sorc/RDASApp/build/lib64:${LD_LIBRARY_PATH}
     ;;
   ioda_mrms_refl)
     module purge
     module use "${HOMErrfs}/sorc/RDASApp/modulefiles"
-    module load "RDAS/${MACHINE}.intel"
+    module load "RDAS/${MACHINE}.${COMPILER}"
     export LD_LIBRARY_PATH=${HOMErrfs}/sorc/RDASApp/build/lib64:${LD_LIBRARY_PATH}
     ;;
   nonvar_bufrobs|nonvar_reflobs|nonvar_cldana)
     module purge
     module use "${HOMErrfs}/sorc/RRFS_UTILS/modulefiles"
-    module load "build_${MACHINE}_intel"
+    module load "build_${MACHINE}_${COMPILER}"
     ;;
   mpassit)
     module purge
@@ -83,7 +83,7 @@ case ${task_id} in
     if [[ ${MACHINE} == "ursa" ]]; then
       module load "build.${MACHINE}.intel-llvm"
     else
-      module load "build.${MACHINE}.intel"
+      module load "build.${MACHINE}.${COMPILER}"
     fi
     ;;
   upp)
@@ -92,27 +92,27 @@ case ${task_id} in
     if [[ ${MACHINE} == "wcoss2" ]]; then
       # need to unset module versions sourced earlier and load a couple more
       source "${HOMErrfs}/versions/unset.ver"
-      module load "${MACHINE}_intel"
+      module load "${MACHINE}_${COMPILER}"
       module load libjpeg/9c
       module load libfabric/1.20.1
     else
-      module load "${MACHINE}_intel"
+      module load "${MACHINE}_${COMPILER}"
     fi
     ;;
   recenter)
     module purge
     module use "${HOMErrfs}/sorc/RRFS_UTILS/modulefiles"
-    module load "build_${MACHINE}_intel"
-    module load "rrfs/${MACHINE}.intel"
+    module load "build_${MACHINE}_${COMPILER}"
+    module load "rrfs/${MACHINE}.${COMPILER}"
     ;;
   ensmean)
     module purge
-    module load "rrfs/${MACHINE}.intel"
+    module load "rrfs/${MACHINE}.${COMPILER}"
     module load nco
     ;;
   *)
     module purge
-    module load "rrfs/${MACHINE}.intel"
+    module load "rrfs/${MACHINE}.${COMPILER}"
     module load nco
     ;;
 esac


### PR DESCRIPTION
I got feedback that rrfs-workflow hardcoded the use of `intel` compilers and does not have the flexibility to use GNU compilers. Actually rrfs-workflow is capable of handling different type of compilers, `intel`, `gnu` or others, but we just have not paid attention to this yet.

This PR removes the hardcoded use of the `intel` compilers and enables the use of other types of compilers (such as `gnu`).
