### PR TITLE
Update UPP hash to include bug fix for surface specific humidity

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -26,7 +26,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = 86079d3
+hash = 9da2b88
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the UPP hash for the release/rrfs_v1 branch is updated to the most current version.  @JiliDong-NOAA added a bug fix for the surface specific humidity calculation with UPP PR [#1325](https://github.com/NOAA-EMC/UPP/pull/1325) (develop branch) and [#1334](https://github.com/NOAA-EMC/UPP/pull/1334) (release/rrfs_v1 branch).  Without this fix, the surface specific humidity is calculated incorrectly, and the values in the RRFS GRIB2 output are erroneous.  With the inclusion of this bug fix, the surface specific humidity is either read in from the history netcdf file (QS), or if it is not available in the model output it is set to undefined everywhere.
- The UPP code can be updated in the real-time parallel whenever.  I just wanted to submit a PR for this change now so that it is not forgotten about!

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
No tests with the RRFS workflow have been run with this change, but there won't be any impacts except to the surface specific humidity variable.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #1122 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@JiliDong-NOAA 
