### PR TITLE
[dev-sci] Add GSI and JEDI log files to COMOUT for archiving

### DIFF
--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -1053,8 +1053,7 @@ if [ -r ${FIX_GSI}/${PREDEF_GRID_NAME}/xnorm_new.240.1351.1976 ] && [ -r ${FIX_G
 fi
 
 $APRUN ./$pgm < gsiparm.anl >>$pgmout 2>errfile
-cp $pgmout rrfs.t${HH}z.gsiout.tm00
-cp $pgmout ${COMOUT}/gsi_${YYYYMMDDHH}.log
+cp $pgmout ${COMOUT}/rrfs.t${HH}z.gsiout.tm00
 export err=$?; err_chk
 mv errfile errfile_gsi
 

--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -514,7 +514,8 @@ cp "${jedi_exec}" "${analworkdir}/${pgm}"
 . prep_step
 
 ${APRUN} ./$pgm jedivar.yaml >>$pgmout 2>errfile
-cp $pgmout ${COMOUT}/jedi_${YYYYMMDDHH}.log
+cp $pgmout ${COMOUT}/rrfs.t${HH}z.jediout.tm00
+cp rdas-atmosphere-templates-fv3_c13.yaml jedivar.yaml ${COMOUT}
 export err=$?; err_chk
 mv errfile errfile_jedi
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Quick PR to copy the GSI and JEDI log files to `COMOUT` for archiving. These files provide quick looks at the obs counts and are thus useful for archiving on HPSS. 

## TESTS CONDUCTED: 
Tested with ongoing retro experiments on WCOSS2.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

## CONTRIBUTORS (optional): 
@delippi
