### PR TITLE
RRFS Prep Cycle Hourly Recovery Capability for NCO

### DIFF
--- a/ecf/defs/rrfs_prod.def
+++ b/ecf/defs/rrfs_prod.def
@@ -57,7 +57,99 @@ suite rrfs_dev
                 event 35 release_enkf_prep_cyc_mem030
                 event 36 release_det_analysis_gsi
                 event 37 release_save_restart_long_1
+                event 500 release_save_restart_long_2
+                event 501 release_save_restart_long_3
                 event 38 release_save_restart_long_6
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 43 release_det_post_f000_00_36_long
                 event 44 release_det_post_f000_15_00_long
                 event 45 release_det_post_f000_30_00_long
@@ -2475,6 +2567,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_long_1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_long_1
+                task jrrfs_det_save_restart_long_2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_2
+                task jrrfs_det_save_restart_long_3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_3
                 task jrrfs_det_save_restart_long_6
                   edit FHR '006'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_long_6
@@ -2489,12 +2587,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem001==complete
+                task jrrfs_enkf_save_restart_long_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem001==complete
+                task jrrfs_enkf_save_restart_long_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem001==complete
                 task jrrfs_enkf_forecast_long_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_long_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem002==complete
+                task jrrfs_enkf_save_restart_long_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem002==complete
+                task jrrfs_enkf_save_restart_long_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem002==complete
                 task jrrfs_enkf_forecast_long_mem003
                   edit MEMBER_NAME '003'
@@ -2503,12 +2617,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem003==complete
+                task jrrfs_enkf_save_restart_long_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem003==complete
+                task jrrfs_enkf_save_restart_long_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem003==complete
                 task jrrfs_enkf_forecast_long_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_long_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem004==complete
+                task jrrfs_enkf_save_restart_long_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem004==complete
+                task jrrfs_enkf_save_restart_long_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem004==complete
                 task jrrfs_enkf_forecast_long_mem005
                   edit MEMBER_NAME '005'
@@ -2517,12 +2647,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem005==complete
+                task jrrfs_enkf_save_restart_long_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem005==complete
+                task jrrfs_enkf_save_restart_long_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem005==complete
                 task jrrfs_enkf_forecast_long_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_long_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem006==complete
+                task jrrfs_enkf_save_restart_long_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem006==complete
+                task jrrfs_enkf_save_restart_long_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem006==complete
                 task jrrfs_enkf_forecast_long_mem007
                   edit MEMBER_NAME '007'
@@ -2531,12 +2677,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem007==complete
+                task jrrfs_enkf_save_restart_long_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem007==complete
+                task jrrfs_enkf_save_restart_long_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem007==complete
                 task jrrfs_enkf_forecast_long_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_long_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem008==complete
+                task jrrfs_enkf_save_restart_long_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem008==complete
+                task jrrfs_enkf_save_restart_long_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem008==complete
                 task jrrfs_enkf_forecast_long_mem009
                   edit MEMBER_NAME '009'
@@ -2545,12 +2707,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem009==complete
+                task jrrfs_enkf_save_restart_long_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem009==complete
+                task jrrfs_enkf_save_restart_long_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem009==complete
                 task jrrfs_enkf_forecast_long_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_long_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem010==complete
+                task jrrfs_enkf_save_restart_long_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem010==complete
+                task jrrfs_enkf_save_restart_long_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem010==complete
                 task jrrfs_enkf_forecast_long_mem011
                   edit MEMBER_NAME '011'
@@ -2559,12 +2737,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem011==complete
+                task jrrfs_enkf_save_restart_long_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem011==complete
+                task jrrfs_enkf_save_restart_long_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem011==complete
                 task jrrfs_enkf_forecast_long_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_long_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem012==complete
+                task jrrfs_enkf_save_restart_long_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem012==complete
+                task jrrfs_enkf_save_restart_long_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem012==complete
                 task jrrfs_enkf_forecast_long_mem013
                   edit MEMBER_NAME '013'
@@ -2573,12 +2767,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem013==complete
+                task jrrfs_enkf_save_restart_long_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem013==complete
+                task jrrfs_enkf_save_restart_long_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem013==complete
                 task jrrfs_enkf_forecast_long_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_long_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem014==complete
+                task jrrfs_enkf_save_restart_long_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem014==complete
+                task jrrfs_enkf_save_restart_long_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem014==complete
                 task jrrfs_enkf_forecast_long_mem015
                   edit MEMBER_NAME '015'
@@ -2587,12 +2797,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem015==complete
+                task jrrfs_enkf_save_restart_long_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem015==complete
+                task jrrfs_enkf_save_restart_long_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem015==complete
                 task jrrfs_enkf_forecast_long_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_long_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem016==complete
+                task jrrfs_enkf_save_restart_long_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem016==complete
+                task jrrfs_enkf_save_restart_long_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem016==complete
                 task jrrfs_enkf_forecast_long_mem017
                   edit MEMBER_NAME '017'
@@ -2601,12 +2827,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem017==complete
+                task jrrfs_enkf_save_restart_long_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem017==complete
+                task jrrfs_enkf_save_restart_long_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem017==complete
                 task jrrfs_enkf_forecast_long_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_long_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem018==complete
+                task jrrfs_enkf_save_restart_long_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem018==complete
+                task jrrfs_enkf_save_restart_long_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem018==complete
                 task jrrfs_enkf_forecast_long_mem019
                   edit MEMBER_NAME '019'
@@ -2615,12 +2857,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem019==complete
+                task jrrfs_enkf_save_restart_long_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem019==complete
+                task jrrfs_enkf_save_restart_long_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem019==complete
                 task jrrfs_enkf_forecast_long_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_long_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem020==complete
+                task jrrfs_enkf_save_restart_long_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem020==complete
+                task jrrfs_enkf_save_restart_long_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem020==complete
                 task jrrfs_enkf_forecast_long_mem021
                   edit MEMBER_NAME '021'
@@ -2629,12 +2887,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem021==complete
+                task jrrfs_enkf_save_restart_long_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem021==complete
+                task jrrfs_enkf_save_restart_long_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem021==complete
                 task jrrfs_enkf_forecast_long_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_long_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem022==complete
+                task jrrfs_enkf_save_restart_long_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem022==complete
+                task jrrfs_enkf_save_restart_long_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem022==complete
                 task jrrfs_enkf_forecast_long_mem023
                   edit MEMBER_NAME '023'
@@ -2643,12 +2917,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem023==complete
+                task jrrfs_enkf_save_restart_long_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem023==complete
+                task jrrfs_enkf_save_restart_long_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem023==complete
                 task jrrfs_enkf_forecast_long_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_long_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem024==complete
+                task jrrfs_enkf_save_restart_long_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem024==complete
+                task jrrfs_enkf_save_restart_long_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem024==complete
                 task jrrfs_enkf_forecast_long_mem025
                   edit MEMBER_NAME '025'
@@ -2657,12 +2947,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem025==complete
+                task jrrfs_enkf_save_restart_long_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem025==complete
+                task jrrfs_enkf_save_restart_long_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem025==complete
                 task jrrfs_enkf_forecast_long_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_long_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem026==complete
+                task jrrfs_enkf_save_restart_long_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem026==complete
+                task jrrfs_enkf_save_restart_long_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem026==complete
                 task jrrfs_enkf_forecast_long_mem027
                   edit MEMBER_NAME '027'
@@ -2671,12 +2977,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem027==complete
+                task jrrfs_enkf_save_restart_long_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem027==complete
+                task jrrfs_enkf_save_restart_long_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem027==complete
                 task jrrfs_enkf_forecast_long_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_long_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem028==complete
+                task jrrfs_enkf_save_restart_long_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem028==complete
+                task jrrfs_enkf_save_restart_long_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem028==complete
                 task jrrfs_enkf_forecast_long_mem029
                   edit MEMBER_NAME '029'
@@ -2685,12 +3007,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_long_mem029==complete
+                task jrrfs_enkf_save_restart_long_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem029==complete
+                task jrrfs_enkf_save_restart_long_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_long_mem029==complete
                 task jrrfs_enkf_forecast_long_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_long_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_long_mem030==complete
+                task jrrfs_enkf_save_restart_long_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_long_mem030==complete
+                task jrrfs_enkf_save_restart_long_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_long_mem030==complete
               endfamily   # enkf
               family ensf
@@ -6303,6 +6641,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -6756,6 +7096,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -7303,6 +7649,98 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -7756,6 +8194,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -7767,12 +8211,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -7781,12 +8241,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -7795,12 +8271,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -7809,12 +8301,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -7823,12 +8331,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -7837,12 +8361,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -7851,12 +8391,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -7865,12 +8421,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -7879,12 +8451,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -7893,12 +8481,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -7907,12 +8511,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -7921,12 +8541,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -7935,12 +8571,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -7949,12 +8601,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -7963,12 +8631,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -8304,6 +8988,8 @@ suite rrfs_dev
                 event 32 release_enkf_prep_cyc_mem030
                 event 33 release_det_analysis_gsi
                 event 34 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 36 release_save_restart_spinup_f001
                 event 37 release_det_post_f000_00_36
                 event 38 release_det_post_f000_15_00
@@ -8799,6 +9485,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -9352,7 +10046,99 @@ suite rrfs_dev
                 event 30 release_enkf_prep_cyc_mem030
                 event 31 release_det_analysis_gsi
                 event 32 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 34 release_save_restart_spinup_f001
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -9840,6 +10626,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -9858,12 +10652,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -9872,12 +10682,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -9886,12 +10712,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -9900,12 +10742,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -9914,12 +10772,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -9928,12 +10802,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -9942,12 +10832,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -9956,12 +10862,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -9970,12 +10892,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -9984,12 +10922,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -9998,12 +10952,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -10012,12 +10982,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -10026,12 +11012,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -10040,12 +11042,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -10054,12 +11072,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -10393,6 +11427,8 @@ suite rrfs_dev
                 event 30 release_enkf_prep_cyc_mem030
                 event 31 release_det_analysis_gsi
                 event 32 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 34 release_save_restart_spinup_f001
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
@@ -10881,6 +11917,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -11449,7 +12493,99 @@ suite rrfs_dev
                 event 35 release_det_analysis_gsi
                 event 36 release_save_restart_spinup_f001
                 event 37 release_save_restart_long_1
+                event 500 release_save_restart_long_2
+                event 501 release_save_restart_long_3
                 event 39 release_save_restart_long_12
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 43 release_det_post_f000_00_36_long
                 event 44 release_det_post_f000_15_00_long
                 event 45 release_det_post_f000_30_00_long
@@ -13902,6 +15038,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_long_1
+                task jrrfs_det_save_restart_long_2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_2
+                task jrrfs_det_save_restart_long_3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_3
                 task jrrfs_det_save_restart_long_12
                   edit CYCLE_TYPE 'prod'
                   edit FHR '012'
@@ -13924,12 +15068,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -13938,12 +15098,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -13952,12 +15128,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -13966,12 +15158,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -13980,12 +15188,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -13994,12 +15218,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -14008,12 +15248,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -14022,12 +15278,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -14036,12 +15308,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -14050,12 +15338,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -14064,12 +15368,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -14078,12 +15398,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -14092,12 +15428,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -14106,12 +15458,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -14120,12 +15488,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
               family ensf
@@ -17709,6 +19093,8 @@ suite rrfs_dev
                 event 2 release_enkf_observer_gsi_ensmean
                 event 3 release_det_analysis_gsi
                 event 4 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 6 release_save_restart_spinup_f001
                 event 7 release_det_post_f000_00_36
                 event 8 release_det_post_f000_15_00
@@ -18474,6 +19860,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -19208,7 +20602,99 @@ suite rrfs_dev
                 event 30 release_enkf_prep_cyc_mem030
                 event 31 release_det_analysis_gsi
                 event 32 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 34 release_save_restart_spinup_f001
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -19696,6 +21182,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -19714,12 +21208,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -19728,12 +21238,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -19742,12 +21268,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -19756,12 +21298,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -19770,12 +21328,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -19784,12 +21358,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -19798,12 +21388,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -19812,12 +21418,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -19826,12 +21448,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -19840,12 +21478,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -19854,12 +21508,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -19868,12 +21538,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -19882,12 +21568,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -19896,12 +21598,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -19910,12 +21628,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -20250,6 +21984,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -20706,6 +22442,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -21253,6 +22995,98 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -21706,6 +23540,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -21717,12 +23557,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -21731,12 +23587,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -21745,12 +23617,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -21759,12 +23647,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -21773,12 +23677,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -21787,12 +23707,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -21801,12 +23737,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -21815,12 +23767,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -21829,12 +23797,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -21843,12 +23827,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -21857,12 +23857,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -21871,12 +23887,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -21885,12 +23917,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -21899,12 +23947,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -21913,12 +23977,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -22253,6 +24333,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -22706,6 +24788,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -23266,7 +25354,99 @@ suite rrfs_dev
                 event 34 release_enkf_prep_cyc_mem030
                 event 35 release_det_analysis_gsi
                 event 36 release_save_restart_long_1
+                event 500 release_save_restart_long_2
+                event 501 release_save_restart_long_3
                 event 37 release_save_restart_long_6
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 42 release_det_post_f000_00_36_long
                 event 43 release_det_post_f000_15_00_long
                 event 44 release_det_post_f000_30_00_long
@@ -25686,6 +27866,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_long_1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_long_1
+                task jrrfs_det_save_restart_long_2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_2
+                task jrrfs_det_save_restart_long_3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_3
                 task jrrfs_det_save_restart_long_6
                   edit FHR '006'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_long_6
@@ -25700,12 +27886,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -25714,12 +27916,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -25728,12 +27946,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -25742,12 +27976,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -25756,12 +28006,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -25770,12 +28036,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -25784,12 +28066,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -25798,12 +28096,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -25812,12 +28126,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -25826,12 +28156,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -25840,12 +28186,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -25854,12 +28216,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -25868,12 +28246,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -25882,12 +28276,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -25896,12 +28306,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
               family ensf
@@ -29514,6 +31940,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -29967,6 +32395,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -30514,6 +32948,98 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -30967,6 +33493,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -30978,12 +33510,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -30992,12 +33540,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -31006,12 +33570,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -31020,12 +33600,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -31034,12 +33630,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -31048,12 +33660,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -31062,12 +33690,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -31076,12 +33720,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -31090,12 +33750,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -31104,12 +33780,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -31118,12 +33810,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -31132,12 +33840,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -31146,12 +33870,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -31160,12 +33900,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -31174,12 +33930,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -31515,6 +34287,8 @@ suite rrfs_dev
                 event 32 release_enkf_prep_cyc_mem030
                 event 33 release_det_analysis_gsi
                 event 34 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 36 release_save_restart_spinup_f001
                 event 37 release_det_post_f000_00_36
                 event 38 release_det_post_f000_15_00
@@ -32010,6 +34784,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -32564,7 +35346,99 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_save_restart_spinup_f001
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 36 release_det_post_f000_00_36
                 event 37 release_det_post_f000_15_00
                 event 38 release_det_post_f000_30_00
@@ -33052,6 +35926,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -33070,12 +35952,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -33084,12 +35982,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -33098,12 +36012,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -33112,12 +36042,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -33126,12 +36072,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -33140,12 +36102,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -33154,12 +36132,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -33168,12 +36162,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -33182,12 +36192,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -33196,12 +36222,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -33210,12 +36252,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -33224,12 +36282,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -33238,12 +36312,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -33252,12 +36342,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -33266,12 +36372,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -33606,6 +36728,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_save_restart_spinup_f001
                 event 36 release_det_post_f000_00_36
                 event 37 release_det_post_f000_15_00
@@ -34094,6 +37218,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -34662,7 +37794,99 @@ suite rrfs_dev
                 event 35 release_det_analysis_gsi
                 event 36 release_save_restart_spinup_f001
                 event 37 release_save_restart_long_1
+                event 500 release_save_restart_long_2
+                event 501 release_save_restart_long_3
                 event 39 release_save_restart_long_12
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 43 release_det_post_f000_00_36_long
                 event 44 release_det_post_f000_15_00_long
                 event 45 release_det_post_f000_30_00_long
@@ -37116,6 +40340,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_long_1
+                task jrrfs_det_save_restart_long_2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_2
+                task jrrfs_det_save_restart_long_3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_long_3
                 task jrrfs_det_save_restart_long_12
                   edit CYCLE_TYPE 'prod'
                   edit FHR '012'
@@ -37138,12 +40370,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -37152,12 +40400,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -37166,12 +40430,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -37180,12 +40460,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -37194,12 +40490,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -37208,12 +40520,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -37222,12 +40550,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -37236,12 +40580,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -37250,12 +40610,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -37264,12 +40640,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -37278,12 +40670,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -37292,12 +40700,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -37306,12 +40730,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -37320,12 +40760,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -37334,12 +40790,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
               family ensf
@@ -40923,6 +44395,8 @@ suite rrfs_dev
                 event 2 release_enkf_observer_gsi_ensmean
                 event 3 release_det_analysis_gsi
                 event 4 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 6 release_save_restart_spinup_f001
                 event 7 release_det_post_f000_00_36
                 event 8 release_det_post_f000_15_00
@@ -41688,6 +45162,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -42423,7 +45905,99 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_save_restart_spinup_f001
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 36 release_det_post_f000_00_36
                 event 37 release_det_post_f000_15_00
                 event 38 release_det_post_f000_30_00
@@ -42911,6 +46485,14 @@ suite rrfs_dev
                   edit CYCLE_TYPE 'prod'
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit CYCLE_TYPE 'prod'
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
                 task jrrfs_det_forecast_spinup
                   edit CYCLE_TYPE 'spinup'
                   trigger ../../analysis/det/jrrfs_det_analysis_nonvarcld_spinup==complete
@@ -42929,12 +46511,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -42943,12 +46541,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -42957,12 +46571,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -42971,12 +46601,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -42985,12 +46631,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -42999,12 +46661,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -43013,12 +46691,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -43027,12 +46721,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -43041,12 +46751,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -43055,12 +46781,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -43069,12 +46811,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -43083,12 +46841,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -43097,12 +46871,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -43111,12 +46901,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -43125,12 +46931,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -43465,6 +47287,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -43918,6 +47742,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -44465,6 +48295,98 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
+                event 600 release_enkf_save_restart_001_f1
+                event 601 release_enkf_save_restart_001_f2
+                event 602 release_enkf_save_restart_001_f3
+                event 603 release_enkf_save_restart_002_f1
+                event 604 release_enkf_save_restart_002_f2
+                event 605 release_enkf_save_restart_002_f3
+                event 606 release_enkf_save_restart_003_f1
+                event 607 release_enkf_save_restart_003_f2
+                event 608 release_enkf_save_restart_003_f3
+                event 609 release_enkf_save_restart_004_f1
+                event 610 release_enkf_save_restart_004_f2
+                event 611 release_enkf_save_restart_004_f3
+                event 612 release_enkf_save_restart_005_f1
+                event 613 release_enkf_save_restart_005_f2
+                event 614 release_enkf_save_restart_005_f3
+                event 615 release_enkf_save_restart_006_f1
+                event 616 release_enkf_save_restart_006_f2
+                event 617 release_enkf_save_restart_006_f3
+                event 618 release_enkf_save_restart_007_f1
+                event 619 release_enkf_save_restart_007_f2
+                event 620 release_enkf_save_restart_007_f3
+                event 621 release_enkf_save_restart_008_f1
+                event 622 release_enkf_save_restart_008_f2
+                event 623 release_enkf_save_restart_008_f3
+                event 624 release_enkf_save_restart_009_f1
+                event 625 release_enkf_save_restart_009_f2
+                event 626 release_enkf_save_restart_009_f3
+                event 627 release_enkf_save_restart_010_f1
+                event 628 release_enkf_save_restart_010_f2
+                event 629 release_enkf_save_restart_010_f3
+                event 630 release_enkf_save_restart_011_f1
+                event 631 release_enkf_save_restart_011_f2
+                event 632 release_enkf_save_restart_011_f3
+                event 633 release_enkf_save_restart_012_f1
+                event 634 release_enkf_save_restart_012_f2
+                event 635 release_enkf_save_restart_012_f3
+                event 636 release_enkf_save_restart_013_f1
+                event 637 release_enkf_save_restart_013_f2
+                event 638 release_enkf_save_restart_013_f3
+                event 639 release_enkf_save_restart_014_f1
+                event 640 release_enkf_save_restart_014_f2
+                event 641 release_enkf_save_restart_014_f3
+                event 642 release_enkf_save_restart_015_f1
+                event 643 release_enkf_save_restart_015_f2
+                event 644 release_enkf_save_restart_015_f3
+                event 645 release_enkf_save_restart_016_f1
+                event 646 release_enkf_save_restart_016_f2
+                event 647 release_enkf_save_restart_016_f3
+                event 648 release_enkf_save_restart_017_f1
+                event 649 release_enkf_save_restart_017_f2
+                event 650 release_enkf_save_restart_017_f3
+                event 651 release_enkf_save_restart_018_f1
+                event 652 release_enkf_save_restart_018_f2
+                event 653 release_enkf_save_restart_018_f3
+                event 654 release_enkf_save_restart_019_f1
+                event 655 release_enkf_save_restart_019_f2
+                event 656 release_enkf_save_restart_019_f3
+                event 657 release_enkf_save_restart_020_f1
+                event 658 release_enkf_save_restart_020_f2
+                event 659 release_enkf_save_restart_020_f3
+                event 660 release_enkf_save_restart_021_f1
+                event 661 release_enkf_save_restart_021_f2
+                event 662 release_enkf_save_restart_021_f3
+                event 663 release_enkf_save_restart_022_f1
+                event 664 release_enkf_save_restart_022_f2
+                event 665 release_enkf_save_restart_022_f3
+                event 666 release_enkf_save_restart_023_f1
+                event 667 release_enkf_save_restart_023_f2
+                event 668 release_enkf_save_restart_023_f3
+                event 669 release_enkf_save_restart_024_f1
+                event 670 release_enkf_save_restart_024_f2
+                event 671 release_enkf_save_restart_024_f3
+                event 672 release_enkf_save_restart_025_f1
+                event 673 release_enkf_save_restart_025_f2
+                event 674 release_enkf_save_restart_025_f3
+                event 675 release_enkf_save_restart_026_f1
+                event 676 release_enkf_save_restart_026_f2
+                event 677 release_enkf_save_restart_026_f3
+                event 678 release_enkf_save_restart_027_f1
+                event 679 release_enkf_save_restart_027_f2
+                event 680 release_enkf_save_restart_027_f3
+                event 681 release_enkf_save_restart_028_f1
+                event 682 release_enkf_save_restart_028_f2
+                event 683 release_enkf_save_restart_028_f3
+                event 684 release_enkf_save_restart_029_f1
+                event 685 release_enkf_save_restart_029_f2
+                event 686 release_enkf_save_restart_029_f3
+                event 687 release_enkf_save_restart_030_f1
+                event 688 release_enkf_save_restart_030_f2
+                event 689 release_enkf_save_restart_030_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -44918,6 +48840,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -44929,12 +48857,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '001'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f2
+                  edit MEMBER_NAME '001'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                task jrrfs_enkf_save_restart_mem001_f3
+                  edit MEMBER_NAME '001'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem001==complete
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f2
+                  edit MEMBER_NAME '002'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                task jrrfs_enkf_save_restart_mem002_f3
+                  edit MEMBER_NAME '002'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem002==complete
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
@@ -44943,12 +48887,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '003'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f2
+                  edit MEMBER_NAME '003'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                task jrrfs_enkf_save_restart_mem003_f3
+                  edit MEMBER_NAME '003'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem003==complete
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f2
+                  edit MEMBER_NAME '004'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                task jrrfs_enkf_save_restart_mem004_f3
+                  edit MEMBER_NAME '004'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem004==complete
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
@@ -44957,12 +48917,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '005'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f2
+                  edit MEMBER_NAME '005'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                task jrrfs_enkf_save_restart_mem005_f3
+                  edit MEMBER_NAME '005'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem005==complete
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f2
+                  edit MEMBER_NAME '006'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                task jrrfs_enkf_save_restart_mem006_f3
+                  edit MEMBER_NAME '006'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem006==complete
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
@@ -44971,12 +48947,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '007'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f2
+                  edit MEMBER_NAME '007'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                task jrrfs_enkf_save_restart_mem007_f3
+                  edit MEMBER_NAME '007'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem007==complete
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f2
+                  edit MEMBER_NAME '008'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                task jrrfs_enkf_save_restart_mem008_f3
+                  edit MEMBER_NAME '008'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem008==complete
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
@@ -44985,12 +48977,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '009'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f2
+                  edit MEMBER_NAME '009'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                task jrrfs_enkf_save_restart_mem009_f3
+                  edit MEMBER_NAME '009'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem009==complete
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f2
+                  edit MEMBER_NAME '010'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                task jrrfs_enkf_save_restart_mem010_f3
+                  edit MEMBER_NAME '010'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem010==complete
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
@@ -44999,12 +49007,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '011'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f2
+                  edit MEMBER_NAME '011'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                task jrrfs_enkf_save_restart_mem011_f3
+                  edit MEMBER_NAME '011'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem011==complete
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f2
+                  edit MEMBER_NAME '012'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                task jrrfs_enkf_save_restart_mem012_f3
+                  edit MEMBER_NAME '012'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem012==complete
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
@@ -45013,12 +49037,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '013'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f2
+                  edit MEMBER_NAME '013'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                task jrrfs_enkf_save_restart_mem013_f3
+                  edit MEMBER_NAME '013'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem013==complete
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f2
+                  edit MEMBER_NAME '014'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                task jrrfs_enkf_save_restart_mem014_f3
+                  edit MEMBER_NAME '014'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem014==complete
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
@@ -45027,12 +49067,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '015'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f2
+                  edit MEMBER_NAME '015'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                task jrrfs_enkf_save_restart_mem015_f3
+                  edit MEMBER_NAME '015'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem015==complete
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f2
+                  edit MEMBER_NAME '016'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                task jrrfs_enkf_save_restart_mem016_f3
+                  edit MEMBER_NAME '016'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem016==complete
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
@@ -45041,12 +49097,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '017'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f2
+                  edit MEMBER_NAME '017'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                task jrrfs_enkf_save_restart_mem017_f3
+                  edit MEMBER_NAME '017'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem017==complete
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f2
+                  edit MEMBER_NAME '018'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                task jrrfs_enkf_save_restart_mem018_f3
+                  edit MEMBER_NAME '018'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem018==complete
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
@@ -45055,12 +49127,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '019'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f2
+                  edit MEMBER_NAME '019'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                task jrrfs_enkf_save_restart_mem019_f3
+                  edit MEMBER_NAME '019'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem019==complete
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f2
+                  edit MEMBER_NAME '020'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                task jrrfs_enkf_save_restart_mem020_f3
+                  edit MEMBER_NAME '020'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem020==complete
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
@@ -45069,12 +49157,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '021'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f2
+                  edit MEMBER_NAME '021'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                task jrrfs_enkf_save_restart_mem021_f3
+                  edit MEMBER_NAME '021'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem021==complete
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f2
+                  edit MEMBER_NAME '022'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                task jrrfs_enkf_save_restart_mem022_f3
+                  edit MEMBER_NAME '022'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem022==complete
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
@@ -45083,12 +49187,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '023'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f2
+                  edit MEMBER_NAME '023'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                task jrrfs_enkf_save_restart_mem023_f3
+                  edit MEMBER_NAME '023'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem023==complete
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f2
+                  edit MEMBER_NAME '024'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                task jrrfs_enkf_save_restart_mem024_f3
+                  edit MEMBER_NAME '024'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem024==complete
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
@@ -45097,12 +49217,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '025'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f2
+                  edit MEMBER_NAME '025'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                task jrrfs_enkf_save_restart_mem025_f3
+                  edit MEMBER_NAME '025'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem025==complete
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f2
+                  edit MEMBER_NAME '026'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                task jrrfs_enkf_save_restart_mem026_f3
+                  edit MEMBER_NAME '026'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem026==complete
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
@@ -45111,12 +49247,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '027'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f2
+                  edit MEMBER_NAME '027'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                task jrrfs_enkf_save_restart_mem027_f3
+                  edit MEMBER_NAME '027'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem027==complete
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f2
+                  edit MEMBER_NAME '028'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                task jrrfs_enkf_save_restart_mem028_f3
+                  edit MEMBER_NAME '028'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem028==complete
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
@@ -45125,12 +49277,28 @@ suite rrfs_dev
                   edit MEMBER_NAME '029'
                   edit FHR '001'
                   trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f2
+                  edit MEMBER_NAME '029'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                task jrrfs_enkf_save_restart_mem029_f3
+                  edit MEMBER_NAME '029'
+                  edit FHR '003'
+                  trigger ./jrrfs_enkf_forecast_mem029==complete
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f2
+                  edit MEMBER_NAME '030'
+                  edit FHR '002'
+                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                task jrrfs_enkf_save_restart_mem030_f3
+                  edit MEMBER_NAME '030'
+                  edit FHR '003'
                   trigger ./jrrfs_enkf_forecast_mem030==complete
               endfamily   # enkf
             endfamily     # forecast
@@ -45465,6 +49633,8 @@ suite rrfs_dev
                 event 31 release_enkf_prep_cyc_mem030
                 event 32 release_det_analysis_gsi
                 event 33 release_save_restart_f1
+                event 200 release_save_restart_f2
+                event 201 release_save_restart_f3
                 event 35 release_det_post_f000_00_36
                 event 36 release_det_post_f000_15_00
                 event 37 release_det_post_f000_30_00
@@ -45918,6 +50088,12 @@ suite rrfs_dev
                 task jrrfs_det_save_restart_f1
                   edit FHR '001'
                   trigger ../../fsm/jrrfs_fsm:release_save_restart_f1
+                task jrrfs_det_save_restart_f2
+                  edit FHR '002'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f2
+                task jrrfs_det_save_restart_f3
+                  edit FHR '003'
+                  trigger ../../fsm/jrrfs_fsm:release_save_restart_f3
               endfamily   # det
               family enkf
                 edit WGF 'enkf'

--- a/ecf/scripts/forecast/det/jrrfs_det_forecast_long.ecf-prod-resource
+++ b/ecf/scripts/forecast/det/jrrfs_det_forecast_long.ecf-prod-resource
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:30:00
+#PBS -l walltime=02:50:00
 #PBS -l place=vscatter:excl,select=154:ncpus=128:ompthreads=2:mem=500G
 #PBS -l debug=true
 

--- a/ecf/scripts/forecast/det/jrrfs_det_save_restart_f2.ecf
+++ b/ecf/scripts/forecast/det/jrrfs_det_save_restart_f2.ecf
@@ -1,10 +1,10 @@
-#PBS -N rrfs_enkf_forecast_mem@enkf_forecast_member@_%CYC%
+#PBS -N rrfs_det_save_restart_f2_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:33:00
-#PBS -l place=vscatter:excl,select=12:ncpus=128:ompthreads=2:mem=500G
+#PBS -l walltime=00:30:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=40G
 #PBS -l debug=true
 
 model=rrfs
@@ -20,19 +20,12 @@ module load python/${python_ver}
 module load prod_util/${prod_util_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
-module load jasper/${jasper_ver}
 module load hdf5-D/${hdf5_ver}
 module load netcdf-D/${netcdf_ver}
-module load pnetcdf-D/${pnetcdf_ver}
-module load fms-D/${fms_ver}
 module load bacio/${bacio_ver}
-module load crtm/${crtm_ver}
 module load g2/${g2_ver}
 module load ip/${ip_ver}
 module load sp/${sp_ver}
-module load w3emc/${w3emc_ver}
-module load pio/${pio_ver}
-module load esmf-D/${esmf_ver}
 module load libjpeg/${libjpeg_ver}
 module load udunits/${udunits_ver}
 module load gsl/${gsl_ver}
@@ -40,11 +33,11 @@ module load nco/${nco_ver}
 
 module list
 export WGF="%WGF%"
-export MEMBER_NAME="%MEMBER_NAME%"
+export FHR="%FHR%"
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMErrfs}/jobs/JRRFS_FORECAST
+${HOMErrfs}/jobs/JRRFS_SAVE_RESTART
 
 %include <tail.h>
 

--- a/ecf/scripts/forecast/det/jrrfs_det_save_restart_f3.ecf
+++ b/ecf/scripts/forecast/det/jrrfs_det_save_restart_f3.ecf
@@ -1,10 +1,10 @@
-#PBS -N rrfs_enkf_forecast_mem@enkf_forecast_member@_%CYC%
+#PBS -N rrfs_det_save_restart_f3_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:33:00
-#PBS -l place=vscatter:excl,select=12:ncpus=128:ompthreads=2:mem=500G
+#PBS -l walltime=00:30:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=40G
 #PBS -l debug=true
 
 model=rrfs
@@ -20,19 +20,12 @@ module load python/${python_ver}
 module load prod_util/${prod_util_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
-module load jasper/${jasper_ver}
 module load hdf5-D/${hdf5_ver}
 module load netcdf-D/${netcdf_ver}
-module load pnetcdf-D/${pnetcdf_ver}
-module load fms-D/${fms_ver}
 module load bacio/${bacio_ver}
-module load crtm/${crtm_ver}
 module load g2/${g2_ver}
 module load ip/${ip_ver}
 module load sp/${sp_ver}
-module load w3emc/${w3emc_ver}
-module load pio/${pio_ver}
-module load esmf-D/${esmf_ver}
 module load libjpeg/${libjpeg_ver}
 module load udunits/${udunits_ver}
 module load gsl/${gsl_ver}
@@ -40,11 +33,11 @@ module load nco/${nco_ver}
 
 module list
 export WGF="%WGF%"
-export MEMBER_NAME="%MEMBER_NAME%"
+export FHR="%FHR%"
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMErrfs}/jobs/JRRFS_FORECAST
+${HOMErrfs}/jobs/JRRFS_SAVE_RESTART
 
 %include <tail.h>
 

--- a/ecf/scripts/forecast/det/jrrfs_det_save_restart_long_2.ecf
+++ b/ecf/scripts/forecast/det/jrrfs_det_save_restart_long_2.ecf
@@ -1,10 +1,10 @@
-#PBS -N rrfs_enkf_forecast_mem@enkf_forecast_member@_%CYC%
+#PBS -N rrfs_det_save_restart_long_2_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:33:00
-#PBS -l place=vscatter:excl,select=12:ncpus=128:ompthreads=2:mem=500G
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=40G
 #PBS -l debug=true
 
 model=rrfs
@@ -20,19 +20,12 @@ module load python/${python_ver}
 module load prod_util/${prod_util_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
-module load jasper/${jasper_ver}
 module load hdf5-D/${hdf5_ver}
 module load netcdf-D/${netcdf_ver}
-module load pnetcdf-D/${pnetcdf_ver}
-module load fms-D/${fms_ver}
 module load bacio/${bacio_ver}
-module load crtm/${crtm_ver}
 module load g2/${g2_ver}
 module load ip/${ip_ver}
 module load sp/${sp_ver}
-module load w3emc/${w3emc_ver}
-module load pio/${pio_ver}
-module load esmf-D/${esmf_ver}
 module load libjpeg/${libjpeg_ver}
 module load udunits/${udunits_ver}
 module load gsl/${gsl_ver}
@@ -40,11 +33,11 @@ module load nco/${nco_ver}
 
 module list
 export WGF="%WGF%"
-export MEMBER_NAME="%MEMBER_NAME%"
+export FHR="%FHR%"
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMErrfs}/jobs/JRRFS_FORECAST
+${HOMErrfs}/jobs/JRRFS_SAVE_RESTART
 
 %include <tail.h>
 

--- a/ecf/scripts/forecast/det/jrrfs_det_save_restart_long_3.ecf
+++ b/ecf/scripts/forecast/det/jrrfs_det_save_restart_long_3.ecf
@@ -1,10 +1,10 @@
-#PBS -N rrfs_enkf_forecast_mem@enkf_forecast_member@_%CYC%
+#PBS -N rrfs_det_save_restart_long_3_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:33:00
-#PBS -l place=vscatter:excl,select=12:ncpus=128:ompthreads=2:mem=500G
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=40G
 #PBS -l debug=true
 
 model=rrfs
@@ -20,19 +20,12 @@ module load python/${python_ver}
 module load prod_util/${prod_util_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
-module load jasper/${jasper_ver}
 module load hdf5-D/${hdf5_ver}
 module load netcdf-D/${netcdf_ver}
-module load pnetcdf-D/${pnetcdf_ver}
-module load fms-D/${fms_ver}
 module load bacio/${bacio_ver}
-module load crtm/${crtm_ver}
 module load g2/${g2_ver}
 module load ip/${ip_ver}
 module load sp/${sp_ver}
-module load w3emc/${w3emc_ver}
-module load pio/${pio_ver}
-module load esmf-D/${esmf_ver}
 module load libjpeg/${libjpeg_ver}
 module load udunits/${udunits_ver}
 module load gsl/${gsl_ver}
@@ -40,11 +33,11 @@ module load nco/${nco_ver}
 
 module list
 export WGF="%WGF%"
-export MEMBER_NAME="%MEMBER_NAME%"
+export FHR="%FHR%"
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMErrfs}/jobs/JRRFS_FORECAST
+${HOMErrfs}/jobs/JRRFS_SAVE_RESTART
 
 %include <tail.h>
 

--- a/ecf/scripts/forecast/enkf/jrrfs_enkf_save_restart_long_master.ecf
+++ b/ecf/scripts/forecast/enkf/jrrfs_enkf_save_restart_long_master.ecf
@@ -1,4 +1,4 @@
-#PBS -N rrfs_enkf_save_restart_long_mem@enkf_save_restart_long_member@_f1_%CYC%
+#PBS -N rrfs_enkf_save_restart_long_mem@enkf_save_restart_long_member@_f@enkf_save_restart_long_fhr@_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/forecast/enkf/jrrfs_enkf_save_restart_master.ecf
+++ b/ecf/scripts/forecast/enkf/jrrfs_enkf_save_restart_master.ecf
@@ -1,10 +1,10 @@
-#PBS -N rrfs_enkf_save_restart_mem%MEMBER_NAME%_f1_%CYC%
+#PBS -N rrfs_enkf_save_restart_mem@enkf_save_restart_member@_f@enkf_save_restart_fhr@_%CYC%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=40G
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=60G:prepost=true
 #PBS -l debug=true
 
 model=rrfs

--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -415,9 +415,12 @@ echo "Copy enkf save restart long files ..."
 rm -f jrrfs_enkf_save_restart_long_mem???_f1.ecf
 for mem in $(seq 1 30); do
   mem_3d=$( printf "%03d" "${mem}" )
-  cp jrrfs_enkf_save_restart_long_master.ecf jrrfs_enkf_save_restart_long_mem${mem_3d}_f1.ecf
-  sed -i -e "s|@enkf_save_restart_long_member@|${mem_3d}|g" jrrfs_enkf_save_restart_long_mem${mem_3d}_f1.ecf
-  add_to_tmpfile "$ECF_DIR/scripts/forecast/enkf/jrrfs_enkf_save_restart_long_mem${mem_3d}_f1.ecf"
+  for fhr_2_save in $(seq 1 3); do
+    cp jrrfs_enkf_save_restart_long_master.ecf jrrfs_enkf_save_restart_long_mem${mem_3d}_f${fhr_2_save}.ecf
+    sed -i -e "s|@enkf_save_restart_long_member@|${mem_3d}|g" jrrfs_enkf_save_restart_long_mem${mem_3d}_f${fhr_2_save}.ecf
+    sed -i -e "s|@enkf_save_restart_long_fhr@|${fhr_2_save}|g" jrrfs_enkf_save_restart_long_mem${mem_3d}_f${fhr_2_save}.ecf
+    add_to_tmpfile "$ECF_DIR/scripts/forecast/enkf/jrrfs_enkf_save_restart_long_mem${mem_3d}_f${fhr_2_save}.ecf"
+  done
 done
 
 # enkf save restart files
@@ -426,8 +429,12 @@ echo "Copy enkf save restart files ..."
 rm -f jrrfs_enkf_save_restart_mem???_f1.ecf
 for mem in $(seq 1 30); do
   mem_3d=$( printf "%03d" "${mem}" )
-  cp jrrfs_enkf_save_restart_master.ecf jrrfs_enkf_save_restart_mem${mem_3d}_f1.ecf
-  add_to_tmpfile "$ECF_DIR/scripts/forecast/enkf/jrrfs_enkf_save_restart_mem${mem_3d}_f1.ecf"
+  for fhr_2_save in $(seq 1 3); do
+    cp jrrfs_enkf_save_restart_master.ecf jrrfs_enkf_save_restart_mem${mem_3d}_f${fhr_2_save}.ecf
+    sed -i -e "s|@enkf_save_restart_member@|${mem_3d}|g" jrrfs_enkf_save_restart_mem${mem_3d}_f${fhr_2_save}.ecf
+    sed -i -e "s|@enkf_save_restart_fhr@|${fhr_2_save}|g" jrrfs_enkf_save_restart_mem${mem_3d}_f${fhr_2_save}.ecf
+    add_to_tmpfile "$ECF_DIR/scripts/forecast/enkf/jrrfs_enkf_save_restart_mem${mem_3d}_f${fhr_2_save}.ecf"
+  done
 done
 
 # enkf save restart spinup files

--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -477,7 +477,11 @@ if [ ${BKTYPE} -eq 0 ]; then
       cpreq -p ${FV3_NML_RESTART_SPINUPCYC_FP} ${DATA}/${FV3_NML_FN}
     else
       if [ ${WGF} = "enkf" ]; then
-       FCST_LEN_HRS=1
+       if [[ $((10#$cyc % 2)) -eq 0 ]]; then
+         FCST_LEN_HRS=3
+       else
+         FCST_LEN_HRS=1
+       fi
        cpreq -p ${FV3_NML_RESTART_FP} ${DATA}/${FV3_NML_FN}
       else
         FCST_LEN_HRS=${FCST_LEN_HRS_CYCLES[$((10#$cyc))]}
@@ -686,6 +690,14 @@ if [ ${CYCLE_TYPE} = "spinup" ]; then
     RESTART_HRS='0'
   fi
 fi
+
+if [ $WGF = "det" ] && [[ ! $((10#$cyc % 6)) -eq 0 ]]; then
+  RESTART_HRS='1 2 3 6 12'
+fi
+if [ $WGF = "enkf" ] && [[ $((10#$cyc % 2)) -eq 0 ]]; then
+  RESTART_HRS='1 2 3'
+fi
+
 if [ $FCST_LEN_HRS -gt 0 ]; then
   cd ${DATA}/RESTART
   file_ids=( "coupler.res" "fv_core.res.nc" "fv_core.res.tile1.nc" "fv_srf_wnd.res.tile1.nc" "fv_tracer.res.tile1.nc" "fv_diag.res.tile1.nc" "phy_data.nc" "sfc_data.nc" )
@@ -718,14 +730,9 @@ fi
 if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN_HRS -gt 6 ]; then
   flag_fcst_restart="TRUE"
   # Update FV3 input.nml for restart
-   mem_res="0"
-   if [ ${WGF} = "ensf" ]; then
-     mem_res=${ensmem_num}
-   fi
    $USHrrfs/update_input_nml.py \
     --path-to-defns ${FIXrrfs}/workflow/${WGF}/workflow.conf \
     --run_dir "${DATA}" \
-    --member ${mem_res} \
     --restart
   export err=$?
   if [ $err -ne 0 ]; then
@@ -909,7 +916,11 @@ cd INPUT
 acsnow_ct=$(ncdump -h sfc_data.nc|grep acsnow|wc -l)
 if [ $acsnow_ct -eq 0 ] && [ ! ${WGF} = "firewx" ]; then
   echo "Run DATA sfc_data.nc surge for acsnow"
-  ncks -A ${FIXrrfs}/acsnow/acsnow.nc sfc_data.nc
+  if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ]; then
+    ncks -A ${FIXrrfs}/acsnow/acsnow_conus3km.nc sfc_data.nc
+  else
+    ncks -A ${FIXrrfs}/acsnow/acsnow.nc sfc_data.nc
+  fi
   export err=$?; err_chk
 fi
 cd ..

--- a/scripts/exrrfs_fsm.sh
+++ b/scripts/exrrfs_fsm.sh
@@ -44,6 +44,8 @@ RRFS_next_1_PDY=$(echo $($NDATE +1 ${CDATE}) | cut -c1-8)
 RRFS_next_1_cyc=$(echo $($NDATE +1 ${CDATE}) | cut -c9-10)
 RRFS_next_2_PDY=$(echo $($NDATE +2 ${CDATE}) | cut -c1-8)
 RRFS_next_2_cyc=$(echo $($NDATE +2 ${CDATE}) | cut -c9-10)
+RRFS_next_3_PDY=$(echo $($NDATE +3 ${CDATE}) | cut -c1-8)
+RRFS_next_3_cyc=$(echo $($NDATE +3 ${CDATE}) | cut -c9-10)
 current_PDY_6hr_fmt=${PDY}
 if [ $((10#$RRFS_Current_cyc)) -ge 0 ] && [ $((10#$RRFS_Current_cyc)) -le 5 ]; then
   current_cyc_6hr_fmt="00"
@@ -91,6 +93,7 @@ scan_release_ensf_make_lbcs="NO"
 scan_release_enkf_make_ics="NO"
 scan_release_enkf_observer_gsi_ensmean="YES"
 scan_release_enkf_save_restart_ensinit="NO"
+scan_release_enkf_save_restart_f1="NO"
 
 if [ ${cyc} == "00" ]; then
   scan_release_det_make_lbcs="YES"
@@ -99,6 +102,7 @@ if [ ${cyc} == "00" ]; then
   scan_release_det_post_long="YES"
   scan_release_ensf_post="YES"
   scan_release_save_restart_long="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "01" ]; then
@@ -109,6 +113,7 @@ fi
 if [ ${cyc} == "02" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "03" ]; then
@@ -123,6 +128,7 @@ if [ ${cyc} == "04" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
   scan_release_save_restart_spinup_f001="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "05" ]; then
@@ -141,6 +147,7 @@ if [ ${cyc} == "06" ]; then
   scan_release_ensf_post="YES"
   scan_release_save_restart_long="YES"
   scan_release_save_restart_spinup_f001="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "07" ]; then
@@ -157,6 +164,7 @@ if [ ${cyc} == "08" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
   scan_release_save_restart_spinup_f001="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "09" ]; then
@@ -167,6 +175,7 @@ fi
 if [ ${cyc} == "10" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "11" ]; then
@@ -182,6 +191,7 @@ if [ ${cyc} == "12" ]; then
   scan_release_det_post_long="YES"
   scan_release_ensf_post="YES"
   scan_release_save_restart_long="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "13" ]; then
@@ -192,6 +202,7 @@ fi
 if [ ${cyc} == "14" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "15" ]; then
@@ -205,6 +216,7 @@ if [ ${cyc} == "16" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
   scan_release_save_restart_spinup_f001="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "17" ]; then
@@ -222,6 +234,7 @@ if [ ${cyc} == "18" ]; then
   scan_release_ensf_post="YES"
   scan_release_save_restart_long="YES"
   scan_release_save_restart_spinup_f001="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "19" ]; then
@@ -237,6 +250,7 @@ if [ ${cyc} == "20" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
   scan_release_save_restart_spinup_f001="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "21" ]; then
@@ -247,6 +261,7 @@ fi
 if [ ${cyc} == "22" ]; then
   scan_release_det_post="YES"
   scan_release_save_restart_f1="YES"
+  scan_release_enkf_save_restart_f1="YES"
 fi
 
 if [ ${cyc} == "23" ]; then
@@ -331,7 +346,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   #### scan_release_det_make_ics
   if [ ${scan_release_det_make_ics} == "YES" ]; then
     echo "Proceeding with scan_release_det_make_ics"
-    ops_gfs_inp_file=${COMINgfs}/gfs.${current_PDY_6hr_fmt}/${current_cyc_6hr_fmt}/atmos/gfs.t${current_cyc_6hr_fmt}z.logf003.txt
+    ops_gfs_inp_file=$(compath.py gfs/${gfs_ver})/gfs.${current_PDY_6hr_fmt}/${current_cyc_6hr_fmt}/atmos/gfs.t${current_cyc_6hr_fmt}z.logf003.txt
     if [ -s ${ops_gfs_inp_file} ]; then
       scan_release_det_make_ics="NO"
       ecflow_client --event release_det_make_ics
@@ -344,7 +359,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   #### scan_release_det_make_lbcs
   if [ ${scan_release_det_make_lbcs} == "YES" ]; then
     echo "Proceeding with scan_release_det_make_lbcs"
-    ops_gfs_inp_file=${COMINgfs}/gfs.${RRFS_previous_PDY}/${previous_cyc_6hr_fmt}/atmos/gfs.t${previous_cyc_6hr_fmt}z.logf006.txt
+    ops_gfs_inp_file=$(compath.py gfs/${gfs_ver})/gfs.${RRFS_previous_PDY}/${previous_cyc_6hr_fmt}/atmos/gfs.t${previous_cyc_6hr_fmt}z.logf006.txt
     if [ -s ${ops_gfs_inp_file} ]; then
       scan_release_det_make_lbcs="NO"
       ecflow_client --event release_det_make_lbcs
@@ -413,7 +428,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   #### release_enkf_make_lbcs
   if [ ${scan_release_enkf_make_lbcs} == "YES" ]; then
     echo "Proceeding with scan_release_enkf_make_lbcs"
-    gefs_inp_dir=${COMINgefs}/gefs.${prior_PDY_6hr_fmt}/${previous_cyc_6hr_fmt}/atmos/pgrb2bp5
+    gefs_inp_dir=$(compath.py gefs/${gefs_ver})/gefs.${prior_PDY_6hr_fmt}/${previous_cyc_6hr_fmt}/atmos/pgrb2bp5
     file_count_tmp=$(ls ${gefs_inp_dir}/gep*.t${previous_cyc_6hr_fmt}z.pgrb2b.0p50.f006 ${gefs_inp_dir}/gep*.t${previous_cyc_6hr_fmt}z.pgrb2b.0p50.f009 ${gefs_inp_dir}/gep*.t${previous_cyc_6hr_fmt}z.pgrb2b.0p50.f012 ${gefs_inp_dir}/gep*.t${previous_cyc_6hr_fmt}z.pgrb2b.0p50.f015 ${gefs_inp_dir}/gep*.t${previous_cyc_6hr_fmt}z.pgrb2b.0p50.f018|wc -l)
     if [ ${file_count_tmp} -eq 150 ]; then
       ecflow_client --event release_enkf_make_lbcs
@@ -429,22 +444,34 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_long} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_long for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/*coupler.res|wc -l)
     if [ ${cyc} == 00 ] || [ ${cyc} == 12 ]; then
-      if [ ${restart_set_found} -ge 1 ]; then
+      if [ ${restart_set_found} -eq 1 ]; then
         ecflow_client --event release_save_restart_long_1
       fi
-      if [ ${restart_set_found} -ge 2 ]; then
+      if [ ${restart_set_found} -eq 2 ]; then
+        ecflow_client --event release_save_restart_long_2
+      fi
+      if [ ${restart_set_found} -eq 3 ]; then
+        ecflow_client --event release_save_restart_long_3
+      fi
+      if [ ${restart_set_found} -ge 4 ]; then
         ecflow_client --event release_save_restart_long_6
         scan_release_save_restart_long="NO"
       fi
     fi
     if [ ${cyc} == 06 ] || [ ${cyc} == 18 ]; then
-      if [ ${restart_set_found} -ge 1 ]; then
+      if [ ${restart_set_found} -eq 1 ]; then
         ecflow_client --event release_save_restart_long_1
       fi
-      if [ ${restart_set_found} -ge 3 ]; then
+      if [ ${restart_set_found} -eq 2 ]; then
+        ecflow_client --event release_save_restart_long_2
+      fi
+      if [ ${restart_set_found} -eq 3 ]; then
+        ecflow_client --event release_save_restart_long_3
+      fi
+      if [ ${restart_set_found} -ge 5 ]; then
         ecflow_client --event release_save_restart_long_12
         scan_release_save_restart_long="NO"
       fi
@@ -457,10 +484,18 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_f1} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_f1 for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
-    if [ ${restart_set_found} -ge 1 ]; then
+    if [ ${restart_set_found} -eq 1 ]; then
       ecflow_client --event release_save_restart_f1
+    fi
+    restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_2_PDY}.${RRFS_next_2_cyc}0000.coupler.res|wc -l)
+    if [ ${restart_set_found} -eq 1 ]; then
+      ecflow_client --event release_save_restart_f2
+    fi
+    restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_3_PDY}.${RRFS_next_3_cyc}0000.coupler.res|wc -l)
+    if [ ${restart_set_found} -eq 1 ]; then
+      ecflow_client --event release_save_restart_f3
       scan_release_save_restart_f1="NO"
     else
       proceed_trigger_scan="YES"
@@ -472,7 +507,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_spinup_f001} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_spinup_f001 for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
     if [ ${restart_set_found} -ge 1 ]; then
       ecflow_client --event release_save_restart_spinup_f001
@@ -483,11 +518,41 @@ while [ $proceed_trigger_scan == "YES" ]; do
   fi
   #### release_save_restart_spinup_f001
 
+  #### release_enkf_save_restart_f1
+  ## Process WGF is enkf
+  if [ ${scan_release_enkf_save_restart_f1} == "YES" ]; then
+    restart_member_completed=0
+    echo "Proceeding with scan_release_enkf_save_restart_f1 for enkf"
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/enkf
+    for member_name in $(seq 1 30); do
+      member_name3d=$( printf "%03d" "${member_name}" )
+      restart_set_mem001_found=$(ls ${umbrella_forecast_data}/${member_name3d}/RESTART/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
+      if [ ${restart_set_mem001_found} -eq 1 ]; then
+        ecflow_client --event release_enkf_save_restart_${member_name3d}_f1
+      fi
+      restart_set_mem002_found=$(ls ${umbrella_forecast_data}/${member_name3d}/RESTART/${RRFS_next_2_PDY}.${RRFS_next_2_cyc}0000.coupler.res|wc -l)
+      if [ ${restart_set_mem002_found} -eq 1 ]; then
+        ecflow_client --event release_enkf_save_restart_${member_name3d}_f2
+      fi
+      restart_set_mem003_found=$(ls ${umbrella_forecast_data}/${member_name3d}/RESTART/${RRFS_next_3_PDY}.${RRFS_next_3_cyc}0000.coupler.res|wc -l)
+      if [ ${restart_set_mem003_found} -eq 1 ]; then
+        ecflow_client --event release_enkf_save_restart_${member_name3d}_f3
+        restart_member_completed=$((restart_member_completed+1))
+      fi
+      if [ $restart_member_completed -lt 30 ]; then
+        proceed_trigger_scan="YES"
+      else
+        scan_release_enkf_save_restart_f1="NO"
+      fi
+    done
+  fi
+  #### release_save_restart_f1
+
   #### release_det_post_long
   if [ ${scan_release_det_post_long} == "YES" ]; then
     echo "Proceeding with scan_release_det_post_long"
     source_file_found="YES"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/output
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/output
     # fhr cover 000~084
     for fhr in $(seq 0 84); do
       fhr_2d=$( printf "%02d" ${fhr} )
@@ -536,7 +601,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_ensf_post} == "YES" ]; then
     echo "Proceeding with scan_release_ensf_post"
     source_file_found="YES"
-    umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/ensf/
+    umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/ensf/
     # mems 1-5
     for mem in $(seq 1 5); do
       memuse=$( printf "%03d" ${mem} )
@@ -568,7 +633,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_det_post} == "YES" ]; then
     echo "Proceeding with scan_release_det_post"
     source_file_found="YES"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/output
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/output
     # fhr cover 000~018
     for fhr in $(seq 0 18); do
       fhr_2d=$( printf "%02d" ${fhr} )
@@ -617,8 +682,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_ensf_make_lbcs} == "YES" ]; then
     echo "Proceeding with scan_release_ensf_make_lbcs"
     source_file_found="YES"
-    # /lfs/h1/ops/prod/com/gefs/v12.3/gefs.20240609/18/atmos/pgrb2bp5/gep01.t18z.pgrb2b.0p50.f006
-    gefs_pth=${COMINgefs}/gefs.${prior_PDY_6hr_fmt}/${previous_cyc_6hr_fmt}/atmos/pgrb2bp5
+    gefs_pth=$(compath.py gefs/${gefs_ver})/gefs.${prior_PDY_6hr_fmt}/${previous_cyc_6hr_fmt}/atmos/pgrb2bp5
     for gp_num in $(seq 1 5); do
       for fhr in $(seq 6 3 66); do
         gp_num_2d=$( printf "%02d" ${gp_num} )
@@ -676,7 +740,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
     else
       enkfgdas_cyc=12
     fi
-    enkfgdas_pth=${COMINgfs}/enkfgdas.${RRFS_Current_PDY}/${enkfgdas_cyc}/atmos
+    enkfgdas_pth=$(compath.py gfs/${gfs_ver})/enkfgdas.${RRFS_Current_PDY}/${enkfgdas_cyc}/atmos
     for mem_nu in $(seq 1 30); do
       mem_nu_3d=$( printf "%03d" ${mem_nu} )
       target_file_scan_atmf=${enkfgdas_pth}/mem${mem_nu_3d}/gdas.t${enkfgdas_cyc}z.atmf007.nc

--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -176,7 +176,7 @@ else
   #     cold start if BKTYPE=1 
   #     warm start if BKTYPE=0
   #     spinupcyc + warm start if BKTYPE=2
-  #       the previous 6 cycles are searched to find the restart files
+  #       the previous 3 cycles are searched to find the restart files
   #       valid at this time from the closet previous cycle.
   #
   #-----------------------------------------------------------------------
@@ -347,7 +347,7 @@ else
     fi
 
     n=${DA_CYCLE_INTERV}
-    while [[ $n -le 6 ]] ; do
+    while [[ $n -le 3 ]] ; do
       checkfile=${bkpath}/${restart_prefix}coupler.res
       if [ -r "${checkfile}" ] ; then
         print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "
@@ -390,7 +390,7 @@ else
 
      restart_prefix="${YYYYMMDD}.${HH}0000."
      n=${DA_CYCLE_INTERV}
-     while [[ $n -le 6 ]] ; do
+     while [[ $n -le 3 ]] ; do
        checkfile=${bkpath}/${restart_prefix}coupler.res
        if [ -r "${checkfile}" ] ; then
          print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "

--- a/scripts/exrrfs_save_restart.sh
+++ b/scripts/exrrfs_save_restart.sh
@@ -91,9 +91,21 @@ fi
 
 if_save_input=FALSE
 
-if [ -s ${umbrella_forecast_data}/INPUT/gfs_ctrl.nc ]; then
-  cpreq ${umbrella_forecast_data}/INPUT/gfs_ctrl.nc ${COMOUT}/INPUT
-  if_save_input=TRUE
+copy_gfs_ctrl=TRUE
+if [ "${WGF}" = "enkf" ]; then
+  if [[ $((10#$cyc % 2)) -eq 0 ]] && [ ! "${FHR}" = "001" ]; then
+    copy_gfs_ctrl=FALSE
+  fi
+elif [ ${WGF} = "det" ]; then
+  if [ ! "${FHR}" = "001" ]; then
+    copy_gfs_ctrl=FALSE
+  fi  
+fi
+if [[ ${copy_gfs_ctrl} = TRUE ]]; then
+  if [ -s ${umbrella_forecast_data}/INPUT/gfs_ctrl.nc ]; then
+    cpreq ${umbrella_forecast_data}/INPUT/gfs_ctrl.nc ${COMOUT}/INPUT
+    if_save_input=TRUE
+  fi
 fi
 
 if [ -r "${shared_forecast_restart_data}/${restart_prefix}.coupler.res" ]; then


### PR DESCRIPTION
Modify the RRFS package and ecflow workflow to implement an hourly recovery capability for the prep cycle job during the initial three-hour window.
Proposed Technical Changes
Increased RESTART file set:
Update the DET forecast to save RESTART file sets at FHR 001, 002, and 003 for all cycles.
Update the ENKF forecast to save RESTART file sets at FHR 001, 002, and 003 for all even-hour cycles.
ECFLOW Workflow:
Modify the ecflow workflow to support additional jobs to save new RESTART set.
Update job cards to accommodate increased resource demands, specifically targeting higher memory allocation and extended wallclock time.
Job Dependencies:
Adjust the prep cycle job to ensure it generates and provides a sufficient volume of INPUT files required to forecast jobs.
Implement necessary updates to the fix files to maintain consistency with the new output cadence.

We (Wei, James, Ming and I) had a meeting on Jan 9th to go over this document and testing. It is my understanding there is no outstanding issue and this PR is now good to go.

[RRFS.NCO.production.job.fallback.instruction.pdf](https://github.com/user-attachments/files/24598719/RRFS.NCO.production.job.fallback.instruction.pdf)
