### PR TITLE
[dev-sci] Diagnostically update delp analysis increment from ps; Add qmin=1e-7

### DIFF
--- a/parm/rdas-atmosphere-templates-fv3_c13.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13.yaml
@@ -4,7 +4,7 @@ algorithm: 3dvar
 # Search path for model and obs for JCB (relative for the submodule, or can be absolute)
 # --------------------------------------------------------------------------------------
 app_path_algorithm: rdas/algorithm/atmosphere
-app_path_model: rdas/model/atmosphere
+app_path_model: rdas/model/fv3/atmosphere
 app_path_observations: rdas/observations/atmosphere
 app_path_observation_chronicle: rdas/observation_chronicle/atmosphere
 
@@ -35,8 +35,27 @@ analysis_variables:
 - northward_wind
 - air_temperature
 - water_vapor_mixing_ratio_wrt_moist_air
-- air_pressure_at_surface
 - ozone_mass_mixing_ratio
+#- air_pressure_thickness
+- air_pressure_at_surface
+
+control_variables:
+- eastward_wind
+- northward_wind
+- virtual_temperature
+- water_vapor_mixing_ratio_wrt_moist_air
+- ozone_mass_mixing_ratio
+- air_pressure_at_surface
+
+state_variables_to_inverse:
+- eastward_wind
+- northward_wind
+- air_temperature
+- water_vapor_mixing_ratio_wrt_moist_air
+- ozone_mass_mixing_ratio
+- geopotential_height_times_gravity_at_surface
+- air_pressure_thickness
+- air_pressure_at_surface
 
 # Testing
 # -------

--- a/parm/rdas-atmosphere-templates-fv3_c13_dbz.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_dbz.yaml
@@ -4,7 +4,7 @@ algorithm: 3dvar
 # Search path for model and obs for JCB (relative for the submodule, or can be absolute)
 # --------------------------------------------------------------------------------------
 app_path_algorithm: rdas/algorithm/atmosphere
-app_path_model: rdas/model/atmosphere
+app_path_model: rdas/model/fv3/atmosphere
 app_path_observations: rdas/observations/atmosphere
 app_path_observation_chronicle: rdas/observation_chronicle/atmosphere
 
@@ -34,7 +34,22 @@ analysis_variables:
 - northward_wind
 - air_temperature
 - water_vapor_mixing_ratio_wrt_moist_air
+- ozone_mass_mixing_ratio
+#- air_pressure_thickness
+- cloud_liquid_water
+- cloud_liquid_ice
+- rain_water
+- snow_water
+- graupel
+- upward_air_velocity
+- equivalent_reflectivity_factor
 - air_pressure_at_surface
+
+control_variables:
+- eastward_wind
+- northward_wind
+- virtual_temperature
+- water_vapor_mixing_ratio_wrt_moist_air
 - ozone_mass_mixing_ratio
 - cloud_liquid_water
 - cloud_liquid_ice
@@ -43,6 +58,17 @@ analysis_variables:
 - graupel
 - upward_air_velocity
 - equivalent_reflectivity_factor
+- air_pressure_at_surface
+
+state_variables_to_inverse:
+- eastward_wind
+- northward_wind
+- air_temperature
+- water_vapor_mixing_ratio_wrt_moist_air
+- ozone_mass_mixing_ratio
+- geopotential_height_times_gravity_at_surface
+- air_pressure_thickness
+- air_pressure_at_surface
 
 # Testing
 # -------

--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -599,6 +599,19 @@ fi
 
 #
 #-----------------------------------------------------------------------
+# Set floor q value to qmin globally to mimic GSI.
+# This edits the background file on disk.
+#-----------------------------------------------------------------------
+#
+# NOTE: GSI uses qmin=1e-7 dated to 2011. We may want to only clip
+#        negative values which may already be done in JEDI. This
+#        step is just to reduce differences between JEDI and GSI for
+#        development testing. We also may add this as a configurable
+#        option in the future if there is such a need.
+ncap2 -O -s 'qmin=1.0e-7f; where(sphum < qmin) sphum = qmin;' fv3_tracer fv3_tracer
+
+#
+#-----------------------------------------------------------------------
 #
 # Run JEDI. Note that we have to launch the forecast from
 # the current cycle's run directory because the JEDI executable will look
@@ -629,7 +642,13 @@ mv errfile errfile_jedi
 #-----------------------------------------------------------------------
 #
 #####################################################################
-# 1. Convert A-grid wind increments to D-grid wind increments
+# 1. Compute delp from ps (increments)
+#####################################################################
+cp "${RDASAPP_DIR}"/rrfs-test/IODA/offline_compute_delp_inc.py .
+python offline_compute_delp_inc.py --sfc_inc inc_jedi.sfc_data.nc --core_inc inc_jedi.fv_core.res.nc --akbk fv3_akbk
+
+#####################################################################
+# 2. Convert A-grid wind increments to D-grid wind increments
 #####################################################################
 export LD_LIBRARY_PATH="/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/hdf5-1.14.3-umtw5lv/lib:${LD_LIBRARY_PATH}"
 export pgm="rdas_ua2u.x"
@@ -647,10 +666,6 @@ if [ ! -s inc_jedi.fv_core.res.nc ]; then
   echo "ERROR: inc_jedi.fv_core.res.nc missing or empty after rdas_ua2u.x"
   exit 6
 fi
-#####################################################################
-# 2. Compute delp from ps
-#####################################################################
-
 #####################################################################
 # 3. Convert doubles to floats
 #####################################################################
@@ -691,27 +706,25 @@ ncrename -v v,v_inc tmp_inc.nc
 ncrename -v T,T_inc tmp_inc.nc
 ncrename -v ua,ua_inc tmp_inc.nc
 ncrename -v va,va_inc tmp_inc.nc
+ncrename -v delp,delp_inc tmp_inc.nc
 if [[ ${anav_type} == "radardbz" || ${anav_type} == "conv_dbz" ]]; then
   ncrename -v W,W_inc tmp_inc.nc
 fi
-# ncrename -v delp,delp_inc tmp_inc.nc
 
 # Append increment vars to tmp_bkg.nc
 ncks -A tmp_inc.nc tmp_bkg.nc
 
 # Perform addition in place
-addstr="u=u+u_inc; v=v+v_inc; T=T+T_inc; ua=ua+ua_inc; va=va+va_inc;"
-varlist="u_inc,v_inc,T_inc,ua_inc,va_inc"
+addstr="u=u+u_inc; v=v+v_inc; T=T+T_inc; ua=ua+ua_inc; va=va+va_inc; delp=delp+delp_inc;"
+varlist="u_inc,v_inc,T_inc,ua_inc,va_inc,delp_inc"
 if [[ ${anav_type} == "radardbz" || ${anav_type} == "conv_dbz" ]]; then
   addstr="${addstr} W=W+W_inc;"
   varlist="${varlist},W_inc"
 fi
-ncap2 -O \
-  -s "${addstr}" \
-  tmp_bkg.nc "$OUT" #add delp
+ncap2 -O -s "${addstr}" tmp_bkg.nc "$OUT"
 
 # Remove increment variables
-ncks -O -x -v ${varlist} "$OUT" "$OUT" #remove delp_inc here
+ncks -O -x -v ${varlist} "$OUT" "$OUT"
 
 # Cleanup
 rm -f tmp_inc.nc tmp_bkg.nc

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -68,7 +68,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/RDASApp
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = 5ad0524
+hash = f9fc96a
 local_path = RDASApp
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR

- Adds an offline python tool to diagnostically update the delp (air_pressure_thickness) analysis increments from ps (air_surface_pressure) analysis increments. These increments are then added to the background just like the other analysis variables.
- Add a qmin=1e-7 function to mimic GSI function. This is temporary and simply for development purposes to reduce the amount of differences between GSI and JEDI.
- Syncs the RDASApp with the most recent making use of several new organizational features as well as the new python tool.

## TESTS CONDUCTED: 
Ran a few DA cycles in simplified workflow

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
- Fixes the qmin issue mentioned in https://github.com/NOAA-EMC/RDASApp/issues/507
- Fixes the delp increment issue mentioned in https://github.com/NOAA-EMC/RDASApp/issues/518

## CONTRIBUTORS (optional): 
@TingLei-NOAA @HuiLiu-NOAA @SamuelDegelia-NOAA  @Masanori-NOAA @ShunLiu-NOAA Thanks for the great discussions and teamwork!

