### PR TITLE
[rrfs-nco] Add sleep-and-wait to exrrfs_prep_cyc.sh

### DIFF
--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -82,6 +82,25 @@ Run command has not been specified for this machine:
 
 esac
 export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
+
+#
+#-----------------------------------------------------------------------
+#
+# Specify Timeout Behavior of prep_cyc to checking for restart files
+# from CYCm1.
+#
+# If 1-hour restart files from CYCm1 do not exist after $SLEEP_TIME,
+# proceed with CYCm2 2-hour restart files, then CYCm3 3-hour restart files.
+#
+# SLEEP_TIME - Amount of time to wait for CYCm1 1-h hrestart files before
+#              trying CYCm2 2-h restart files
+# SLEEP_INT  - Amount of time to wait between checking for restart files
+#
+#-----------------------------------------------------------------------
+SLEEP_TIME=300
+SLEEP_INT=15
+SLEEP_LOOP_MAX=`expr $SLEEP_TIME / $SLEEP_INT`
+
 #
 #-----------------------------------------------------------------------
 #
@@ -349,6 +368,17 @@ else
     n=${DA_CYCLE_INTERV}
     while [[ $n -le 3 ]] ; do
       checkfile=${bkpath}/${restart_prefix}coupler.res
+      ic=0
+      if [ ! -r "${checkfile}" ] ; then
+        while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
+          print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
+          ic=`expr $ic + 1`
+          sleep $SLEEP_INT
+          if [ -r "${checkfile}" ] ; then
+            break
+          fi
+        done
+      fi
       if [ -r "${checkfile}" ] ; then
         print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "
         break
@@ -392,6 +422,17 @@ else
      n=${DA_CYCLE_INTERV}
      while [[ $n -le 3 ]] ; do
        checkfile=${bkpath}/${restart_prefix}coupler.res
+       ic=0
+       if [ ! -r "${checkfile}" ] ; then
+         while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
+           print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
+           ic=`expr $ic + 1`
+           sleep $SLEEP_INT
+           if [ -r "${checkfile}" ] ; then
+             break
+           fi
+         done
+       fi
        if [ -r "${checkfile}" ] ; then
          print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "
          break

--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -368,8 +368,8 @@ else
     n=${DA_CYCLE_INTERV}
     while [[ $n -le 3 ]] ; do
       checkfile=${bkpath}/${restart_prefix}coupler.res
-      ic=0
-      if [ ! -r "${checkfile}" ] ; then
+      if [ ! -r "${checkfile}" ] && [ "$n" == "1" ] ; then
+        ic=0
         while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
           print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
           ic=`expr $ic + 1`
@@ -422,8 +422,8 @@ else
      n=${DA_CYCLE_INTERV}
      while [[ $n -le 3 ]] ; do
        checkfile=${bkpath}/${restart_prefix}coupler.res
-       ic=0
-       if [ ! -r "${checkfile}" ] ; then
+       if [ ! -r "${checkfile}" ] && [ "$n" == "1" ] ; then
+         ic=0
          while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
            print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
            ic=`expr $ic + 1`


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Add sleep-and-wait up to 5 min in `prep_cyc` jobs to allow runtime variations in `CYCm1`.
  - To avoid `prep_cyc` starting before `save_restart` from `CYCm1` completes and using `CYCm2` 2-h restart files.
  - If `CYCm1`1-h restart files don't exist, sleep up to 5 min to wait.
  - If still no, try `CYCm2` 2-h restart, then `CYCm3` 3-h. 
  - No sleep for checking `CYCm2` 2-h and `CYCm3` 3-h.  
  - See #1200 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others: NCO SPA

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->


## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

