### PR TITLE
Remove copy from sorc directory in post task

### DIFF
--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -89,7 +89,6 @@ Run command has not been specified for this machine:
     ;;
 
 esac
-UPP_DIR=${UPP_DIR:-$HOMErrfs/sorc/UPP}
 #
 #-----------------------------------------------------------------------
 #
@@ -172,7 +171,7 @@ EOF
 #
 #-----------------------------------------------------------------------
 #
-cpreq -p ${UPP_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
+cpreq -p ${FIX_UPP}/nam_micro_lookup.dat ./eta_micro_lookup.dat
 
 # get crtm fix files
 for what in "amsre_aqua" "imgr_g11" "imgr_g12" "imgr_g13" \


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the exrrfs_post.sh script is updated to no longer retrieve the nam_micro_lookup.dat fix file from the sorc/UPP/parm directory.  This solution is not preferable by NCO.  This fix file should be retrieved from the fix/upp directory within rrfs-workflow instead.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
This change will soon be tested on Cactus by @lgannoaa 

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #1124 