### PR TITLE
Module update for special case with process_smoke job

### DIFF
--- a/ecf/scripts/init/det/jrrfs_det_process_smoke_spinup.ecf
+++ b/ecf/scripts/init/det/jrrfs_det_process_smoke_spinup.ecf
@@ -20,9 +20,8 @@ module load python/${python_ver}
 module load prod_util/${prod_util_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
-module load hdf5-D/${hdf5_ver}
-module load netcdf-D/${netcdf_ver}
-module load pnetcdf-D/${pnetcdf_ver}
+module load hdf5/1.12.2
+module load netcdf/4.7.4
 module load udunits/${udunits_ver}
 module load gsl/${gsl_ver}
 module load nco/${nco_ver}


### PR DESCRIPTION
det_process_smoke_spinup used python utility in special case uses regular implementation of the hdf/netcdf module.