### PR TITLE
[dev-sci] Hotfix for task dependencies when running radar DA 

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -1921,6 +1921,7 @@ MODULES_RUN_TASK_FP script.
          <taskdep task="&ANALYSIS_GSI_TN;_spinup{{ uscore_ensmem_name }}"/>
          <taskdep task="&ANALYSIS_JEDI_TN;_spinup{{ uscore_ensmem_name }}"/>
          {%- if do_envar_radar_ref and do_jedivar %}
+         <taskdep task="&HYBRID_RADAR_REF_TN;_spinup"/>
          <taskdep task="&HYBRID_RADAR_REF_JEDI_TN;_spinup"/>
          {%- endif %}
        </and>
@@ -2220,11 +2221,7 @@ MODULES_RUN_TASK_FP script.
       {%- elif do_dacycle and do_refl2tten%}
       <taskdep task="&RADAR_REFL2TTEN_TN;_spinup"/>
       {%- elif do_dacycle %}
-        {%- if do_envar_radar_ref and not do_envar_radar_ref_once %}
-        <taskdep task="&HYBRID_RADAR_REF_TN;_spinup"/>
-        {%- else  %}
-        <taskdep task="&POSTANAL_TN;_spinup{{ uscore_ensmem_name }}"/>
-        {%- endif %}
+      <taskdep task="&POSTANAL_TN;_spinup{{ uscore_ensmem_name }}"/>
       {%- elif do_enkfupdate or do_enkf_radar_ref %}
         <and>
           <or>
@@ -2994,6 +2991,7 @@ MODULES_RUN_TASK_FP script.
          <taskdep task="&ANALYSIS_GSI_TN;_prod{{ uscore_ensmem_name }}"/>
          <taskdep task="&ANALYSIS_JEDI_TN;_prod{{ uscore_ensmem_name }}"/>
          {%- if do_envar_radar_ref and do_jedivar %}
+         <taskdep task="&HYBRID_RADAR_REF_TN;_prod"/>
          <taskdep task="&HYBRID_RADAR_REF_JEDI_TN;_prod"/>
          {%- endif %}
        </and>
@@ -3451,11 +3449,7 @@ MODULES_RUN_TASK_FP script.
       {%- elif do_dacycle and do_refl2tten%}
       <taskdep task="&RADAR_REFL2TTEN_TN;_prod"/>
       {%- elif do_dacycle %}
-        {%- if do_envar_radar_ref and not do_envar_radar_ref_once %}
-        <taskdep task="&HYBRID_RADAR_REF_TN;_prod"/>
-        {%- else  %}
-        <taskdep task="&POSTANAL_TN;_prod"/>
-        {%- endif %}
+      <taskdep task="&POSTANAL_TN;_prod"/>
       {%- elif do_enkfupdate or do_enkf_radar_ref %}
         {%- if do_recenter %}
         <or>
@@ -3527,11 +3521,7 @@ MODULES_RUN_TASK_FP script.
       {%- elif do_dacycle and do_refl2tten%}
       <taskdep task="&RADAR_REFL2TTEN_TN;_prod"/>
       {%- elif do_dacycle %}
-        {%- if do_envar_radar_ref and not do_envar_radar_ref_once %}
-        <taskdep task="&HYBRID_RADAR_REF_TN;_prod"/>
-        {%- else  %}
-        <taskdep task="&POSTANAL_TN;_prod"/>
-        {%- endif %}
+      <taskdep task="&POSTANAL_TN;_prod"/>
       {%- elif do_enkfupdate or do_enkf_radar_ref %}
         {%- if do_recenter %}
         <or>

--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -700,7 +700,7 @@ if [[ ${anav_type} == "radardbz" || ${anav_type} == "conv_dbz" ]]; then
   addstr="${addstr} ice_wat=ice_wat+ice_wat_inc;"
   addstr="${addstr} liq_wat=liq_wat+liq_wat_inc;"
   addstr="${addstr} rainwat=rainwat+rainwat_inc;"
-  addstr="${addstr} snowwat=snowwat+ice_wat_inc;"
+  addstr="${addstr} snowwat=snowwat+snowwat_inc;"
   addstr="${addstr} graupel=graupel+graupel_inc;"
   varlist="${varlist},ice_wat_inc,liq_wat_inc,rainwat_inc,snowwat_inc,graupel_inc"
 fi


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

This PR fixes rocoto task dependencies related to `RUN_FCST_TN` and `POSTANAL_TN` when running radar DA.

Previously, `RUN_FCST_TN` depended only on `HYBRID_RADAR_REF_TN` when performing radar DA. However, the forecast task now needs to depend on `POSTANAL_TN` given that the latter is responsible for copying `INPUT.gsi` or `INPUT.jedi` into `INPUT`. Without this dependency, there were sporadic conditions where `INPUT` was being copied at the same time the forecast was starting, leading to missing input files and forecast crashes.

This PR also fixes a dependency issue for `POSTANAL_TN`. The previous configuration depended only on `HYBRID_RADAR_REF_JEDI_TN`, but it should also depend on `HYBRID_RADAR_REF_TN` (the GSI-based radar analysis task). This did not cause failures in practice because the JEDI task typically runs much more slowly, but it should be corrected for consistency and robustness.

## TESTS CONDUCTED: 
Tested by running a few retro cycles on WCOSS2 to confirm that `RUN_FCST_TN` does not start until `POSTANAL_TN` is done. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None


