### PR TITLE
[rrfs-nco] Add ecf link script and fix typo in post manager

### DIFF
--- a/ecf/make_nco_links.sh
+++ b/ecf/make_nco_links.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# prior to running this script
+# generate ecf files using below script:
+# $PACKAGEHOME/ecf/setup_ecf_links.sh
+
+if [ $# -ne 1 ]; then 
+    echo "Provide one argument."
+    echo ""
+    echo "usage:"
+    echo "       $0 DIR_TO_ECF_SCRIPTS"
+    echo "example:"
+    echo "       ./make_nco_links.sh /lfs/h1/ops/para/packages/rrfs.v1.0.0/ecf/scripts"
+else
+    cd $1
+    mkdir det
+    ln -sf ../init/det/ ./det/init
+    ln -sf ../ics/det/ ./det/ics
+    ln -sf ../prep/det/ ./det/prep
+    ln -sf ../analysis/det/ ./det/analysis
+    ln -sf ../forecast/det/ ./det/forecast
+    ln -sf ../post/det/ ./det/post
+    ln -sf ../product/det/ ./det/prdgen
+    mkdir enkf
+    ln -sf ../ics/enkf/ ./enkf/ics
+    ln -sf ../init/enkf/ ./enkf/init
+    ln -sf ../prep/enkf/ ./enkf/prep
+    ln -sf ../analysis/enkf ./enkf/analysis
+    ln -sf ../forecast/enkf ./enkf/forecast
+    mkdir ensf
+    ln -sf ../ics/ensf ./ensf/ics
+    ln -sf ../prep/ensf ./ensf/prep
+    ln -sf ../analysis/ensf ./ensf/analysis
+    ln -sf ../forecast/ensf ./ensf/forecast
+    ln -sf ../post/ensf ./ensf/post
+    ln -sf ../product/ensf ./ensf/prdgen
+    mkdir firewx
+    ln -sf ../ics/firewx ./firewx/ics
+    ln -sf ../forecast/firewx ./firewx/forecast
+    ln -sf ../post/firewx ./firewx/post
+    ln -sf ../product/firewx ./firewx/prdgen
+fi

--- a/scripts/exrrfs_post_manager.sh
+++ b/scripts/exrrfs_post_manager.sh
@@ -214,7 +214,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
           if [ ${array_element_scan_release_ensf_post[$((10#$search_str))]} == "NO" ]; then
             array_element_scan_release_ensf_post[$((10#$search_str))]="found"
             ecflow_client --event release_ensf_post_mem${memuse}_f${fhr_3d}
-            it=1
+            ic=1
             continue
           fi
         else


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The current path structure of the .ecf scripts requires some linking for NCO's ecflow definition to find them. Adding a script that makes these links until ecf files are permanently relocated.
- Fix a typo in the post_manager script.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others:
  - ops parallel runs
 
## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

