### PR TITLE
[dev-sci] Hotfix to actually check if cycle is a cold start before exiting 

### DIFF
--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -1029,7 +1029,7 @@ EOF
 #
 #-----------------------------------------------------------------------
 #
-if [ ${DO_DACOLD} = "FALSE" ] && [ ${BKTYPE} -eq 1 ]; then
+if [[ "${DO_DACOLD}" = "FALSE" && "${BKTYPE}" -eq 1 ]]; then
   echo "Not performing DA for cold cycles - do early clean exit"
   exit 0
 fi

--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -500,7 +500,7 @@ cp ${FIX_JEDI}/${PREDEF_GRID_NAME}/mgbf_p196_14x14.nml .
 #
 #-----------------------------------------------------------------------
 #
-if [ ${DO_DACOLD} = "FALSE" ] && [ ${BKTYPE} -eq 1 ]; then
+if [[ "${DO_DACOLD}" = "FALSE" && "${BKTYPE}" -eq 1 ]]; then
   echo "Not performing DA for cold cycles - do early clean exit"
   exit 0
 fi


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR fixes a bug introduced in #1098 when adding the option to skip DA during cold start cycles. The logic only checked whether `DO_DACOLD = "FALSE"` before exiting the task, without verifying that the current cycle was actually a cold start. As a result, setting `DO_DACOLD = "FALSE"` caused all DA to be skipped, including for warm start cycles.

The updated logic now also checks the cycle’s `BKTYPE` to ensure we only skip DA when the cycle is truly a cold start. Apologies for missing this before! 

## TESTS CONDUCTED: 
Tested by running on both cold-start and warn-start cycles this time...

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

