### PR TITLE
[rrfs-nco] Do not read data from COM - add cpreq to DATA directory

### DIFF
--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -154,10 +154,23 @@ the grid and (filtered) orography files ..."
 
 cd ${DATA}/INPUT
 
+cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}mosaic.halo${NH3}.nc .
+cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}grid.tile7.halo${NH3}.nc .
+cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}grid.tile${TILE_RGNL}.halo${NH4}.nc .
+cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH0}.nc .
+cpreq ${FIXLAM}/${CRES}.facsf.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.maximum_snow_albedo.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.slope_type.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.snowfree_albedo.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.soil_type.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.substrate_temperature.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.vegetation_greenness.tile${TILE_RGNL}.nc .
+cpreq ${FIXLAM}/${CRES}.vegetation_type.tile${TILE_RGNL}.nc .
+
 relative_or_null=""
 
 # Symlink to mosaic file with a completely different name.
-target="${FIXLAM}/${CRES}${DOT_OR_USCORE}mosaic.halo${NH3}.nc" # must use *mosaic.halo3.nc
+target="./${CRES}${DOT_OR_USCORE}mosaic.halo${NH3}.nc" # must use *mosaic.halo3.nc
 symlink="grid_spec.nc"
 if [ -f "${target}" ]; then
   cpreq $target $symlink
@@ -171,7 +184,7 @@ fi
 mosaic_fn="grid_spec.nc"
 grid_fn=$( get_charvar_from_netcdf "${mosaic_fn}" "gridfiles" )
 
-target="${FIXLAM}/${CRES}${DOT_OR_USCORE}grid.tile7.halo${NH3}.nc"
+target="./${CRES}${DOT_OR_USCORE}grid.tile7.halo${NH3}.nc"
 symlink="${grid_fn}"
 if [ -f "${target}" ]; then
   cpreq $target $symlink
@@ -193,7 +206,7 @@ fi
 # Note that even though the message says "Stopped", the task still con-
 # sumes core-hours.
 #
-target="${FIXLAM}/${CRES}${DOT_OR_USCORE}grid.tile${TILE_RGNL}.halo${NH4}.nc"
+target="./${CRES}${DOT_OR_USCORE}grid.tile${TILE_RGNL}.halo${NH4}.nc"
 symlink="grid.tile${TILE_RGNL}.halo${NH4}.nc"
 if [ -f "${target}" ]; then
   cpreq $target $symlink
@@ -206,7 +219,7 @@ fi
 relative_or_null=""
 
 # Symlink to halo-0 orography file with "${CRES}_" and "halo0" stripped from name.
-target="${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH0}.nc"
+target="./${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH0}.nc"
 symlink="oro_data.nc"
 if [ -f "${target}" ]; then
   cpreq $target $symlink
@@ -229,7 +242,7 @@ fi
 # Note that even though the message says "Stopped", the task still con-
 # sumes core-hours.
 #
-target="${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH4}.nc"
+target="./${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH4}.nc"
 symlink="oro_data.tile${TILE_RGNL}.halo${NH4}.nc"
 if [ -f "${target}" ]; then
   cpreq $target $symlink
@@ -249,7 +262,8 @@ suites=( "RRFS_sas" "FV3_RAP" "FV3_HRRR" "FV3_HRRR_gf" "FV3_GFS_v15_thompson_myn
 if [[ ${suites[@]} =~ "${CCPP_PHYS_SUITE}" ]] ; then
   fileids=( "ss" "ls" )
   for fileid in "${fileids[@]}"; do
-    target="${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data_${fileid}.tile${TILE_RGNL}.halo${NH0}.nc"
+    cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data_${fileid}.tile${TILE_RGNL}.halo${NH0}.nc .
+    target="./${CRES}${DOT_OR_USCORE}oro_data_${fileid}.tile${TILE_RGNL}.halo${NH0}.nc"
     symlink="oro_data_${fileid}.nc"
     if [ -f "${target}" ]; then
       cpreq $target $symlink
@@ -344,7 +358,8 @@ if [ "${DO_NON_DA_RUN}" = "TRUE" ]; then
   ln -sf ${relative_or_null} $target $symlink
 
   for fhr in $(seq -f "%03g" ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} ${FCST_LEN_HRS}); do
-    target="${COMOUT}/lbcs/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
+    cpreq ${COMOUT}/lbcs/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc .
+    target="./lbcs/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
     symlink="gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
     ln -sf ${relative_or_null} $target $symlink
   done

--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -359,9 +359,6 @@ if [ "${DO_NON_DA_RUN}" = "TRUE" ]; then
 
   for fhr in $(seq -f "%03g" ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} ${FCST_LEN_HRS}); do
     cpreq ${COMOUT}/lbcs/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc .
-    target="./lbcs/gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
-    symlink="gfs_bndy.tile${TILE_RGNL}.${fhr}.nc"
-    ln -sf ${relative_or_null} $target $symlink
   done
 else
   if [ ${BKTYPE} -eq 1 ]; then

--- a/scripts/exrrfs_make_ics.sh
+++ b/scripts/exrrfs_make_ics.sh
@@ -175,6 +175,8 @@ esac
 
 if [ ${PREDEF_GRID_NAME} = "RRFS_FIREWX_1.5km" ]; then
   export FIXLAM=${firewx_input_dir}/${PDY}${cyc}
+  cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}mosaic.halo$((10#${NH4})).nc .
+  cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo$((10#${NH4})).nc .
 else
   export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
 fi
@@ -618,9 +620,9 @@ hh="${cdate_crnt_fhr:8:2}"
 #
 settings="
 'config': {
- 'fix_dir_target_grid': ${FIXLAM},
- 'mosaic_file_target_grid': ${FIXLAM}/${CRES}${DOT_OR_USCORE}mosaic.halo$((10#${NH4})).nc,
- 'orog_dir_target_grid': ${FIXLAM},
+ 'fix_dir_target_grid': ./,
+ 'mosaic_file_target_grid': ./${CRES}${DOT_OR_USCORE}mosaic.halo$((10#${NH4})).nc,
+ 'orog_dir_target_grid': ./,
  'orog_files_target_grid': ${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo$((10#${NH4})).nc,
  'vcoord_file_target_grid': ${FIXam}/${VCOORD_FILE},
  'varmap_file': ${PARMrrfs}/${varmap_file},

--- a/scripts/exrrfs_make_lbcs.sh
+++ b/scripts/exrrfs_make_lbcs.sh
@@ -203,6 +203,8 @@ esac
 
 if [ ${WGF} = "firewx" ]; then
   export FIXLAM=${firewx_input_dir}/${PDY}${cyc}
+  cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}mosaic.halo$((10#${NH4})).nc .
+  cpreq ${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo$((10#${NH4})).nc .
 else
   export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
 fi
@@ -721,9 +723,9 @@ list file has not specified for this external LBC model (EXTRN_MDL_NAME_LBCS):
 #
   settings="
 'config': {
- 'fix_dir_target_grid': ${FIXLAM},
- 'mosaic_file_target_grid': ${FIXLAM}/${CRES}${DOT_OR_USCORE}mosaic.halo$((10#${NH4})).nc,
- 'orog_dir_target_grid': ${FIXLAM},
+ 'fix_dir_target_grid': ./,
+ 'mosaic_file_target_grid': ./${CRES}${DOT_OR_USCORE}mosaic.halo$((10#${NH4})).nc,
+ 'orog_dir_target_grid': ./,
  'orog_files_target_grid': ${CRES}${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo$((10#${NH4})).nc,
  'vcoord_file_target_grid': ${FIXam}/${VCOORD_FILE},
  'varmap_file': ${PARMrrfs}/${varmap_file},

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -171,10 +171,13 @@ else
   prslev_subh=${net4}.t${cyc}z.prslev.${gridspacing}.subh.f${fhr}.${gridname}.grib2
 fi
 
+cpreq ${COMOUT}/${prslev} .
+cpreq ${COMOUT}/${natlev} .
+
 # extract the output fields for the testbed files
 if [[ ! -z ${TESTBED_FIELDS_FN} ]]; then
   if [[ -f ${FIX_UPP}/${TESTBED_FIELDS_FN} ]]; then
-    wgrib2 ${COMOUT}/${prslev} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN} | wgrib2 -i -grib ${DATA}/${testbed} ${COMOUT}/${prslev}
+    wgrib2 ${prslev} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN} | wgrib2 -i -grib ${DATA}/${testbed} ${prslev}
     export err=$?; err_chk
   else
     echo "${FIX_UPP}/${TESTBED_FIELDS_FN} not found"
@@ -183,7 +186,7 @@ fi
 if [[ ! -z ${TESTBED_FIELDS_FN2} ]]; then
   if [[ -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} ]]; then
     if [[ -f ${COMOUT}/${natlev} ]]; then
-      wgrib2 ${COMOUT}/${natlev} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} | wgrib2 -i -append -grib ${DATA}/${testbed} ${COMOUT}/${natlev}
+      wgrib2 ${natlev} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} | wgrib2 -i -append -grib ${DATA}/${testbed} ${natlev}
       export err=$?; err_chk
     fi
   else
@@ -200,20 +203,21 @@ if [ "${PREDEF_GRID_NAME}" != "RRFS_FIREWX_1.5km" ]; then
 fi
 
 if [ -s ${COMOUT}/${prslev} ]; then
-  wgrib2 ${COMOUT}/${prslev} -s > ${COMOUT}/${prslev}.idx
+  wgrib2 ${prslev} -s > ${COMOUT}/${prslev}.idx
 fi
 if [ -s ${COMOUT}/${natlev} ]; then
-  wgrib2 ${COMOUT}/${natlev} -s > ${COMOUT}/${natlev}.idx
+  wgrib2 ${natlev} -s > ${COMOUT}/${natlev}.idx
 fi
 
 if [ "${PREDEF_GRID_NAME}" != "RRFS_FIREWX_1.5km" ]; then
   if [ -s ${COMOUT}/${testbed} ]; then
-    wgrib2 ${COMOUT}/${testbed} -s > ${COMOUT}/${testbed}.idx
+    wgrib2 ${testbed} -s > ${COMOUT}/${testbed}.idx
   fi
 fi
 
 if [ "${DO_ENSFCST}" != "TRUE" ] && [ ${fhr} != '000' ] && [ -e $COMOUT/${prslev_subh} ]; then
-  wgrib2 ${COMOUT}/${prslev_subh} -s > ${COMOUT}/${prslev_subh}.idx
+  cpreq ${COMOUT}/${prslev_subh} .
+  wgrib2 ${prslev_subh} -s > ${COMOUT}/${prslev_subh}.idx
 fi
 
 #  Generate products
@@ -224,7 +228,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
   DATAprdgen=$DATA/prdgen_${fhr}
   mkdir $DATAprdgen
 
-  wgrib2 ${COMOUT}/${prslev} >& $DATAprdgen/prslevf${fhr}.txt
+  wgrib2 ${prslev} >& $DATAprdgen/prslevf${fhr}.txt
 
   # Create parm files for subsetting on the fly - do it for each forecast hour
   # 4 subpieces for CONUS and Alaska grids
@@ -274,15 +278,17 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
     if [ ${DO_ENSFCST} = "TRUE" ]; then
       for task in $(seq ${tasks[count]})
       do
-        cat $DATAprdgen/prdgen_${domain}_${task}/${domain}_${task}.grib2 >> ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2
+        cat $DATAprdgen/prdgen_${domain}_${task}/${domain}_${task}.grib2 >> rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2
+        cpreq rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2 ${COMOUT}
       done
-      wgrib2 ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
+      wgrib2 rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
     else
       for task in $(seq ${tasks[count]})
       do
-        cat $DATAprdgen/prdgen_${domain}_${task}/${domain}_${task}.grib2 >> ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2
+        cat $DATAprdgen/prdgen_${domain}_${task}/${domain}_${task}.grib2 >> rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2
+        cpreq rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2 ${COMOUT}
       done
-      wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
+      wgrib2 rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
     fi
     count=$count+1
   done
@@ -312,13 +318,14 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         gridspecs="mercator:20 284.5:544:2500:297.491 15.0:310:2500:22.005"
       fi
         
-      wgrib2 ${COMOUT}/${prslev_subh} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
+      wgrib2 ${prslev_subh} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
       wgrib2 inputs.grib${domain}.uv -set_bitmap 1 -set_grib_type c3 \
         -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
         -new_grid_interpolation neighbor \
         -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-        -new_grid ${gridspecs} ${COMOUT}/${prslev_subh_dom}
-      wgrib2 ${COMOUT}/${prslev_subh_dom} -s > ${COMOUT}/${prslev_subh_dom}.idx
+        -new_grid ${gridspecs} ${prslev_subh_dom}
+      cpreq ${prslev_subh_dom} ${COMOUT}
+      wgrib2 ${prslev_subh_dom} -s > ${COMOUT}/${prslev_subh_dom}.idx
     done
   fi
 
@@ -332,8 +339,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
   fi
   if [[ ! -z ${TESTBED_FIELDS_FN} ]]; then
     if [[ -f ${FIX_UPP}/${TESTBED_FIELDS_FN} ]]; then
-      wgrib2 ${COMOUT}/${prslev_conus} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN} | wgrib2 -i -grib ${COMOUT}/${testbed_conus} ${COMOUT}/${prslev_conus}
-      wgrib2 ${COMOUT}/${testbed_conus} -s > ${COMOUT}/${testbed_conus}.idx
+      wgrib2 ${prslev_conus} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN} | wgrib2 -i -grib ${testbed_conus} ${prslev_conus}
+      cpreq ${testbed_conus} ${COMOUT}
+      wgrib2 ${testbed_conus} -s > ${COMOUT}/${testbed_conus}.idx
     else
       echo "WARNING: ${FIX_UPP}/${TESTBED_FIELDS_FN} not found"
     fi
@@ -369,7 +377,8 @@ $GTYPE
 EOF
 
   # Read in corner lat lons from UPP text file
-  export FORT11=${COMOUT}/latlons_corners.txt.f${fhr}
+  cpreq ${COMOUT}/latlons_corners.txt.f${fhr} .
+  export FORT11=${DATA}/latlons_corners.txt.f${fhr}
   export FORT45=itagfw
 
   # Calculate the wgrib2 gridspecs for the fire weather grid
@@ -377,14 +386,16 @@ EOF
   export err=$?; err_chk
 
   grid_specs_firewx=`head $DATA/copygb_gridnavfw.txt`
-  eval infile=${COMOUT}/${net4}.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx.grib2
+  cpreq ${COMOUT}/${net4}.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx.grib2 .
+  eval infile=${net4}.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx.grib2
 
   wgrib2 ${infile} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
    -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
    -new_grid_interpolation neighbor \
    -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2
-  wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
+   -new_grid ${grid_specs_firewx} rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2
+  cpreq rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 ${COMOUT}
+  wgrib2 rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
 
 fi
 #

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -23,17 +23,18 @@ runRRFS="000 003 006 009 012 015 018 021 024 027 030 033 036 039 042 045 048 051
 if  echo $runRRFS |grep $fhr;
 then
   # Processing AWIPS grid (RRFS 3-km North America grid)
-  export INPUTfile=${COMOUT}/rrfs.t${cyc}z.prslev.3km.f${fhr}.na.grib2
+  cpreq ${COMOUT}/rrfs.t${cyc}z.prslev.3km.f${fhr}.na.grib2 .
+  export INPUTfile=rrfs.t${cyc}z.prslev.3km.f${fhr}.na.grib2
 
   # Only grab records that need WMO headers for AWIPS
-  $WGRIB2 ${INPUTfile} | grep -F -f ${PARMrrfs}/wmo/rrfsparams_3km | $WGRIB2 -i ${INPUTfile} -new_grid_winds grid -set_grib_type same -grib rrfs.t${cyc}z.prslev.3km.f${fhr}.na.grib2
+  $WGRIB2 ${INPUTfile} | grep -F -f ${PARMrrfs}/wmo/rrfsparams_3km | $WGRIB2 -i ${INPUTfile} -new_grid_winds grid -set_grib_type same -grib rrfs.t${cyc}z.prslev.3km.f${fhr}.na.awips.grib2
 
   # Run tocgrib2
 
   export pgm="tocgrib2"
   . prep_step
 
-  export FORT11=rrfs.t${cyc}z.prslev.3km.f${fhr}.na.grib2
+  export FORT11=rrfs.t${cyc}z.prslev.3km.f${fhr}.na.awips.grib2
   export FORT51=grib2.t${cyc}z.awprrfs_f${fhr}_${cyc}
   $TOCGRIB2 < $PARMrrfs/wmo/grib2_awips_rrfs_f${fhr}
   export err=$?; err_chk

--- a/ush/set_FV3nml_sfc_climo_filenames.sh
+++ b/ush/set_FV3nml_sfc_climo_filenames.sh
@@ -150,7 +150,7 @@ for (( i=0; i<${num_nml_vars}; i++ )); do
 #
 # Set the full path to the surface climatology file.
 #
-  fp="${FIXLAM}/${CRES}.${sfc_climo_field_name}.$suffix"
+  fp="${DATA}/INPUT/${CRES}.${sfc_climo_field_name}.$suffix"
 #
 # Add a line to the variable "settings" that specifies (in a yaml-compliant
 # format) the name of the current namelist variable and the value it should


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- NCO has stated that for any jobs accessing data in COM, the data should be copied via cpreq into the DATA directory first.  Based on my look through of the workflow, I found the following tasks will need to utilize cpreq commands:
   - forecast (firewx)
   - make_ics (firewx)
   - make_lbcs (firewx)
   - prdgen

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
These changes are currently untested.  I will work with @lgannoaa to test these changes later today, which is why this PR is still a draft for now.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- This PR resolves issue #1266 