### PR TITLE
[rrfs-nco] Add $envir and $rrfs_ver_2d to umbrella dir names

### DIFF
--- a/jobs/JRRFS_ANALYSIS_ENKF
+++ b/jobs/JRRFS_ANALYSIS_ENKF
@@ -52,10 +52,10 @@ export CDATE="${PDY}${cyc}"
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" == "spinup" ]; then
   export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}_spinup)}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 else
   export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 fi
   
 export FORECAST_INPUT_PRODUCT=${umbrella_forecast_data}

--- a/jobs/JRRFS_ANALYSIS_GSI
+++ b/jobs/JRRFS_ANALYSIS_GSI
@@ -66,32 +66,32 @@ export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 # Define umbrella data directories
 #-----------------------------------------------------------------------
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
     if [ "${MEM_TYPE}" = "MEAN" ]; then
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}/ensmean
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/ensmean
       export shared_output_data=${umbrella_analysis_data}/output/ensmean
     else
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
       export shared_output_data=${umbrella_analysis_data}/output/${mem_num}
     fi
   else
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
     export shared_output_data=${umbrella_analysis_data}/output
   fi
 else
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
   if [ "${MEM_TYPE}" = "MEAN" ]; then
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/ensmean
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/ensmean
     export shared_output_data=${umbrella_analysis_data}/output/ensmean
   else
     if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
       export shared_output_data=${umbrella_analysis_data}/output/${mem_num}
     else
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
       export shared_output_data=${umbrella_analysis_data}/output
     fi
   fi

--- a/jobs/JRRFS_ANALYSIS_GSIDIAG
+++ b/jobs/JRRFS_ANALYSIS_GSIDIAG
@@ -39,9 +39,9 @@ case "${WGF}" in
 esac
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 else
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 
 export DATA=${DATA:-${umbrella_analysis_data}/${jobid}}

--- a/jobs/JRRFS_ANALYSIS_NONVARCLD
+++ b/jobs/JRRFS_ANALYSIS_NONVARCLD
@@ -65,13 +65,13 @@ esac
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 if [ ${CYCLE_TYPE} = "spinup" ]; then
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 else
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 fi
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
   export umbrella_forecast_data=${umbrella_forecast_data}/${mem_num}

--- a/jobs/JRRFS_BLEND_ICS
+++ b/jobs/JRRFS_BLEND_ICS
@@ -30,9 +30,9 @@ fi
 export mem_num=m$(echo "${ENSMEM_INDX}")
 
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}/${mem_num}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}}
 else
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 export shared_output_data=${umbrella_ics_data}/ics
 
@@ -105,7 +105,7 @@ else
   exit 1
 fi
 
-export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}/${mem_num}}
+export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}}
 export shared_output_data=${umbrella_ics_data}/ics
 
 #-----------------------------------------------------------------------

--- a/jobs/JRRFS_BUFRSND
+++ b/jobs/JRRFS_BUFRSND
@@ -95,11 +95,11 @@ export mem_num=m$(echo "${ENSMEM_INDX}")
 CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export DO_ENSFCST=${DO_ENSFCST:-"FALSE"}
 export COMOUT=${COMOUT:-$(compath.py -o rrfs/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
-export umbrella_forecast_data="${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}"
+export umbrella_forecast_data="${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}"
 
 if [ "${DO_ENSFCST}" = "TRUE" ]; then
   export COMOUT=${COMOUT}/${mem_num}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
 fi
 
 # Location of dyn/phy files from forecast task

--- a/jobs/JRRFS_CALC_ENSMEAN
+++ b/jobs/JRRFS_CALC_ENSMEAN
@@ -81,10 +81,10 @@ export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}_spinup)}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 else
   export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 fi
 mkdir -p ${COMOUT}
 

--- a/jobs/JRRFS_FORECAST
+++ b/jobs/JRRFS_FORECAST
@@ -119,8 +119,8 @@ esac
 #-----------------------------------------------------------------------
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export CYCLE_SUBTYPE=${CYCLE_SUBTYPE:-empty}
-export umbrella_ics_data="${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}/ics"
-export umbrella_post_data=${DATAROOT}/rrfs_post_${cyc}_${rrfs_ver}/${WGF}
+export umbrella_ics_data="${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/ics"
+export umbrella_post_data=${DATAROOT}/rrfs_post_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 spinup_prefix=""
 spinup_postfix=""
 if [ ${CYCLE_TYPE} = "spinup" ]; then
@@ -134,9 +134,9 @@ else
 fi
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
   spinup_postfix="/${mem_num}"
-  export umbrella_ics_data="${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}/${mem_num}/ics"
+  export umbrella_ics_data="${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}/ics"
 fi
-export umbrella_forecast_data=${DATAROOT}/rrfs_forecast${spinup_prefix}_${cyc}_${rrfs_ver}/${WGF}${spinup_postfix}
+export umbrella_forecast_data=${DATAROOT}/rrfs_forecast${spinup_prefix}_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}${spinup_postfix}
 export FORECAST_INPUT_PRODUCT=${umbrella_forecast_data}/INPUT
 export shared_forecast_output_data=${umbrella_forecast_data}/output
 export shared_forecast_restart_data=${umbrella_forecast_data}/RESTART

--- a/jobs/JRRFS_MAKE_ICS
+++ b/jobs/JRRFS_MAKE_ICS
@@ -54,11 +54,11 @@ else
   export DO_ENSEMBLE="FALSE"
 fi
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}/${mem_num}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}}
 elif [ $WGF = "firewx" ]; then
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 else
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 export shared_output_data=${umbrella_ics_data}/ics
 #-----------------------------------------------------------------------

--- a/jobs/JRRFS_MAKE_LBCS
+++ b/jobs/JRRFS_MAKE_LBCS
@@ -94,7 +94,7 @@ if [ $WGF = "enkf" ] || [ $WGF = "ensf" ]; then
 else
   export ENSMEM_INDX=""
   export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${rrfs_ver}/${RUN}.${PDY}/${cyc}/lbcs)}"
-  export umbrella_lbcops_data=${umbrella_ops_data:-${DATAROOT}/rrfs_lbcops_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_lbcops_data=${umbrella_ops_data:-${DATAROOT}/rrfs_lbcops_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
   if [ -d ${umbrella_lbcops_data} ] && [ ${BCGRP} = "00" ]; then
     mv ${umbrella_lbcops_data} ${umbrella_lbcops_data}_$$
   fi

--- a/jobs/JRRFS_POST
+++ b/jobs/JRRFS_POST
@@ -100,17 +100,17 @@ export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export DO_ENSFCST=${DO_ENSFCST:-"FALSE"}
 export COMrrfs=${COMrrfs:-$(compath.py -o rrfs/${rrfs_ver})}
 export COMOUT=${COMOUT:-$(compath.py -o rrfs/${rrfs_ver}/${RUN}.${PDY}/${cyc})}
-export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 
 # Output from 15-min, 30-min, 45-min subhourly post jobs goes to umbrella data
-export umbrella_post_data=${DATAROOT}/rrfs_post_${cyc}_${rrfs_ver}/${WGF}
+export umbrella_post_data=${DATAROOT}/rrfs_post_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 
 # Post jobs do not run for spinup cycles, subhourly post jobs are only for deterministic runs
 if [ ${DO_ENSFCST} = "TRUE" ]; then
   export COMOUT=${COMOUT}/${mem_num}
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
 elif [ ${WGF} = "firewx" ]; then
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 fi
 
 # FSM job copies dyn/phy netcdf output and log files into shared_forecast_output_data directory

--- a/jobs/JRRFS_POST_MANAGER
+++ b/jobs/JRRFS_POST_MANAGER
@@ -17,8 +17,7 @@ export PARMrrfs=${PARMrrfs:-${HOMErrfs}/parm}
 export EXECrrfs=${EXECrrfs:-${HOMErrfs}/exec}
 export FIXrrfs=${FIXrrfs:-${HOMErrfs}/fix}
 
-export SHORTVER=$(echo "$rrfs_ver" | cut -d "." -f1-2)
-export umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${SHORTVER}/${WGF}
+export umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 
 #################################### 
 # Specify Timeout Behavior of Post

--- a/jobs/JRRFS_PREP_CYC
+++ b/jobs/JRRFS_PREP_CYC
@@ -53,9 +53,9 @@ else
   export DO_ENSEMBLE="FALSE"
 fi
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}/${mem_num}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}}
 else
-  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_ics_data=${umbrella_ics_data:-${DATAROOT}/rrfs_ics_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 
 # Umbrella Data for the initial condition that will be used in 
@@ -114,9 +114,9 @@ export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 export COMOUT=${COMOUT:-${COMrrfs}/${RUN}.${PDY}/${cyc}}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT=${COMOUT}_spinup
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 else
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 fi
 if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
   if [ ${MEMBER_NAME} = "ensmean" ] ; then
@@ -126,15 +126,15 @@ if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
   fi
   if [ "${CYCLE_TYPE}" = "spinup" ]; then
     if [ ${MEMBER_NAME} = "ensmean" ] ; then
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}/${MEMBER_NAME}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${MEMBER_NAME}
     else
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
     fi
   else
     if [ ${MEMBER_NAME} = "ensmean" ] ; then
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${MEMBER_NAME}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${MEMBER_NAME}
     else
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
     fi
   fi
 fi

--- a/jobs/JRRFS_PROCESS_BUFR
+++ b/jobs/JRRFS_PROCESS_BUFR
@@ -44,9 +44,9 @@ esac
 export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 else
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 export shared_output_data=${umbrella_init_data}/output
 

--- a/jobs/JRRFS_PROCESS_LIGHTNING
+++ b/jobs/JRRFS_PROCESS_LIGHTNING
@@ -46,9 +46,9 @@ esac
 export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 else
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 export shared_output_data=${umbrella_init_data}/output
 

--- a/jobs/JRRFS_PROCESS_RADAR
+++ b/jobs/JRRFS_PROCESS_RADAR
@@ -45,9 +45,9 @@ esac
 export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 else
-  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_init_data=${umbrella_init_data:-${DATAROOT}/rrfs_init_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
 fi
 export shared_output_data=${umbrella_init_data}/output
 

--- a/jobs/JRRFS_RECENTER
+++ b/jobs/JRRFS_RECENTER
@@ -81,12 +81,12 @@ export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export COMrrfs=$(compath.py -o ${NET}/${rrfs_ver})
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
   export COMOUT="${COMrrfs}/enkfrrfs.${PDY}/${cyc}_spinup"
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
-  export CRTL_CENTER=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/det
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
+  export CRTL_CENTER=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det
 else
   export COMOUT="${COMrrfs}/enkfrrfs.${PDY}/${cyc}"
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
-  export CRTL_CENTER=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
+  export CRTL_CENTER=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det
 fi
 mkdir -p "${COMOUT}"
 

--- a/jobs/JRRFS_SAVE_DA_OUTPUT
+++ b/jobs/JRRFS_SAVE_DA_OUTPUT
@@ -96,7 +96,7 @@ if [ ${WGF} == "ensf" ]; then
 else
   export COMOUT="${COMrrfs}/${RUN}.${PDY}/${cyc}/${mem_num}/forecast"
 fi
-export umbrella_forecast_data="${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}/INPUT"
+export umbrella_forecast_data="${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}/INPUT"
 export DATA=${DATA:-${DATAROOT}/${jobid}}
 mkdir -p ${COMOUT}/DA_OUTPUT
 

--- a/jobs/JRRFS_SAVE_RESTART
+++ b/jobs/JRRFS_SAVE_RESTART
@@ -54,16 +54,16 @@ export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 export CYCLE_SUBTYPE=${CYCLE_SUBTYPE:-empty}
 export COMrrfs=${COMrrfs:-$(compath.py -o rrfs/${rrfs_ver})}
 export SURFACE_DIR=${SURFACE_DIR:-${COMrrfs}/surface}
-export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
 
 if [ ${CYCLE_TYPE} = "spinup" ]; then
-  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+  export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
   fi
 else
   if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
   fi
 fi
 

--- a/jobs/JRRFS_UPDATE_LBC_SOIL
+++ b/jobs/JRRFS_UPDATE_LBC_SOIL
@@ -52,23 +52,23 @@ export COMrrfs=${COMrrfs:-$(compath.py -o ${NET}/${rrfs_ver})}
 # Define umbrella data directories
 #-----------------------------------------------------------------------
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_calc_ensmean_data=${umbrella_calc_ensmean_data:-${DATAROOT}/rrfs_calc_ensmean_spinup_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_calc_ensmean_data=${umbrella_calc_ensmean_data:-${DATAROOT}/rrfs_calc_ensmean_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
   if [ "${DO_ENSEMBLE}" = "TRUE" ] && [ ! "${MEM_TYPE}" = "MEAN" ]; then
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
   else
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/${WGF}
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
   fi
 else
-  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver}/${WGF}}
-  export umbrella_calc_ensmean_data=${umbrella_calc_ensmean_data:-${DATAROOT}/rrfs_calc_ensmean_${cyc}_${rrfs_ver}/${WGF}}
+  export umbrella_analysis_data=${umbrella_analysis_data:-${DATAROOT}/rrfs_analysis_gsi_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
+  export umbrella_calc_ensmean_data=${umbrella_calc_ensmean_data:-${DATAROOT}/rrfs_calc_ensmean_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}}
   if [ "${MEM_TYPE}" = "MEAN" ]; then
-    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/ensmean
+    export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/ensmean
   else
     if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}/${mem_num}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}/${mem_num}
     else
-      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/${WGF}
+      export umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/${WGF}
     fi
   fi
 fi

--- a/scripts/exrrfs_fsm.sh
+++ b/scripts/exrrfs_fsm.sh
@@ -430,7 +430,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_long} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_long for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/*coupler.res|wc -l)
     if [ ${cyc} == 00 ] || [ ${cyc} == 12 ]; then
       if [ ${restart_set_found} -ge 1 ]; then
@@ -458,7 +458,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_f1} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_f1 for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
     if [ ${restart_set_found} -ge 1 ]; then
       ecflow_client --event release_save_restart_f1
@@ -473,7 +473,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_spinup_f001} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_spinup_f001 for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
     if [ ${restart_set_found} -ge 1 ]; then
       ecflow_client --event release_save_restart_spinup_f001
@@ -488,7 +488,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_det_post_long} == "YES" ]; then
     echo "Proceeding with scan_release_det_post_long"
     source_file_found="YES"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/output
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/output
     # fhr cover 000~084
     for fhr in $(seq 0 84); do
       fhr_2d=$( printf "%02d" ${fhr} )
@@ -537,7 +537,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_ensf_post} == "YES" ]; then
     echo "Proceeding with scan_release_ensf_post"
     source_file_found="YES"
-    umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/ensf/
+    umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/ensf/
     # mems 1-5
     for mem in $(seq 1 5); do
       memuse=$( printf "%03d" ${mem} )
@@ -569,7 +569,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_det_post} == "YES" ]; then
     echo "Proceeding with scan_release_det_post"
     source_file_found="YES"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/output
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/output
     # fhr cover 000~018
     for fhr in $(seq 0 18); do
       fhr_2d=$( printf "%02d" ${fhr} )

--- a/scripts/exrrfs_recenter.sh
+++ b/scripts/exrrfs_recenter.sh
@@ -162,10 +162,10 @@ for imem in  $(seq 1 $nens)
 #
 #-----------------------------------------------------------------------
 #
-dynvarfile_control=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/INPUT/fv_core.res.tile1.nc
-tracerfile_control=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/INPUT/fv_tracer.res.tile1.nc
-dynvarfile_control_spinup=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/det/INPUT/fv_core.res.tile1.nc
-tracerfile_control_spinup=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/det/INPUT/fv_tracer.res.tile1.nc
+dynvarfile_control=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/INPUT/fv_core.res.tile1.nc
+tracerfile_control=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/INPUT/fv_tracer.res.tile1.nc
+dynvarfile_control_spinup=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det/INPUT/fv_core.res.tile1.nc
+tracerfile_control_spinup=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det/INPUT/fv_tracer.res.tile1.nc
 if [ -r "${dynvarfile_control_spinup}" ] && [ -r "${tracerfile_control_spinup}" ] && [[ ${DO_ENSFCST} != "TRUE" ]] ; then
   ln -sf ${ctrlpath}/INPUT/fv_core.res.tile1.nc  ./control_dynvar
   ln -sf ${ctrlpath}/INPUT/fv_tracer.res.tile1.nc   ./control_tracer

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export rrfs_ver=v1.0
+export rrfs_ver_2d=v1.0
 
 export bacio_ver=2.4.1
 export cray_mpich_ver=8.1.19


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- modified shared umbrella working directory names to include `$envir` (e.g. para, prod, test)
- created a new variable in versions/run.ver: `$rrfs_ver_2d`
- changed variable used to include two-digit version number in shared umbrella working directory names from `rrfs_ver` to `rrfs_ver_2d`
  - The former (`rrfs_ver`) is set to a three-digit version number in production ecflow header files, and we do not want a three-digit version number in these shared working directories.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others:
  - [x] ran for multiple cycles successfully in NCO's parallel

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #1147 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

