### PR TITLE
Update names of deterministic RRFS WMO files

### DIFF
--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -34,11 +34,11 @@ then
   . prep_step
 
   export FORT11=rrfs.t${cyc}z.prslev.3km.f${fhr}.na.grib2
-  export FORT51=grib2.t${cyc}z.awprrfs_f${fhr}_${cyc}
+  export FORT51=grib2.rrfs.t${cyc}z.awips.f${fhr}
   $TOCGRIB2 < $PARMrrfs/wmo/grib2_awips_rrfs_f${fhr}
   export err=$?; err_chk
 
-  cpreq -p grib2.t${cyc}z.awprrfs_f${fhr}_${cyc} ${COMOUT}/wmo
+  cpreq -p grib2.rrfs.t${cyc}z.awips.f${fhr} ${COMOUT}/wmo
 
 # DBN alerts from HRRR script - someone can modify this for RRFS later
 #  if [ $SENDDBN_NTC = YES -a $fhr -le 18 ]


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- The filenames of the WMO-headed files for the deterministic RRFS need to be updated to reflect the latest conventions outlined in the EE2 standards.  grib2.t${cyc}z.awprrfs_f${fhr}_${cyc} is modified to grib2.rrfs.t${cyc}z.awips.f${fhr} in ush/prdgen/rrfs_mkawp.sh.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Since this is such a simple change, no tests were conducted and I don't anticipate it causing any problems.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #1269 