### PR TITLE
Update UPP hash in RRFS to add UUtah SLR 2024 algorithm

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -26,7 +26,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = 9da2b88
+hash = 3f5f2ad
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR updates the hash of the UPP code to the latest version in the release/rrfs_v1 branch (commit 3f5f2ad).  WPC is concerned about the SLR values in RRFS being too low, and they are the result of using the older version of the UUtah SLR algorithm.  The decision was made last week to use the latest UUtah SLR scheme (referred to as 2024 algorithm) that is available in the UPP develop branch.  Here is the corresponding [UPP PR](https://github.com/NOAA-EMC/UPP/pull/1406) with these code changes.
- We would like to get these changes into NCO's RRFS real-time parallel soon.  This PR will involve re-compiling the UPP code.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
The UPP code built successfully for me using the rrfs-workflow on Dogwood.  The UPP code changes were tested as part of the separate UPP PR and here is a comparison plot of the SLR values (inversely related to the SDEN parameter) before and after the changes.
<img width="495" height="405" alt="image" src="https://github.com/user-attachments/assets/b64606d3-d1f9-42d6-906f-ee2792a40a6e" />
<img width="495" height="405" alt="image" src="https://github.com/user-attachments/assets/58d89c88-5025-4252-812d-51f90476a43d" />

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@JesseMeng-NOAA @WenMeng-NOAA 
