### PR TITLE
[rrfs-nco] Update rrfs_util to use ens_mean_recenter with improved MPI handling

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -46,7 +46,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 2f20426
+hash = 097381f
 local_path = rrfs_utl
 required = True
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
-Update rrfs_util to use ens_mean_recenter with improved MPI handling

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->


### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [X] Engineering tests
  - [ ] Non-DA engineering test
  - [X] DA engineering test
    - [X] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
Thanks to @hu5970 for updating rrfs_util lib.
