### PR TITLE
[rrfs-nco] update ensemble forecast restart namelist with correct physics options

### DIFF
--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -717,9 +717,14 @@ fi
 if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN_HRS -gt 6 ]; then
   flag_fcst_restart="TRUE"
   # Update FV3 input.nml for restart
+   mem_res="0"
+   if [ ${WGF} = "ensf" ]; then
+     mem_res=${ensmem_num}
+   fi
    $USHrrfs/update_input_nml.py \
     --path-to-defns ${FIXrrfs}/workflow/${WGF}/workflow.conf \
     --run_dir "${DATA}" \
+    --member ${mem_res} \
     --restart
   export err=$?
   if [ $err -ne 0 ]; then

--- a/scripts/exrrfs_process_smoke.sh
+++ b/scripts/exrrfs_process_smoke.sh
@@ -66,8 +66,6 @@ YYYYMMDD=${YYYYMMDDHH:0:8}
 HH=${YYYYMMDDHH:8:2}
 ${ECHO} ${YYYYMMDD}
 ${ECHO} ${HH}
-current_hh=`${DATE} -d ${HH} +"%H"`
-prev_hh=`${DATE} -d "$current_hh -24 hour" +"%H"`
 previous_day=$($NDATE -24 ${YYYYMMDDHH})
 nfiles=24
 smokeFile=SMOKE_RRFS_data_${YYYYMMDDHH}00.nc

--- a/ush/update_input_nml.py
+++ b/ush/update_input_nml.py
@@ -20,7 +20,7 @@ from python_utils import (
 from set_namelist_fcst_rst import set_namelist
 
 
-def update_input_nml(run_dir):
+def update_input_nml(run_dir,member):
     """Update the FV3 input.nml file in the specified run directory
 
     Args:
@@ -67,9 +67,24 @@ def update_input_nml(run_dir):
             "warm_start": True,
         }
 
-        settings["gfs_physics_nml"] = {
-           "sigmab_coldstart": False,
-        }
+        if int(member)==0:
+            settings["gfs_physics_nml"] = {
+               "sigmab_coldstart": False,
+            }
+        elif int(member)==1 or int(member)==3 or int(member)==4:
+            settings["gfs_physics_nml"] = {
+               "gf_coldstart": False,
+            }
+            settings["nam_stochy"] = {
+               "stochini": True,
+            }
+        else:
+            settings["gfs_physics_nml"] = {
+               "sigmab_coldstart": False,
+            }
+            settings["nam_stochy"] = {
+               "stochini": True,
+            }
 
         # settings["gfs_physics_nml"] = {
         #    "nstf_name": [2, 0, 0, 0, 0],
@@ -141,6 +156,14 @@ def parse_args(argv):
         help="Run directory."
     )
 
+
+    parser.add_argument(
+        "-m", "--member",
+        dest="member",
+        required=True,
+        help="members."
+    )
+
     parser.add_argument(
         "-p", "--path-to-defns",
         dest="path_to_defns",
@@ -162,5 +185,5 @@ if __name__ == "__main__":
     cfg = flatten_dict(cfg)
     import_vars(dictionary=cfg)
     update_input_nml(
-        run_dir=args.run_dir,
+        run_dir=args.run_dir,member=args.member
     )


### PR DESCRIPTION


- This PR addresses the physics option changes for ensemble forecast restart runs, as explained [here](https://docs.google.com/document/d/10TfqmWNHHJFd9WML0H5XcQ74zPnt-0s9ytmMCYfkDFw/edit?usp=sharing)  
- it also cleans up exrrfs_process_smoke.sh following the ndate changes by removing two unused variables
- please note that the restart namelist changes have been tested only at the single command line level, not within the full workflow  


## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

