### PR TITLE
fix a small bug for atms ioda naming convention

### DIFF
--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -64,7 +64,7 @@ done
 ${cpreq} "${FIXrrfs}/jedi/atms_beamwidth.txt" .
 ${cpreq} "${PARMrrfs}/bufr_atms_mapping.yaml" .
 input_file="atmsbufr"
-output_file="ioda.atms_{splits/satId}.nc"
+output_file="ioda_atms_{splits/satId}.nc"
 yaml="bufr_atms_mapping.yaml"
 if [[ -f "$input_file" ]]; then
   ./bufr2netcdf.x "$input_file" "$yaml" "$output_file"


### PR DESCRIPTION
fix a small bug for atms ioda naming convention 
Machines/Platforms: Gaea
