### PR TITLE
[rrfs-nco] New fallback capability

### DIFF
--- a/ecf/defs/rrfs_prod.def
+++ b/ecf/defs/rrfs_prod.def
@@ -629,172 +629,256 @@ suite rrfs_dev
                   edit BCGRP '00'
                 task jrrfs_det_make_lbcs_01
                   edit BCGRP '01'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_02
                   edit BCGRP '02'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_03
                   edit BCGRP '03'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_04
                   edit BCGRP '04'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_05
                   edit BCGRP '05'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_06
                   edit BCGRP '06'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_07
                   edit BCGRP '07'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_08
                   edit BCGRP '08'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_09
                   edit BCGRP '09'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_10
                   edit BCGRP '10'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_11
                   edit BCGRP '11'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_12
                   edit BCGRP '12'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_13
                   edit BCGRP '13'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_14
                   edit BCGRP '14'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_15
                   edit BCGRP '15'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_16
                   edit BCGRP '16'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_17
                   edit BCGRP '17'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_18
                   edit BCGRP '18'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_19
                   edit BCGRP '19'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_20
                   edit BCGRP '20'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_21
                   edit BCGRP '21'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_22
                   edit BCGRP '22'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_23
                   edit BCGRP '23'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_24
                   edit BCGRP '24'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_25
                   edit BCGRP '25'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_26
                   edit BCGRP '26'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_27
                   edit BCGRP '27'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_28
                   edit BCGRP '28'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_29
                   edit BCGRP '29'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_30
                   edit BCGRP '30'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_31
                   edit BCGRP '31'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_32
                   edit BCGRP '32'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_33
                   edit BCGRP '33'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_34
                   edit BCGRP '34'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_35
                   edit BCGRP '35'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_36
                   edit BCGRP '36'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_37
                   edit BCGRP '37'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_38
                   edit BCGRP '38'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_39
                   edit BCGRP '39'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_40
                   edit BCGRP '40'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_41
                   edit BCGRP '41'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_42
                   edit BCGRP '42'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_43
                   edit BCGRP '43'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_44
                   edit BCGRP '44'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_45
                   edit BCGRP '45'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_46
                   edit BCGRP '46'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_47
                   edit BCGRP '47'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_48
                   edit BCGRP '48'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_49
                   edit BCGRP '49'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_50
                   edit BCGRP '50'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_51
                   edit BCGRP '51'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_52
                   edit BCGRP '52'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_53
                   edit BCGRP '53'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_54
                   edit BCGRP '54'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_55
                   edit BCGRP '55'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_56
                   edit BCGRP '56'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_57
                   edit BCGRP '57'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_58
                   edit BCGRP '58'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_59
                   edit BCGRP '59'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_60
                   edit BCGRP '60'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_61
                   edit BCGRP '61'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_62
                   edit BCGRP '62'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_63
                   edit BCGRP '63'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_64
                   edit BCGRP '64'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_65
                   edit BCGRP '65'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_66
                   edit BCGRP '66'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_67
                   edit BCGRP '67'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_68
                   edit BCGRP '68'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_69
                   edit BCGRP '69'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_70
                   edit BCGRP '70'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_71
                   edit BCGRP '71'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_72
                   edit BCGRP '72'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_73
                   edit BCGRP '73'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_74
                   edit BCGRP '74'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_75
                   edit BCGRP '75'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_76
                   edit BCGRP '76'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_77
                   edit BCGRP '77'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_78
                   edit BCGRP '78'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_79
                   edit BCGRP '79'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_80
                   edit BCGRP '80'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_81
                   edit BCGRP '81'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_82
                   edit BCGRP '82'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_83
                   edit BCGRP '83'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_84
                   edit BCGRP '84'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -2052,109 +2136,109 @@ suite rrfs_dev
                   trigger ./jrrfs_firewx_make_ics==complete
                 task jrrfs_firewx_make_lbcs_01
                   edit BCGRP '01'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_02
                   edit BCGRP '02'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_03
                   edit BCGRP '03'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_04
                   edit BCGRP '04'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_05
                   edit BCGRP '05'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_06
                   edit BCGRP '06'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_07
                   edit BCGRP '07'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_08
                   edit BCGRP '08'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_09
                   edit BCGRP '09'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_10
                   edit BCGRP '10'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_11
                   edit BCGRP '11'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_12
                   edit BCGRP '12'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_13
                   edit BCGRP '13'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_14
                   edit BCGRP '14'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_15
                   edit BCGRP '15'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_16
                   edit BCGRP '16'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_17
                   edit BCGRP '17'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_18
                   edit BCGRP '18'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_19
                   edit BCGRP '19'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_20
                   edit BCGRP '20'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_21
                   edit BCGRP '21'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_22
                   edit BCGRP '22'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_23
                   edit BCGRP '23'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_24
                   edit BCGRP '24'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_25
                   edit BCGRP '25'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_26
                   edit BCGRP '26'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_27
                   edit BCGRP '27'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_28
                   edit BCGRP '28'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_29
                   edit BCGRP '29'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_30
                   edit BCGRP '30'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_31
                   edit BCGRP '31'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_32
                   edit BCGRP '32'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_33
                   edit BCGRP '33'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_34
                   edit BCGRP '34'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_35
                   edit BCGRP '35'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
               endfamily   # firewx
             endfamily     # ics
             family prep
@@ -2586,450 +2670,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_long_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_long_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_long_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_long_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_long_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_long_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_long_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_long_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem003==complete
                 task jrrfs_enkf_save_restart_long_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_long_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_long_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_long_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_long_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_long_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_long_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_long_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem005==complete
                 task jrrfs_enkf_save_restart_long_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_long_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_long_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_long_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_long_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_long_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_long_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_long_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_long_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_long_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_long_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_long_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_long_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_long_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_long_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_long_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_long_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_long_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_long_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_long_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_long_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_long_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_long_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_long_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_long_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_long_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_long_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_long_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_long_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_long_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_long_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_long_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_long_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_long_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_long_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_long_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_long_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_long_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_long_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_long_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_long_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_long_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_long_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_long_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_long_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_long_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_long_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_long_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_long_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_long_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_long_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_long_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_long_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_long_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_long_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_long_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_long_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_long_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_long_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_long_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_long_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_long_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_long_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_long_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_long_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_long_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_long_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_long_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_long_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_long_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_long_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_long_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_long_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_long_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_long_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_long_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_long_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_long_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_long_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_long_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_long_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_long_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_long_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_long_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_long_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_long_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_long_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_long_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_long_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_long_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_long_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_long_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_long_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_long_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_long_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_long_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_long_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_long_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_long_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_long_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_long_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_long_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_long_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_long_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_long_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_long_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
               family ensf
                 edit WGF 'ensf'
@@ -8210,450 +8294,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -10651,450 +10735,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -13080,172 +13164,256 @@ suite rrfs_dev
                   edit BCGRP '00'
                 task jrrfs_det_make_lbcs_01
                   edit BCGRP '01'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_02
                   edit BCGRP '02'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_03
                   edit BCGRP '03'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_04
                   edit BCGRP '04'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_05
                   edit BCGRP '05'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_06
                   edit BCGRP '06'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_07
                   edit BCGRP '07'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_08
                   edit BCGRP '08'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_09
                   edit BCGRP '09'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_10
                   edit BCGRP '10'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_11
                   edit BCGRP '11'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_12
                   edit BCGRP '12'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_13
                   edit BCGRP '13'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_14
                   edit BCGRP '14'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_15
                   edit BCGRP '15'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_16
                   edit BCGRP '16'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_17
                   edit BCGRP '17'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_18
                   edit BCGRP '18'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_19
                   edit BCGRP '19'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_20
                   edit BCGRP '20'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_21
                   edit BCGRP '21'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_22
                   edit BCGRP '22'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_23
                   edit BCGRP '23'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_24
                   edit BCGRP '24'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_25
                   edit BCGRP '25'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_26
                   edit BCGRP '26'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_27
                   edit BCGRP '27'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_28
                   edit BCGRP '28'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_29
                   edit BCGRP '29'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_30
                   edit BCGRP '30'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_31
                   edit BCGRP '31'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_32
                   edit BCGRP '32'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_33
                   edit BCGRP '33'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_34
                   edit BCGRP '34'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_35
                   edit BCGRP '35'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_36
                   edit BCGRP '36'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_37
                   edit BCGRP '37'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_38
                   edit BCGRP '38'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_39
                   edit BCGRP '39'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_40
                   edit BCGRP '40'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_41
                   edit BCGRP '41'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_42
                   edit BCGRP '42'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_43
                   edit BCGRP '43'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_44
                   edit BCGRP '44'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_45
                   edit BCGRP '45'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_46
                   edit BCGRP '46'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_47
                   edit BCGRP '47'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_48
                   edit BCGRP '48'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_49
                   edit BCGRP '49'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_50
                   edit BCGRP '50'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_51
                   edit BCGRP '51'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_52
                   edit BCGRP '52'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_53
                   edit BCGRP '53'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_54
                   edit BCGRP '54'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_55
                   edit BCGRP '55'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_56
                   edit BCGRP '56'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_57
                   edit BCGRP '57'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_58
                   edit BCGRP '58'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_59
                   edit BCGRP '59'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_60
                   edit BCGRP '60'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_61
                   edit BCGRP '61'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_62
                   edit BCGRP '62'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_63
                   edit BCGRP '63'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_64
                   edit BCGRP '64'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_65
                   edit BCGRP '65'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_66
                   edit BCGRP '66'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_67
                   edit BCGRP '67'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_68
                   edit BCGRP '68'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_69
                   edit BCGRP '69'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_70
                   edit BCGRP '70'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_71
                   edit BCGRP '71'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_72
                   edit BCGRP '72'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_73
                   edit BCGRP '73'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_74
                   edit BCGRP '74'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_75
                   edit BCGRP '75'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_76
                   edit BCGRP '76'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_77
                   edit BCGRP '77'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_78
                   edit BCGRP '78'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_79
                   edit BCGRP '79'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_80
                   edit BCGRP '80'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_81
                   edit BCGRP '81'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_82
                   edit BCGRP '82'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_83
                   edit BCGRP '83'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_84
                   edit BCGRP '84'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -14503,109 +14671,109 @@ suite rrfs_dev
                   trigger ./jrrfs_firewx_make_ics==complete
                 task jrrfs_firewx_make_lbcs_01
                   edit BCGRP '01'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_02
                   edit BCGRP '02'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_03
                   edit BCGRP '03'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_04
                   edit BCGRP '04'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_05
                   edit BCGRP '05'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_06
                   edit BCGRP '06'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_07
                   edit BCGRP '07'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_08
                   edit BCGRP '08'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_09
                   edit BCGRP '09'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_10
                   edit BCGRP '10'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_11
                   edit BCGRP '11'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_12
                   edit BCGRP '12'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_13
                   edit BCGRP '13'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_14
                   edit BCGRP '14'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_15
                   edit BCGRP '15'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_16
                   edit BCGRP '16'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_17
                   edit BCGRP '17'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_18
                   edit BCGRP '18'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_19
                   edit BCGRP '19'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_20
                   edit BCGRP '20'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_21
                   edit BCGRP '21'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_22
                   edit BCGRP '22'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_23
                   edit BCGRP '23'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_24
                   edit BCGRP '24'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_25
                   edit BCGRP '25'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_26
                   edit BCGRP '26'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_27
                   edit BCGRP '27'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_28
                   edit BCGRP '28'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_29
                   edit BCGRP '29'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_30
                   edit BCGRP '30'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_31
                   edit BCGRP '31'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_32
                   edit BCGRP '32'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_33
                   edit BCGRP '33'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_34
                   edit BCGRP '34'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_35
                   edit BCGRP '35'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
               endfamily   # firewx
             endfamily     # ics
             family prep
@@ -15067,450 +15235,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
               family ensf
                 edit WGF 'ensf'
@@ -21207,450 +21375,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -23556,450 +23724,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -25927,172 +26095,256 @@ suite rrfs_dev
                   edit BCGRP '00'
                 task jrrfs_det_make_lbcs_01
                   edit BCGRP '01'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_02
                   edit BCGRP '02'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_03
                   edit BCGRP '03'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_04
                   edit BCGRP '04'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_05
                   edit BCGRP '05'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_06
                   edit BCGRP '06'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_07
                   edit BCGRP '07'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_08
                   edit BCGRP '08'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_09
                   edit BCGRP '09'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_10
                   edit BCGRP '10'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_11
                   edit BCGRP '11'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_12
                   edit BCGRP '12'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_13
                   edit BCGRP '13'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_14
                   edit BCGRP '14'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_15
                   edit BCGRP '15'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_16
                   edit BCGRP '16'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_17
                   edit BCGRP '17'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_18
                   edit BCGRP '18'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_19
                   edit BCGRP '19'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_20
                   edit BCGRP '20'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_21
                   edit BCGRP '21'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_22
                   edit BCGRP '22'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_23
                   edit BCGRP '23'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_24
                   edit BCGRP '24'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_25
                   edit BCGRP '25'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_26
                   edit BCGRP '26'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_27
                   edit BCGRP '27'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_28
                   edit BCGRP '28'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_29
                   edit BCGRP '29'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_30
                   edit BCGRP '30'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_31
                   edit BCGRP '31'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_32
                   edit BCGRP '32'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_33
                   edit BCGRP '33'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_34
                   edit BCGRP '34'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_35
                   edit BCGRP '35'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_36
                   edit BCGRP '36'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_37
                   edit BCGRP '37'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_38
                   edit BCGRP '38'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_39
                   edit BCGRP '39'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_40
                   edit BCGRP '40'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_41
                   edit BCGRP '41'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_42
                   edit BCGRP '42'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_43
                   edit BCGRP '43'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_44
                   edit BCGRP '44'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_45
                   edit BCGRP '45'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_46
                   edit BCGRP '46'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_47
                   edit BCGRP '47'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_48
                   edit BCGRP '48'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_49
                   edit BCGRP '49'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_50
                   edit BCGRP '50'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_51
                   edit BCGRP '51'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_52
                   edit BCGRP '52'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_53
                   edit BCGRP '53'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_54
                   edit BCGRP '54'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_55
                   edit BCGRP '55'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_56
                   edit BCGRP '56'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_57
                   edit BCGRP '57'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_58
                   edit BCGRP '58'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_59
                   edit BCGRP '59'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_60
                   edit BCGRP '60'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_61
                   edit BCGRP '61'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_62
                   edit BCGRP '62'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_63
                   edit BCGRP '63'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_64
                   edit BCGRP '64'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_65
                   edit BCGRP '65'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_66
                   edit BCGRP '66'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_67
                   edit BCGRP '67'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_68
                   edit BCGRP '68'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_69
                   edit BCGRP '69'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_70
                   edit BCGRP '70'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_71
                   edit BCGRP '71'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_72
                   edit BCGRP '72'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_73
                   edit BCGRP '73'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_74
                   edit BCGRP '74'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_75
                   edit BCGRP '75'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_76
                   edit BCGRP '76'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_77
                   edit BCGRP '77'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_78
                   edit BCGRP '78'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_79
                   edit BCGRP '79'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_80
                   edit BCGRP '80'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_81
                   edit BCGRP '81'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_82
                   edit BCGRP '82'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_83
                   edit BCGRP '83'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_84
                   edit BCGRP '84'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -27350,109 +27602,109 @@ suite rrfs_dev
                   trigger ./jrrfs_firewx_make_ics==complete
                 task jrrfs_firewx_make_lbcs_01
                   edit BCGRP '01'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_02
                   edit BCGRP '02'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_03
                   edit BCGRP '03'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_04
                   edit BCGRP '04'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_05
                   edit BCGRP '05'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_06
                   edit BCGRP '06'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_07
                   edit BCGRP '07'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_08
                   edit BCGRP '08'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_09
                   edit BCGRP '09'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_10
                   edit BCGRP '10'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_11
                   edit BCGRP '11'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_12
                   edit BCGRP '12'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_13
                   edit BCGRP '13'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_14
                   edit BCGRP '14'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_15
                   edit BCGRP '15'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_16
                   edit BCGRP '16'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_17
                   edit BCGRP '17'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_18
                   edit BCGRP '18'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_19
                   edit BCGRP '19'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_20
                   edit BCGRP '20'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_21
                   edit BCGRP '21'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_22
                   edit BCGRP '22'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_23
                   edit BCGRP '23'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_24
                   edit BCGRP '24'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_25
                   edit BCGRP '25'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_26
                   edit BCGRP '26'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_27
                   edit BCGRP '27'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_28
                   edit BCGRP '28'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_29
                   edit BCGRP '29'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_30
                   edit BCGRP '30'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_31
                   edit BCGRP '31'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_32
                   edit BCGRP '32'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_33
                   edit BCGRP '33'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_34
                   edit BCGRP '34'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_35
                   edit BCGRP '35'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
               endfamily   # firewx
             endfamily     # ics
             family prep
@@ -27885,450 +28137,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
               family ensf
                 edit WGF 'ensf'
@@ -33509,450 +33761,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -35951,450 +36203,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -38382,172 +38634,256 @@ suite rrfs_dev
                   edit BCGRP '00'
                 task jrrfs_det_make_lbcs_01
                   edit BCGRP '01'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_02
                   edit BCGRP '02'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_03
                   edit BCGRP '03'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_04
                   edit BCGRP '04'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_05
                   edit BCGRP '05'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_06
                   edit BCGRP '06'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_07
                   edit BCGRP '07'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_08
                   edit BCGRP '08'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_09
                   edit BCGRP '09'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_10
                   edit BCGRP '10'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_11
                   edit BCGRP '11'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_12
                   edit BCGRP '12'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_13
                   edit BCGRP '13'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_14
                   edit BCGRP '14'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_15
                   edit BCGRP '15'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_16
                   edit BCGRP '16'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_17
                   edit BCGRP '17'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_18
                   edit BCGRP '18'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_19
                   edit BCGRP '19'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_20
                   edit BCGRP '20'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_21
                   edit BCGRP '21'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_22
                   edit BCGRP '22'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_23
                   edit BCGRP '23'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_24
                   edit BCGRP '24'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_25
                   edit BCGRP '25'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_26
                   edit BCGRP '26'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_27
                   edit BCGRP '27'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_28
                   edit BCGRP '28'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_29
                   edit BCGRP '29'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_30
                   edit BCGRP '30'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_31
                   edit BCGRP '31'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_32
                   edit BCGRP '32'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_33
                   edit BCGRP '33'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_34
                   edit BCGRP '34'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_35
                   edit BCGRP '35'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_36
                   edit BCGRP '36'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_37
                   edit BCGRP '37'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_38
                   edit BCGRP '38'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_39
                   edit BCGRP '39'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_40
                   edit BCGRP '40'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_41
                   edit BCGRP '41'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_42
                   edit BCGRP '42'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_43
                   edit BCGRP '43'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_44
                   edit BCGRP '44'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_45
                   edit BCGRP '45'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_46
                   edit BCGRP '46'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_47
                   edit BCGRP '47'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_48
                   edit BCGRP '48'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_49
                   edit BCGRP '49'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_50
                   edit BCGRP '50'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_51
                   edit BCGRP '51'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_52
                   edit BCGRP '52'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_53
                   edit BCGRP '53'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_54
                   edit BCGRP '54'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_55
                   edit BCGRP '55'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_56
                   edit BCGRP '56'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_57
                   edit BCGRP '57'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_58
                   edit BCGRP '58'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_59
                   edit BCGRP '59'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_60
                   edit BCGRP '60'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_61
                   edit BCGRP '61'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_62
                   edit BCGRP '62'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_63
                   edit BCGRP '63'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_64
                   edit BCGRP '64'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_65
                   edit BCGRP '65'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_66
                   edit BCGRP '66'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_67
                   edit BCGRP '67'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_68
                   edit BCGRP '68'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_69
                   edit BCGRP '69'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_70
                   edit BCGRP '70'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_71
                   edit BCGRP '71'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_72
                   edit BCGRP '72'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_73
                   edit BCGRP '73'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_74
                   edit BCGRP '74'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_75
                   edit BCGRP '75'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_76
                   edit BCGRP '76'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_77
                   edit BCGRP '77'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_78
                   edit BCGRP '78'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_79
                   edit BCGRP '79'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_80
                   edit BCGRP '80'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_81
                   edit BCGRP '81'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_82
                   edit BCGRP '82'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_83
                   edit BCGRP '83'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
                 task jrrfs_det_make_lbcs_84
                   edit BCGRP '84'
+                  trigger ./jrrfs_det_make_lbcs_00==complete
               endfamily   # det
               family enkf
                 edit WGF 'enkf'
@@ -39805,109 +40141,109 @@ suite rrfs_dev
                   trigger ./jrrfs_firewx_make_ics==complete
                 task jrrfs_firewx_make_lbcs_01
                   edit BCGRP '01'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_02
                   edit BCGRP '02'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_03
                   edit BCGRP '03'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_04
                   edit BCGRP '04'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_05
                   edit BCGRP '05'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_06
                   edit BCGRP '06'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_07
                   edit BCGRP '07'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_08
                   edit BCGRP '08'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_09
                   edit BCGRP '09'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_10
                   edit BCGRP '10'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_11
                   edit BCGRP '11'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_12
                   edit BCGRP '12'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_13
                   edit BCGRP '13'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_14
                   edit BCGRP '14'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_15
                   edit BCGRP '15'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_16
                   edit BCGRP '16'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_17
                   edit BCGRP '17'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_18
                   edit BCGRP '18'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_19
                   edit BCGRP '19'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_20
                   edit BCGRP '20'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_21
                   edit BCGRP '21'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_22
                   edit BCGRP '22'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_23
                   edit BCGRP '23'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_24
                   edit BCGRP '24'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_25
                   edit BCGRP '25'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_26
                   edit BCGRP '26'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_27
                   edit BCGRP '27'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_28
                   edit BCGRP '28'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_29
                   edit BCGRP '29'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_30
                   edit BCGRP '30'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_31
                   edit BCGRP '31'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_32
                   edit BCGRP '32'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_33
                   edit BCGRP '33'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_34
                   edit BCGRP '34'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
                 task jrrfs_firewx_make_lbcs_35
                   edit BCGRP '35'
-                  trigger ./jrrfs_firewx_make_ics==complete
+                  trigger ./jrrfs_firewx_make_ics==complete and ./jrrfs_firewx_make_lbcs_00==complete
               endfamily   # firewx
             endfamily     # ics
             family prep
@@ -40369,450 +40705,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete and ../../analysis/enkf/jrrfs_enkf_save_da_output_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
               family ensf
                 edit WGF 'ensf'
@@ -46510,450 +46846,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post
@@ -48856,450 +49192,450 @@ suite rrfs_dev
                 task jrrfs_enkf_save_restart_mem001_f1
                   edit MEMBER_NAME '001'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f1
                 task jrrfs_enkf_save_restart_mem001_f2
                   edit MEMBER_NAME '001'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f2
                 task jrrfs_enkf_save_restart_mem001_f3
                   edit MEMBER_NAME '001'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem001==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_001_f3
                 task jrrfs_enkf_forecast_mem002
                   edit MEMBER_NAME '002'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem002==complete
                 task jrrfs_enkf_save_restart_mem002_f1
                   edit MEMBER_NAME '002'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f1
                 task jrrfs_enkf_save_restart_mem002_f2
                   edit MEMBER_NAME '002'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f2
                 task jrrfs_enkf_save_restart_mem002_f3
                   edit MEMBER_NAME '002'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem002==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_002_f3
                 task jrrfs_enkf_forecast_mem003
                   edit MEMBER_NAME '003'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem003==complete
                 task jrrfs_enkf_save_restart_mem003_f1
                   edit MEMBER_NAME '003'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f1
                 task jrrfs_enkf_save_restart_mem003_f2
                   edit MEMBER_NAME '003'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f2
                 task jrrfs_enkf_save_restart_mem003_f3
                   edit MEMBER_NAME '003'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem003==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_003_f3
                 task jrrfs_enkf_forecast_mem004
                   edit MEMBER_NAME '004'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem004==complete
                 task jrrfs_enkf_save_restart_mem004_f1
                   edit MEMBER_NAME '004'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f1
                 task jrrfs_enkf_save_restart_mem004_f2
                   edit MEMBER_NAME '004'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f2
                 task jrrfs_enkf_save_restart_mem004_f3
                   edit MEMBER_NAME '004'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem004==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_004_f3
                 task jrrfs_enkf_forecast_mem005
                   edit MEMBER_NAME '005'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem005==complete
                 task jrrfs_enkf_save_restart_mem005_f1
                   edit MEMBER_NAME '005'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f1
                 task jrrfs_enkf_save_restart_mem005_f2
                   edit MEMBER_NAME '005'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f2
                 task jrrfs_enkf_save_restart_mem005_f3
                   edit MEMBER_NAME '005'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem005==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_005_f3
                 task jrrfs_enkf_forecast_mem006
                   edit MEMBER_NAME '006'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem006==complete
                 task jrrfs_enkf_save_restart_mem006_f1
                   edit MEMBER_NAME '006'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f1
                 task jrrfs_enkf_save_restart_mem006_f2
                   edit MEMBER_NAME '006'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f2
                 task jrrfs_enkf_save_restart_mem006_f3
                   edit MEMBER_NAME '006'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem006==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_006_f3
                 task jrrfs_enkf_forecast_mem007
                   edit MEMBER_NAME '007'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem007==complete
                 task jrrfs_enkf_save_restart_mem007_f1
                   edit MEMBER_NAME '007'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f1
                 task jrrfs_enkf_save_restart_mem007_f2
                   edit MEMBER_NAME '007'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f2
                 task jrrfs_enkf_save_restart_mem007_f3
                   edit MEMBER_NAME '007'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem007==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_007_f3
                 task jrrfs_enkf_forecast_mem008
                   edit MEMBER_NAME '008'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem008==complete
                 task jrrfs_enkf_save_restart_mem008_f1
                   edit MEMBER_NAME '008'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f1
                 task jrrfs_enkf_save_restart_mem008_f2
                   edit MEMBER_NAME '008'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f2
                 task jrrfs_enkf_save_restart_mem008_f3
                   edit MEMBER_NAME '008'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem008==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_008_f3
                 task jrrfs_enkf_forecast_mem009
                   edit MEMBER_NAME '009'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem009==complete
                 task jrrfs_enkf_save_restart_mem009_f1
                   edit MEMBER_NAME '009'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f1
                 task jrrfs_enkf_save_restart_mem009_f2
                   edit MEMBER_NAME '009'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f2
                 task jrrfs_enkf_save_restart_mem009_f3
                   edit MEMBER_NAME '009'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem009==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_009_f3
                 task jrrfs_enkf_forecast_mem010
                   edit MEMBER_NAME '010'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem010==complete
                 task jrrfs_enkf_save_restart_mem010_f1
                   edit MEMBER_NAME '010'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f1
                 task jrrfs_enkf_save_restart_mem010_f2
                   edit MEMBER_NAME '010'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f2
                 task jrrfs_enkf_save_restart_mem010_f3
                   edit MEMBER_NAME '010'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem010==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_010_f3
                 task jrrfs_enkf_forecast_mem011
                   edit MEMBER_NAME '011'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem011==complete
                 task jrrfs_enkf_save_restart_mem011_f1
                   edit MEMBER_NAME '011'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f1
                 task jrrfs_enkf_save_restart_mem011_f2
                   edit MEMBER_NAME '011'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f2
                 task jrrfs_enkf_save_restart_mem011_f3
                   edit MEMBER_NAME '011'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem011==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_011_f3
                 task jrrfs_enkf_forecast_mem012
                   edit MEMBER_NAME '012'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem012==complete
                 task jrrfs_enkf_save_restart_mem012_f1
                   edit MEMBER_NAME '012'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f1
                 task jrrfs_enkf_save_restart_mem012_f2
                   edit MEMBER_NAME '012'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f2
                 task jrrfs_enkf_save_restart_mem012_f3
                   edit MEMBER_NAME '012'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem012==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_012_f3
                 task jrrfs_enkf_forecast_mem013
                   edit MEMBER_NAME '013'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem013==complete
                 task jrrfs_enkf_save_restart_mem013_f1
                   edit MEMBER_NAME '013'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f1
                 task jrrfs_enkf_save_restart_mem013_f2
                   edit MEMBER_NAME '013'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f2
                 task jrrfs_enkf_save_restart_mem013_f3
                   edit MEMBER_NAME '013'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem013==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_013_f3
                 task jrrfs_enkf_forecast_mem014
                   edit MEMBER_NAME '014'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem014==complete
                 task jrrfs_enkf_save_restart_mem014_f1
                   edit MEMBER_NAME '014'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f1
                 task jrrfs_enkf_save_restart_mem014_f2
                   edit MEMBER_NAME '014'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f2
                 task jrrfs_enkf_save_restart_mem014_f3
                   edit MEMBER_NAME '014'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem014==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_014_f3
                 task jrrfs_enkf_forecast_mem015
                   edit MEMBER_NAME '015'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem015==complete
                 task jrrfs_enkf_save_restart_mem015_f1
                   edit MEMBER_NAME '015'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f1
                 task jrrfs_enkf_save_restart_mem015_f2
                   edit MEMBER_NAME '015'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f2
                 task jrrfs_enkf_save_restart_mem015_f3
                   edit MEMBER_NAME '015'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem015==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_015_f3
                 task jrrfs_enkf_forecast_mem016
                   edit MEMBER_NAME '016'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem016==complete
                 task jrrfs_enkf_save_restart_mem016_f1
                   edit MEMBER_NAME '016'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f1
                 task jrrfs_enkf_save_restart_mem016_f2
                   edit MEMBER_NAME '016'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f2
                 task jrrfs_enkf_save_restart_mem016_f3
                   edit MEMBER_NAME '016'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem016==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_016_f3
                 task jrrfs_enkf_forecast_mem017
                   edit MEMBER_NAME '017'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem017==complete
                 task jrrfs_enkf_save_restart_mem017_f1
                   edit MEMBER_NAME '017'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f1
                 task jrrfs_enkf_save_restart_mem017_f2
                   edit MEMBER_NAME '017'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f2
                 task jrrfs_enkf_save_restart_mem017_f3
                   edit MEMBER_NAME '017'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem017==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_017_f3
                 task jrrfs_enkf_forecast_mem018
                   edit MEMBER_NAME '018'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem018==complete
                 task jrrfs_enkf_save_restart_mem018_f1
                   edit MEMBER_NAME '018'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f1
                 task jrrfs_enkf_save_restart_mem018_f2
                   edit MEMBER_NAME '018'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f2
                 task jrrfs_enkf_save_restart_mem018_f3
                   edit MEMBER_NAME '018'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem018==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_018_f3
                 task jrrfs_enkf_forecast_mem019
                   edit MEMBER_NAME '019'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem019==complete
                 task jrrfs_enkf_save_restart_mem019_f1
                   edit MEMBER_NAME '019'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f1
                 task jrrfs_enkf_save_restart_mem019_f2
                   edit MEMBER_NAME '019'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f2
                 task jrrfs_enkf_save_restart_mem019_f3
                   edit MEMBER_NAME '019'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem019==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_019_f3
                 task jrrfs_enkf_forecast_mem020
                   edit MEMBER_NAME '020'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem020==complete
                 task jrrfs_enkf_save_restart_mem020_f1
                   edit MEMBER_NAME '020'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f1
                 task jrrfs_enkf_save_restart_mem020_f2
                   edit MEMBER_NAME '020'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f2
                 task jrrfs_enkf_save_restart_mem020_f3
                   edit MEMBER_NAME '020'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem020==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_020_f3
                 task jrrfs_enkf_forecast_mem021
                   edit MEMBER_NAME '021'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem021==complete
                 task jrrfs_enkf_save_restart_mem021_f1
                   edit MEMBER_NAME '021'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f1
                 task jrrfs_enkf_save_restart_mem021_f2
                   edit MEMBER_NAME '021'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f2
                 task jrrfs_enkf_save_restart_mem021_f3
                   edit MEMBER_NAME '021'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem021==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_021_f3
                 task jrrfs_enkf_forecast_mem022
                   edit MEMBER_NAME '022'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem022==complete
                 task jrrfs_enkf_save_restart_mem022_f1
                   edit MEMBER_NAME '022'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f1
                 task jrrfs_enkf_save_restart_mem022_f2
                   edit MEMBER_NAME '022'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f2
                 task jrrfs_enkf_save_restart_mem022_f3
                   edit MEMBER_NAME '022'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem022==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_022_f3
                 task jrrfs_enkf_forecast_mem023
                   edit MEMBER_NAME '023'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem023==complete
                 task jrrfs_enkf_save_restart_mem023_f1
                   edit MEMBER_NAME '023'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f1
                 task jrrfs_enkf_save_restart_mem023_f2
                   edit MEMBER_NAME '023'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f2
                 task jrrfs_enkf_save_restart_mem023_f3
                   edit MEMBER_NAME '023'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem023==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_023_f3
                 task jrrfs_enkf_forecast_mem024
                   edit MEMBER_NAME '024'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem024==complete
                 task jrrfs_enkf_save_restart_mem024_f1
                   edit MEMBER_NAME '024'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f1
                 task jrrfs_enkf_save_restart_mem024_f2
                   edit MEMBER_NAME '024'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f2
                 task jrrfs_enkf_save_restart_mem024_f3
                   edit MEMBER_NAME '024'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem024==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_024_f3
                 task jrrfs_enkf_forecast_mem025
                   edit MEMBER_NAME '025'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem025==complete
                 task jrrfs_enkf_save_restart_mem025_f1
                   edit MEMBER_NAME '025'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f1
                 task jrrfs_enkf_save_restart_mem025_f2
                   edit MEMBER_NAME '025'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f2
                 task jrrfs_enkf_save_restart_mem025_f3
                   edit MEMBER_NAME '025'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem025==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_025_f3
                 task jrrfs_enkf_forecast_mem026
                   edit MEMBER_NAME '026'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem026==complete
                 task jrrfs_enkf_save_restart_mem026_f1
                   edit MEMBER_NAME '026'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f1
                 task jrrfs_enkf_save_restart_mem026_f2
                   edit MEMBER_NAME '026'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f2
                 task jrrfs_enkf_save_restart_mem026_f3
                   edit MEMBER_NAME '026'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem026==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_026_f3
                 task jrrfs_enkf_forecast_mem027
                   edit MEMBER_NAME '027'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem027==complete
                 task jrrfs_enkf_save_restart_mem027_f1
                   edit MEMBER_NAME '027'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f1
                 task jrrfs_enkf_save_restart_mem027_f2
                   edit MEMBER_NAME '027'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f2
                 task jrrfs_enkf_save_restart_mem027_f3
                   edit MEMBER_NAME '027'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem027==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_027_f3
                 task jrrfs_enkf_forecast_mem028
                   edit MEMBER_NAME '028'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem028==complete
                 task jrrfs_enkf_save_restart_mem028_f1
                   edit MEMBER_NAME '028'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f1
                 task jrrfs_enkf_save_restart_mem028_f2
                   edit MEMBER_NAME '028'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f2
                 task jrrfs_enkf_save_restart_mem028_f3
                   edit MEMBER_NAME '028'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem028==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_028_f3
                 task jrrfs_enkf_forecast_mem029
                   edit MEMBER_NAME '029'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem029==complete
                 task jrrfs_enkf_save_restart_mem029_f1
                   edit MEMBER_NAME '029'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f1
                 task jrrfs_enkf_save_restart_mem029_f2
                   edit MEMBER_NAME '029'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f2
                 task jrrfs_enkf_save_restart_mem029_f3
                   edit MEMBER_NAME '029'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem029==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_029_f3
                 task jrrfs_enkf_forecast_mem030
                   edit MEMBER_NAME '030'
                   trigger ../../analysis/enkf/jrrfs_enkf_analysis_nonvarcld_mem030==complete
                 task jrrfs_enkf_save_restart_mem030_f1
                   edit MEMBER_NAME '030'
                   edit FHR '001'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f1
                 task jrrfs_enkf_save_restart_mem030_f2
                   edit MEMBER_NAME '030'
                   edit FHR '002'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f2
                 task jrrfs_enkf_save_restart_mem030_f3
                   edit MEMBER_NAME '030'
                   edit FHR '003'
-                  trigger ./jrrfs_enkf_forecast_mem030==complete
+                  trigger ../../fsm/jrrfs_fsm:release_enkf_save_restart_030_f3
               endfamily   # enkf
             endfamily     # forecast
             family post

--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -166,6 +166,10 @@ print_info_msg "$VERBOSE" "background type is $BKTYPE"
 if  [[ ${regional_ensemble_option:-1} -eq 5 ]]; then
   ens_nstarthr=$( printf "%02d" ${DA_CYCLE_INTERV} )
   n=${DA_CYCLE_INTERV}
+  SLEEP_TIME=300
+  SLEEP_INT=15
+  SLEEP_LOOP_MAX=`expr $SLEEP_TIME / $SLEEP_INT`
+  ic=0
   while [[ $n -le 3 ]] ; do  # this check only works for hourly cycle
       imem=1
       ifound=0
@@ -205,8 +209,13 @@ if  [[ ${regional_ensemble_option:-1} -eq 5 ]]; then
       if [[ $ifound -eq ${NUM_ENS_MEMBERS} ]]; then
 	      break
       else
-        rm -f ${DATA}/parallel_copy.sh
-        (( n += 1 ))
+        [[ -f ${DATA}/parallel_copy.sh ]] && rm -f ${DATA}/parallel_copy.sh
+        if [[ ${n} -eq ${DA_CYCLE_INTERV} ]] && [[ ${ic} -lt $SLEEP_LOOP_MAX ]]; then
+          ic=`expr $ic + 1`
+          sleep $SLEEP_INT
+        else
+          (( n += 1 ))
+        fi
       fi
   done
 

--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -165,26 +165,27 @@ print_info_msg "$VERBOSE" "background type is $BKTYPE"
 #
 if  [[ ${regional_ensemble_option:-1} -eq 5 ]]; then
   ens_nstarthr=$( printf "%02d" ${DA_CYCLE_INTERV} )
-  imem=1
-  ifound=0
-  touch ${DATA}/parallel_copy.sh
-  for hrs in ${CYCL_HRS_HYB_FV3LAM_ENS[@]}; do
-    if [ $HH == ${hrs} ]; then
+  n=${DA_CYCLE_INTERV}
+  while [[ $n -le 3 ]] ; do  # this check only works for hourly cycle
+      imem=1
+      ifound=0
+      touch ${DATA}/parallel_copy.sh
+      YYYYMMDDHHInterv=$($NDATE -${n} ${YYYYMMDDHH})
+      YYYYMMDDInterv=${YYYYMMDDHHInterv:0:8}
+      HHInterv=${YYYYMMDDHHInterv:8:2}
+      if [ ${n} -eq 1 ]; then
+        for cycl_hrs in ${CYCL_HRS_PRODSTART_ENS[@]}; do
+          if [ $HH == ${cycl_hrs} ]; then
+            HHInterv=${YYYYMMDDHHInterv:8:2}_spinup
+          fi
+         done
+       fi
+      restart_prefix="${YYYYMMDD}.${HH}0000."
       while [[ $imem -le ${NUM_ENS_MEMBERS} ]];do
         memcharv0=$( printf "%03d" $imem )
         memchar=m$( printf "%03d" $imem )
-	prev_YYYYMMDDHHInterv=$($NDATE -${DA_CYCLE_INTERV} ${YYYYMMDDHH})
-	YYYYMMDDInterv=${prev_YYYYMMDDHHInterv:0:8}
-        HHInterv=${prev_YYYYMMDDHHInterv:8:2}
-        restart_prefix="${YYYYMMDD}.${HH}0000."
         bkpathmem=${COMrrfs}/enkfrrfs.${YYYYMMDDInterv}/${HHInterv}/${memchar}/forecast/RESTART
-        if [ ${DO_SPINUP} == "TRUE" ]; then
-          for cycl_hrs in ${CYCL_HRS_PRODSTART_ENS[@]}; do
-           if [ $HH == ${cycl_hrs} ]; then
-             bkpathmem=${COMrrfs}/enkfrrfs.${YYYYMMDDInterv}/${HHInterv}_spinup/${memchar}/forecast/RESTART
-           fi
-          done
-        fi
+
         dynvarfile=${bkpathmem}/${restart_prefix}fv_core.res.tile1.nc
         tracerfile=${bkpathmem}/${restart_prefix}fv_tracer.res.tile1.nc
         phyvarfile=${bkpathmem}/${restart_prefix}phy_data.nc
@@ -200,7 +201,13 @@ if  [[ ${regional_ensemble_option:-1} -eq 5 ]]; then
         fi
         (( imem += 1 ))
       done
-    fi
+      # check if we got enough ensemble forecast
+      if [[ $ifound -eq ${NUM_ENS_MEMBERS} ]]; then
+	      break
+      else
+        rm -f ${DATA}/parallel_copy.sh
+        (( n += 1 ))
+      fi
   done
 
   if [[ $ifound -ne ${NUM_ENS_MEMBERS} ]] || [[ ${BKTYPE} -eq 1 ]]; then

--- a/scripts/exrrfs_blend_ics.sh
+++ b/scripts/exrrfs_blend_ics.sh
@@ -125,55 +125,40 @@ if [[ $DO_ENS_BLENDING == "TRUE" ]]; then
   # Loop through each ensemble member and check if the 1h RRFS EnKF files exist
   #### Check NUM_ENS_MEMBERS for all WGF case to remove thie for loop dead code
   #### waite for 5 minutes
+  NUM_ENS_MEMBERS_FOUND="NO"
   yyyymmdd_m=${yyyymmdd_m1}
   hh_m=${hh_m1}
   nnn=1
   while [[ $nnn -le 5 ]] ; do
-    existing_files=0
-    for imem in $(seq 1 ${NUM_ENS_MEMBERS}); do
-        checkfile="${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res"
-        if [[ -f $checkfile ]]; then
-           ((existing_files++))
-           echo "checkfile count: $existing_files"
-        else
-           echo "File missing: $checkfile"
-        fi
-    done
-    if [ $existing_files -eq ${NUM_ENS_MEMBERS} ]; then
-       print_info_msg "$VERBOSE" "Found ${NUM_ENS_MEMBERS} from ${RUN}.${yyyymmdd_m1}/${hh_m1}"
-       break
-    else
+   checkfile="${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res"
+   if [[ -f $checkfile ]]; then
+      NUM_ENS_MEMBERS_FOUND="YES"
+      nnn=6
+      print_info_msg "$VERBOSE" "Found ${NUM_ENS_MEMBERS} from ${RUN}.${yyyymmdd_m1}/${hh_m1}"
+   else
+      echo "File missing: $checkfile"
       sleep 60
       ((nnn++))
-    fi
+   fi
   done
   # if m1 cyc does not have enough ensemble forecast, check m3 cycle
-  if [ $existing_files -lt ${NUM_ENS_MEMBERS} ]; then
-    nnn=1
-    while [[ $nnn -le 3 ]] ; do
-      existing_files=0
-      for imem in $(seq 1 ${NUM_ENS_MEMBERS}); do
-        checkfile="${COMrrfs}/${RUN}.${yyyymmdd_m3}/${hh_m3}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res"
-        if [[ -f $checkfile ]]; then
-           ((existing_files++))
-           echo "checkfile count: $existing_files"
-        else
-           echo "File missing: $checkfile"
-        fi
-      done
-      if [ $existing_files -eq ${NUM_ENS_MEMBERS} ]; then
-         yyyymmdd_m=${yyyymmdd_m3}
-         hh_m=${hh_m3}
-         print_info_msg "$VERBOSE" "Found ${NUM_ENS_MEMBERS} from ${RUN}.${yyyymmdd_m3}/${hh_m3}"
-         break
-      else
-        sleep 60
-        ((nnn++))
-      fi
-    done
-  fi
+  nnn=1
+  while [[ $nnn -le 3 ]] ; do
+    checkfile="${COMrrfs}/${RUN}.${yyyymmdd_m3}/${hh_m3}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res"
+    if [[ -f $checkfile ]]; then
+      NUM_ENS_MEMBERS_FOUND="YES"
+      nnn=4
+      yyyymmdd_m=${yyyymmdd_m3}
+      hh_m=${hh_m3}
+      print_info_msg "$VERBOSE" "Found ${NUM_ENS_MEMBERS} from ${RUN}.${yyyymmdd_m3}/${hh_m3}"
+    else
+       echo "File missing: $checkfile"
+       sleep 60
+       ((nnn++))
+    fi
+  done
   # Check if the number of existing files is equal to the total number of ensemble members
-  if [[ $existing_files -eq ${NUM_ENS_MEMBERS} ]]; then
+  if [[ ${NUM_ENS_MEMBERS_FOUND} == "YES" ]]; then
       # Check if run_blending file exists, and if not, touch it
       if [[ ! -f $run_blending ]]; then
           touch $run_blending

--- a/scripts/exrrfs_blend_ics.sh
+++ b/scripts/exrrfs_blend_ics.sh
@@ -99,8 +99,11 @@ pgm="blending"
 yyyymmdd="${cdate_crnt_fhr:0:8}"
 hh="${cdate_crnt_fhr:8:2}"
 cdate_crnt_fhr_m1=$($NDATE -1 ${yyyymmdd}${hh})
+cdate_crnt_fhr_m3=$($NDATE -3 ${yyyymmdd}${hh})
 yyyymmdd_m1="${cdate_crnt_fhr_m1:0:8}"
+yyyymmdd_m3="${cdate_crnt_fhr_m3:0:8}"
 hh_m1="${cdate_crnt_fhr_m1:8:2}"
+hh_m3="${cdate_crnt_fhr_m3:8:2}"
 
 DO_ENS_BLENDING=${DO_ENS_BLENDING:-"TRUE"}
 # Check for 1h RRFS EnKF files, if at least one missing then use 1tstep initialization
@@ -121,27 +124,54 @@ if [[ $DO_ENS_BLENDING == "TRUE" ]]; then
 
   # Loop through each ensemble member and check if the 1h RRFS EnKF files exist
   #### Check NUM_ENS_MEMBERS for all WGF case to remove thie for loop dead code
-  wait_for_restart_file=YES
-  while [[ $wait_for_restart_file = "YES" ]] ; do
+  #### waite for 5 minutes
+  yyyymmdd_m=${yyyymmdd_m1}
+  hh_m=${hh_m1}
+  nnn=1
+  while [[ $nnn -le 5 ]] ; do
+    existing_files=0
     for imem in $(seq 1 ${NUM_ENS_MEMBERS}); do
         checkfile="${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res"
         if [[ -f $checkfile ]]; then
-            ((existing_files++))
-            echo "checkfile count: $existing_files"
+           ((existing_files++))
+           echo "checkfile count: $existing_files"
         else
-            if [[ -f $checkfile ]]; then
-              ((existing_files++))
-              echo "RESTART file from previous cycle has become available"
-            else
-              echo "File missing: $checkfile"
-            fi
+           echo "File missing: $checkfile"
         fi
     done
-    if [ ! $existing_files -eq ${NUM_ENS_MEMBERS} ]; then
-      sleep 180
+    if [ $existing_files -eq ${NUM_ENS_MEMBERS} ]; then
+       print_info_msg "$VERBOSE" "Found ${NUM_ENS_MEMBERS} from ${RUN}.${yyyymmdd_m1}/${hh_m1}"
+       break
+    else
+      sleep 60
+      ((nnn++))
     fi
-    wait_for_restart_file=NO
   done
+  # if m1 cyc does not have enough ensemble forecast, check m3 cycle
+  if [ $existing_files -lt ${NUM_ENS_MEMBERS} ]; then
+    nnn=1
+    while [[ $nnn -le 3 ]] ; do
+      existing_files=0
+      for imem in $(seq 1 ${NUM_ENS_MEMBERS}); do
+        checkfile="${COMrrfs}/${RUN}.${yyyymmdd_m3}/${hh_m3}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res"
+        if [[ -f $checkfile ]]; then
+           ((existing_files++))
+           echo "checkfile count: $existing_files"
+        else
+           echo "File missing: $checkfile"
+        fi
+      done
+      if [ $existing_files -eq ${NUM_ENS_MEMBERS} ]; then
+         yyyymmdd_m=${yyyymmdd_m3}
+         hh_m=${hh_m3}
+         print_info_msg "$VERBOSE" "Found ${NUM_ENS_MEMBERS} from ${RUN}.${yyyymmdd_m3}/${hh_m3}"
+         break
+      else
+        sleep 60
+        ((nnn++))
+      fi
+    done
+  fi
   # Check if the number of existing files is equal to the total number of ensemble members
   if [[ $existing_files -eq ${NUM_ENS_MEMBERS} ]]; then
       # Check if run_blending file exists, and if not, touch it
@@ -194,8 +224,8 @@ if [[ $DO_ENS_BLENDING == "TRUE" ]]; then
      export PYTHONPATH=$PYTHONPATH:$HOMErrfs/lib
 
      # Required NETCDF files - RRFS
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_core.res.tile1.nc ./fv_core.res.tile1.nc
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_tracer.res.tile1.nc ./fv_tracer.res.tile1.nc
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_core.res.tile1.nc ./fv_core.res.tile1.nc
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_tracer.res.tile1.nc ./fv_tracer.res.tile1.nc
 
      # Shortcut the file names/arguments.
      Lx=$ENS_BLENDING_LENGTHSCALE
@@ -229,11 +259,11 @@ if [[ $DO_ENS_BLENDING == "TRUE" ]]; then
 #     ln -s ${DATA}/fv_tracer.res.tile1.nc ${shared_output_data}/fv_tracer.res.tile1.nc
      cpreq ${DATA}/fv_tracer.res.tile1.nc ${shared_output_data}/fv_tracer.res.tile1.nc
      # Move the remaining RESTART files to INPUT
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_core.res.nc          ${shared_output_data}/fv_core.res.nc
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_srf_wnd.res.tile1.nc ${shared_output_data}/fv_srf_wnd.res.tile1.nc
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.phy_data.nc             ${shared_output_data}/phy_data.nc
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.sfc_data.nc             ${shared_output_data}/sfc_data.nc
-     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m1}/${hh_m1}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res             ${shared_output_data}/coupler.res
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_core.res.nc          ${shared_output_data}/fv_core.res.nc
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.fv_srf_wnd.res.tile1.nc ${shared_output_data}/fv_srf_wnd.res.tile1.nc
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.phy_data.nc             ${shared_output_data}/phy_data.nc
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.sfc_data.nc             ${shared_output_data}/sfc_data.nc
+     cpreq -p ${COMrrfs}/${RUN}.${yyyymmdd_m}/${hh_m}/${mem_num}/forecast/RESTART/${yyyymmdd}.${hh}0000.coupler.res             ${shared_output_data}/coupler.res
   fi
 fi
 #

--- a/scripts/exrrfs_fsm.sh
+++ b/scripts/exrrfs_fsm.sh
@@ -444,16 +444,16 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_long} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_long for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}_prod/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/*coupler.res|wc -l)
     if [ ${cyc} == 00 ] || [ ${cyc} == 12 ]; then
-      if [ ${restart_set_found} -eq 1 ]; then
+      if [ ${restart_set_found} -ge 1 ]; then
         ecflow_client --event release_save_restart_long_1
       fi
-      if [ ${restart_set_found} -eq 2 ]; then
+      if [ ${restart_set_found} -ge 2 ]; then
         ecflow_client --event release_save_restart_long_2
       fi
-      if [ ${restart_set_found} -eq 3 ]; then
+      if [ ${restart_set_found} -ge 3 ]; then
         ecflow_client --event release_save_restart_long_3
       fi
       if [ ${restart_set_found} -ge 4 ]; then
@@ -462,13 +462,13 @@ while [ $proceed_trigger_scan == "YES" ]; do
       fi
     fi
     if [ ${cyc} == 06 ] || [ ${cyc} == 18 ]; then
-      if [ ${restart_set_found} -eq 1 ]; then
+      if [ ${restart_set_found} -ge 1 ]; then
         ecflow_client --event release_save_restart_long_1
       fi
-      if [ ${restart_set_found} -eq 2 ]; then
+      if [ ${restart_set_found} -ge 2 ]; then
         ecflow_client --event release_save_restart_long_2
       fi
-      if [ ${restart_set_found} -eq 3 ]; then
+      if [ ${restart_set_found} -ge 3 ]; then
         ecflow_client --event release_save_restart_long_3
       fi
       if [ ${restart_set_found} -ge 5 ]; then
@@ -484,7 +484,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_f1} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_f1 for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}_prod/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
     if [ ${restart_set_found} -eq 1 ]; then
       ecflow_client --event release_save_restart_f1
@@ -507,7 +507,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   ## Process WGF is det
   if [ ${scan_release_save_restart_spinup_f001} == "YES" ]; then
     echo "Proceeding with scan_release_save_restart_spinup_f001 for det"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}/det/RESTART
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver}_prod/det/RESTART
     restart_set_found=$(ls ${umbrella_forecast_data}/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
     if [ ${restart_set_found} -ge 1 ]; then
       ecflow_client --event release_save_restart_spinup_f001
@@ -523,18 +523,18 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_enkf_save_restart_f1} == "YES" ]; then
     restart_member_completed=0
     echo "Proceeding with scan_release_enkf_save_restart_f1 for enkf"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/enkf
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}_prod/enkf
     for member_name in $(seq 1 30); do
       member_name3d=$( printf "%03d" "${member_name}" )
-      restart_set_mem001_found=$(ls ${umbrella_forecast_data}/${member_name3d}/RESTART/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
+      restart_set_mem001_found=$(ls ${umbrella_forecast_data}/m${member_name3d}/RESTART/${RRFS_next_1_PDY}.${RRFS_next_1_cyc}0000.coupler.res|wc -l)
       if [ ${restart_set_mem001_found} -eq 1 ]; then
         ecflow_client --event release_enkf_save_restart_${member_name3d}_f1
       fi
-      restart_set_mem002_found=$(ls ${umbrella_forecast_data}/${member_name3d}/RESTART/${RRFS_next_2_PDY}.${RRFS_next_2_cyc}0000.coupler.res|wc -l)
+      restart_set_mem002_found=$(ls ${umbrella_forecast_data}/m${member_name3d}/RESTART/${RRFS_next_2_PDY}.${RRFS_next_2_cyc}0000.coupler.res|wc -l)
       if [ ${restart_set_mem002_found} -eq 1 ]; then
         ecflow_client --event release_enkf_save_restart_${member_name3d}_f2
       fi
-      restart_set_mem003_found=$(ls ${umbrella_forecast_data}/${member_name3d}/RESTART/${RRFS_next_3_PDY}.${RRFS_next_3_cyc}0000.coupler.res|wc -l)
+      restart_set_mem003_found=$(ls ${umbrella_forecast_data}/m${member_name3d}/RESTART/${RRFS_next_3_PDY}.${RRFS_next_3_cyc}0000.coupler.res|wc -l)
       if [ ${restart_set_mem003_found} -eq 1 ]; then
         ecflow_client --event release_enkf_save_restart_${member_name3d}_f3
         restart_member_completed=$((restart_member_completed+1))
@@ -552,7 +552,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_det_post_long} == "YES" ]; then
     echo "Proceeding with scan_release_det_post_long"
     source_file_found="YES"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/output
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}_prod/det/output
     # fhr cover 000~084
     for fhr in $(seq 0 84); do
       fhr_2d=$( printf "%02d" ${fhr} )
@@ -601,7 +601,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_ensf_post} == "YES" ]; then
     echo "Proceeding with scan_release_ensf_post"
     source_file_found="YES"
-    umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/ensf/
+    umbrella_forecast_data_base=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}_prod/ensf/
     # mems 1-5
     for mem in $(seq 1 5); do
       memuse=$( printf "%03d" ${mem} )
@@ -633,7 +633,7 @@ while [ $proceed_trigger_scan == "YES" ]; do
   if [ ${scan_release_det_post} == "YES" ]; then
     echo "Proceeding with scan_release_det_post"
     source_file_found="YES"
-    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}/det/output
+    umbrella_forecast_data=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver}_prod/det/output
     # fhr cover 000~018
     for fhr in $(seq 0 18); do
       fhr_2d=$( printf "%02d" ${fhr} )

--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -269,16 +269,13 @@ else
       cpreq -p ${bkpath}/gfs_ctrl.nc gfs_ctrl.nc        
       cpreq -p ${bkpath}/gfs_data.tile7.halo0.nc gfs_data.tile7.halo0.nc        
       cpreq -p ${bkpath}/sfc_data.tile7.halo0.nc sfc_data.tile7.halo0.nc        
-      #cpreq -p ${bkpath}/gfs_bndy.tile7.000.nc bk_gfs_bndy.tile7.000.nc
-      #cpreq -p ${bkpath}/gfs_data.tile7.halo0.nc bk_gfs_data.tile7.halo0.nc
-      #cpreq -p ${bkpath}/sfc_data.tile7.halo0.nc bk_sfc_data.tile7.halo0.nc
       print_info_msg "$VERBOSE" "cold start from $bkpath"
       echo "${YYYYMMDDHH}(${CYCLE_TYPE}): cold start at ${current_time} from $bkpath "
     else
       err_exit "Cannot find cold start initial condition from : ${bkpath}"
     fi
 
-  elif [[ $BKTYPE == 3 ]]; then
+  elif [[ $BKTYPE == 3 ]]; then  # Blending 
     bkpath=${ICS_ROOT}
     if [ -r "${bkpath}/coupler.res" ]; then
       cpreq -p ${bkpath}/fv_core.res.nc fv_core.res.nc
@@ -289,12 +286,6 @@ else
       cpreq -p ${bkpath}/sfc_data.nc sfc_data.nc
       cpreq -p ${bkpath}/gfs_ctrl.nc gfs_ctrl.nc
       cpreq -p ${bkpath}/coupler.res bk_coupler.res
-      #cpreq -p ${bkpath}/fv_core.res.nc bk_fv_core.res.nc
-      #cpreq -p ${bkpath}/fv_core.res.tile1.nc bk_fv_core.res.tile1.nc
-      #cpreq -p ${bkpath}/fv_srf_wnd.res.tile1.nc bk_fv_srf_wnd.res.tile1.nc
-      #cpreq -p ${bkpath}/fv_tracer.res.tile1.nc bk_fv_tracer.res.tile1.nc
-      #cpreq -p ${bkpath}/phy_data.nc bk_phy_data.nc
-      #cpreq -p ${bkpath}/sfc_data.nc bk_sfc_data.nc
       echo "${YYYYMMDDHH}(${CYCLE_TYPE}): blended warm start at ${current_time} from $bkpath "
     else
       err_exit "Error: cannot find blended warm start initial condition from : ${bkpath}"
@@ -340,115 +331,70 @@ else
     bkpath=${LBCS_ROOT}/${RUN}.${PDY}/${cyc}_spinup/${mem_num}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
     ctrl_bkpath=${LBCS_ROOT}/${RUN}.${PDY}/${cyc}_spinup/${mem_num}/forecast/INPUT
   else
-    YYYYMMDDHHmInterv=$($NDATE -${DA_CYCLE_INTERV} ${YYYYMMDD}${HH})
-    YYYYMMDDInterv=`echo ${YYYYMMDDHHmInterv} | cut -c1-8`
-    HHInterv=`echo ${YYYYMMDDHHmInterv} | cut -c9-10`
-    if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-      if [ ${CYCLE_TYPE} == "spinup" ]; then
-        bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${mem_num}/${fg_restart_dirname}/RESTART
-      else
+    n=${DA_CYCLE_INTERV}
+      YYYYMMDDHHmInterv=$($NDATE -${n} ${YYYYMMDD}${HH})
+      YYYYMMDDInterv=`echo ${YYYYMMDDHHmInterv} | cut -c1-8`
+      HHInterv=`echo ${YYYYMMDDHHmInterv} | cut -c9-10`
+      if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
         if [ ${cyc} == "08" ] || [ ${cyc} == "20" ]; then
           bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${mem_num}/${fg_restart_dirname}/RESTART
         else
           bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${mem_num}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
         fi
-      fi
-    else
-      if [ ${CYCLE_TYPE} == "spinup" ]; then
-        bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${fg_restart_dirname}/RESTART
       else
-        if [ ${BKTYPE} -eq 2 ]; then
+        if [ ${CYCLE_TYPE} == "spinup" ]; then
           bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${fg_restart_dirname}/RESTART
         else
-          bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-        fi
-      fi
-    fi
-
-    n=${DA_CYCLE_INTERV}
-    while [[ $n -le 3 ]] ; do
-      checkfile=${bkpath}/${restart_prefix}coupler.res
-      if [ ! -r "${checkfile}" ] && [ "$n" == "1" ] ; then
-        ic=0
-        while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
-          print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
-          ic=`expr $ic + 1`
-          sleep $SLEEP_INT
-          if [ -r "${checkfile}" ] ; then
-            break
-          fi
-        done
-      fi
-      if [ -r "${checkfile}" ] ; then
-        print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "
-        break
-      else
-        n=$((n + ${DA_CYCLE_INTERV}))
-	YYYYMMDDHHmInterv=$($NDATE -${n} ${YYYYMMDD}${HH})
-        YYYYMMDDInterv=`echo ${YYYYMMDDHHmInterv} | cut -c1-8`
-        HHInterv=`echo ${YYYYMMDDHHmInterv} | cut -c9-10`
-        if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-          if [ ${CYCLE_TYPE} == "spinup" ]; then
-            bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${mem_num}/${fg_restart_dirname}/RESTART
-          else
-            bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${mem_num}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-          fi
-        else
-          if [ ${CYCLE_TYPE} == "spinup" ]; then
+          if [ ${BKTYPE} -eq 2 ]; then
             bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${fg_restart_dirname}/RESTART
           else
             bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-          fi
+	  fi
         fi
-        print_info_msg "$VERBOSE" "Trying this path: ${bkpath}"
       fi
-    done
-
+      print_info_msg "$VERBOSE" "Trying this path: ${bkpath}"
     checkfile=${bkpath}/${restart_prefix}coupler.res
-    # spin-up cycle is not success, try to find background from full cycle
-    if [ ! -r "${checkfile}" ] && [ ${BKTYPE} -eq 2 ]; then
-     print_info_msg "$VERBOSE" "cannot find background from spin-up cycle, try product cycle"
-     fg_restart_dirname=forecast
-     YYYYMMDDHHmInterv=$($NDATE -${DA_CYCLE_INTERV} ${YYYYMMDD}${HH})
-     YYYYMMDDInterv=`echo ${YYYYMMDDHHmInterv} | cut -c1-8`
-     HHInterv=`echo ${YYYYMMDDHHmInterv} | cut -c9-10`
-     if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-       bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${mem_num}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-     else
-       bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-     fi
-
-     restart_prefix="${YYYYMMDD}.${HH}0000."
-     n=${DA_CYCLE_INTERV}
-     while [[ $n -le 3 ]] ; do
-       checkfile=${bkpath}/${restart_prefix}coupler.res
-       if [ ! -r "${checkfile}" ] && [ "$n" == "1" ] ; then
-         ic=0
-         while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
-           print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
-           ic=`expr $ic + 1`
-           sleep $SLEEP_INT
-           if [ -r "${checkfile}" ] ; then
-             break
+    if [ ! -r "${checkfile}" ] && [ ${CYCLE_TYPE} != "spinup" ]; then
+      fallback_enable="YES"
+      ic=0
+      while [[ $ic -lt $SLEEP_LOOP_MAX ]]; do
+        print_info_msg "$VERBOSE" "${checkfile} not available. Sleep $SLEEP_INT sec... "
+        ic=`expr $ic + 1`
+        sleep $SLEEP_INT
+        if [ -r "${checkfile}" ] ; then
+          ic=$SLEEP_LOOP_MAX
+          print_info_msg "$VERBOSE" "${checkfile} is now available. Proceed without fallback"
+          fallback_enable="NO"
+        fi
+      done
+      if [ ${fallback_enable} == "YES" ]; then
+        print_info_msg "$VERBOSE" "cannot find background, fallback for product cycle"
+        fg_restart_dirname=forecast
+        restart_prefix="${YYYYMMDD}.${HH}0000."
+        if [ ${BKTYPE} -eq 2 ] && [ "${DO_ENSEMBLE}" = "FALSE" ]; then  #det cycle 09/21z start from n=1
+          n=${DA_CYCLE_INTERV}
+        else
+          n=$((n + ${DA_CYCLE_INTERV}))
+        fi
+        while [[ $n -le 3 ]] ; do
+           YYYYMMDDHHmInterv=$($NDATE -${n} ${YYYYMMDD}${HH})
+           YYYYMMDDInterv=`echo ${YYYYMMDDHHmInterv} | cut -c1-8`
+           HHInterv=`echo ${YYYYMMDDHHmInterv} | cut -c9-10`
+           if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
+             bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${mem_num}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
+           else
+             bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
            fi
-         done
-       fi
-       if [ -r "${checkfile}" ] ; then
-         print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "
-         break
-       else
-         n=$((n + ${DA_CYCLE_INTERV}))
-	 YYYYMMDDHHmInterv=$($NDATE -${n} ${YYYYMMDD}${HH})
-         YYYYMMDDInterv=`echo ${YYYYMMDDHHmInterv} | cut -c1-8`
-         HHInterv=`echo ${YYYYMMDDHHmInterv} | cut -c9-10`
-         if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-           bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${mem_num}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-         else
-           bkpath=${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${fg_restart_dirname}/RESTART  # cycling, use background from RESTART
-         fi
-         print_info_msg "$VERBOSE" "Trying this path: ${bkpath}"
-       fi
-     done
+           print_info_msg "$VERBOSE" "Trying this path: ${bkpath}"
+  
+           checkfile=${bkpath}/${restart_prefix}coupler.res
+           if [ -r "${checkfile}" ] ; then
+             print_info_msg "$VERBOSE" "Found ${checkfile}; Use it as background for analysis "
+             break
+    	 fi
+           n=$((n + ${DA_CYCLE_INTERV}))
+        done
+      fi
     fi
   fi
 
@@ -467,31 +413,10 @@ else
       fi
       cpreq -p ${bkpath}/${restart_prefix}${file}  bk_${file}
     done
-    if [ "${CYCLE_SUBTYPE}" = "spinup" ] ; then
-      cpreq -p ${LBCS_ROOT}/${RUN}.${PDY}/${cyc}_spinup/${mem_num}/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-    else
-      if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-        if [ "${CYCLE_TYPE}" = "spinup" ]; then
-          cpreq -p ${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${mem_num}/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-        else
-          if [ ${cyc} == "08" ] || [ ${cyc} == "20" ]; then
-            cpreq -p ${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${mem_num}/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-          else
-            cpreq -p ${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${mem_num}/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-          fi
-        fi
-      else
-        if [ "${CYCLE_TYPE}" = "spinup" ]; then
-          cpreq -p ${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-        else
-          if [ ${BKTYPE} == "2" ]; then
-            cpreq -p ${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}_spinup/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-          else
-            cpreq -p ${LBCS_ROOT}/${RUN}.${YYYYMMDDInterv}/${HHInterv}/${fg_restart_dirname}/INPUT/gfs_ctrl.nc  gfs_ctrl.nc
-          fi
-        fi
-      fi
-    fi
+
+    ctrl_bkpath=${bkpath}/../INPUT
+    cpreq -p ${ctrl_bkpath}/gfs_ctrl.nc  gfs_ctrl.nc
+
     echo "${YYYYMMDDHH}(${CYCLE_TYPE}): warm start at ${current_time} from ${checkfile} "
     #
     # remove checksum from restart files. Checksum will cause trouble if model initializes from analysis
@@ -1105,30 +1030,6 @@ for file_for_fcst_INPUT in *.nc coupler.res fv3_grid_spec bk_coupler.res gvf* *.
   fi
   mv ${DATA}/${file_for_fcst_INPUT} ${FORECAST_INPUT_PRODUCT}
 done
-
-
-#### mv ${DATA}/*.nc ${ICS_ROOT}
-#### ln -s ${ICS_ROOT}/*.nc ${FORECAST_INPUT_PRODUCT}
-#### if [ -s ${DATA}/coupler.res ]; then
-####   mv ${DATA}/coupler.res ${ICS_ROOT}
-####   ln -s ${ICS_ROOT}/coupler.res ${FORECAST_INPUT_PRODUCT}
-#### fi
-#### if [ -s ${DATA}/fv3_grid_spec ]; then
-####   mv ${DATA}/fv3_grid_spec ${ICS_ROOT}
-####   ln -s ${ICS_ROOT}/fv3_grid_spec ${FORECAST_INPUT_PRODUCT}
-#### fi
-#### if [ -s ${DATA}/bk_coupler.res ]; then
-####   mv ${DATA}/bk_coupler.res ${ICS_ROOT}
-####   ln -s ${ICS_ROOT}/bk_coupler.res ${FORECAST_INPUT_PRODUCT}
-#### fi
-#### if [ $(eval ls ${DATA}/gvf*|wc -l) -gt 0 ]; then
-####   mv ${DATA}/gvf* ${ICS_ROOT}
-####   ln -s ${ICS_ROOT}/gvf* ${FORECAST_INPUT_PRODUCT}
-#### fi
-#### if [ $(eval ls ${DATA}/*.grib2|wc -l) -gt 0 ]; then
-####   mv ${DATA}/*.grib2 ${ICS_ROOT}
-####   ln -s ${ICS_ROOT}/*.grib2 ${FORECAST_INPUT_PRODUCT}
-#### fi
 
 #
 #-----------------------------------------------------------------------

--- a/scripts/exrrfs_recenter.sh
+++ b/scripts/exrrfs_recenter.sh
@@ -46,8 +46,6 @@ RRFS for the specified cycle.
 #-----------------------------------------------------------------------
 #
 
-export ctrlpath=${CRTL_CENTER}
-
 #
 # Set environment
 #
@@ -148,16 +146,6 @@ for imem in  $(seq 1 $nens)
 #
 #-----------------------------------------------------------------------
 #
-# Prepare the data structure for ensemble mean
-#
-#-----------------------------------------------------------------------
-#
-#cp -f ./fv3sar_tile1_mem001_dynvar fv3sar_tile1_dynvar
-#cp -f ./fv3sar_tile1_mem001_tracer fv3sar_tile1_tracer
-#cp -f ./fv3sar_tile1_mem001_sfcvar fv3sar_tile1_sfcvar
-#
-#-----------------------------------------------------------------------
-#
 # link the control member 
 #
 #-----------------------------------------------------------------------
@@ -167,10 +155,12 @@ tracerfile_control=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det/
 dynvarfile_control_spinup=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det/INPUT/fv_core.res.tile1.nc
 tracerfile_control_spinup=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det/INPUT/fv_tracer.res.tile1.nc
 if [ -r "${dynvarfile_control_spinup}" ] && [ -r "${tracerfile_control_spinup}" ] && [[ ${DO_ENSFCST} != "TRUE" ]] ; then
+  ctrlpath=${DATAROOT}/rrfs_forecast_spinup_${cyc}_${rrfs_ver_2d}_${envir}/det
   ln -sf ${ctrlpath}/INPUT/fv_core.res.tile1.nc  ./control_dynvar
   ln -sf ${ctrlpath}/INPUT/fv_tracer.res.tile1.nc   ./control_tracer
   ln -sf ${ctrlpath}/INPUT/sfc_data.nc  ./control_sfcvar
 elif [ -r "${dynvarfile_control}" ] && [ -r "${tracerfile_control}" ] ; then
+  ctrlpath=${DATAROOT}/rrfs_forecast_${cyc}_${rrfs_ver_2d}_${envir}/det
   ln -sf ${ctrlpath}/INPUT/fv_core.res.tile1.nc  ./control_dynvar
   ln -sf ${ctrlpath}/INPUT/fv_tracer.res.tile1.nc   ./control_tracer
   ln -sf ${ctrlpath}/INPUT/sfc_data.nc  ./control_sfcvar


### PR DESCRIPTION
Standard Operating Procedure: RRFS NCO Production Fallback and Recovery
1. Purpose and Document Scope
This document provides a comprehensive operational framework for the Rapid Refresh Forecast System (RRFS) NCO production fallback steps. It serves as the primary instructional guide for Senior Operations Support (SOS) and operational support staff during periods of system instability.
The primary objective of these procedures is to ensure that RRFS production can be resumed with maximum efficiency following a system-wide outage, a multi-hour (up to three hours) processing delay, or an emergency production switch. By following the protocols outlined herein, staff can minimize data gaps and maintain the continuity of the forecast cycle under adverse technical conditions.

2. Technical Background: The RESTART Mechanism
The RRFS resiliency strategy is built upon a modified RESTART file architecture. Unlike standard workflows that may fail to continue cycling, the RRFS architecture design with the use of RESTART file sets have been specifically engineered to generate and retain forecast data for the first three hours of a cycle—specifically the F001, F002, and F003 files.
This redundancy is strategically implemented across the following job suites:
Deterministic (det): Applied to all 24 daily cycles, providing a robust recovery window for every hour of the day.
ENKF: Applied to all even-hour forecast jobs.
By retaining these early-hour restart states, the system can 'fallback' to previous three successful cycles. This capability allows the current run to resume seamlessly, effectively bridging the gap caused by temporary outages. For a deeper dive into the algorithmic logic and shell scripting behind this automated look-back, personnel should refer to the RRFSv1 Fallback Warning Functions technical reference.

3. Critical Limitations and Operational Guardrails
While the fallback system is highly flexible, it operates within strict meteorological and structural constraints.
A. The Major Cycle Mandate (00Z, 06Z, 12Z, 18Z)
The cycles at 00Z, 06Z, 12Z, and 18Z are designated as "Major Cycles." These cycles are non-negotiable and cannot be skipped or bypassed during a recovery effort.
Major cycles perform the intensive data assimilation necessary to create the Initial Condition (IC) files. These IC files serve as the critical input data for all subsequent "proceeding" hourly cycles until the next major cycle is reached. If a major cycle is skipped, the hourly jobs will lack the foundational physics and atmospheric state required to run, leading to a cascading failure of the workflow.
B. Spinup Cycle Group Logic
The RRFS utilizes two daily "Spinup" windows to compute science enhancement features:
(det) Morning Spinup: 03Z through 08Z.
(det) Evening Spinup: 15Z through 20Z.
(ENKF) Morning Spinup: 07Z
(ENKF) Evening Spinup: 19Z
These groups operate under "all-or-nothing" logic. A spinup cycle is designed to proceed only if every spinup job within that specific time-block completes successfully. If a failure occurs—for instance, a det_forecast_spinup job fails at 18Z—the remaining jobs in that window (19Z and 20Z) should be set to "complete" (skipped). The system is programmed to run at the next "Regular" cycle (09Z or 21Z) using the RRFS regular cycling files. This design prevents a localized spinup error from stalling the entire production line for the remainder of the day.
Note: Normal routine to recover (SOS->SPA->Developers), but cancel if 21z started before it can be fixed.

4. Implementation Procedures
The fallback mechanism allows for a recovery depth of up to three hours. Below are the standard execution steps for the most common recovery scenarios.
Scenario 1: Two-Hour Fallback (Example: Resuming at 14Z)
If the 13Z cycle is unavailable or the system was down during that window, use the 12Z data to start the 14Z cycle.
Purge Intermediate Data: Manually delete the COM directories for both det and enkf suites for the 13Z cycle. This ensures the 14Z jobs do not attempt to link to partial or corrupted files.
Run 14Z init jobs.
Trigger 14Z Prep: Manually initiate the 14Z prep jobs for both suites.
System Action: * The Deterministic prep_cyc job will automatically identify that 13Z is missing and will seek out the F002 RESTART file from the 12Z cycle.
The ENKF prep_cyc_ensmean and all 30 members of the enkf_prep_cyc_mem will locate and ingest the 12Z RESTART files.
Rerun 13Z cycle after 14Z det and ENKF prep_cyc jobs completed as desired by operational requirement.

Scenario 2: Three-Hour Fallback (Example: Resuming at 15Z)
In the event of a more prolonged outage requiring a three-hour jump:
Purge Intermediate Data: Delete the COM directories for both 13Z and 14Z for both suites.
Run 15Z init and ics jobs.
Trigger 15Z Prep: Run the 15Z prep jobs.
System Action: The Deterministic prep_cyc job will look back three hours, finding and utilizing the F003 RESTART file from the 12Z cycle.
The ENKF suite will similarly utilize the 12Z RESTART files to initialize the 30-member ensemble and the mean.
Rerun jobs from previous failed cycle after 15Z prep_cyc jobs completed as desired by operational requirement.

5. Summary Reference Table
Cycle Type
Time/Group
Fallback Allowed?
Recovery Action
Major Cycle
00Z, 06Z, 12Z, 18Z
No
Must run to completion before proceeding.
Det Spinup Group
03Z–08Z / 15Z–20Z
No
Skip remaining group jobs; resume at 09Z/21Z.
Standard Hourly
All other hours
Yes
Fall back 2 or 3 hours using F002/F003 RESTART.

Test plan
Test the fallback functions in prep_cyc:
Running the deterministic and enkf cycles for 24 hours. Then check the following cycling information to make sure all cycles are normal:
All deterministic full cycles use 1-h forecasts from the previous 1-h  deterministic full cycle except 09/21Z using 1-h forecasts from 08/20Z spin-up cycle.
Spin-up cycle cold start at 03/15Z and do 1-h cycle from 03-08/15-20. At 04/16Z, there is surface cycle and smoke cycle using restart files 1-h forecast from full cycle.
All enkf cycles use 1-h forecast from the previous 1-h cycle but 07/19Z spin-up cycle either cold starts or does blending with 1-h forecast from 06/18Z enkf ensemble forecast and 08/20z cycles use the 1-h forecast from spinup 07/19Z cycle.
All GSI analysis should use 1-h forecasts from a 30 member enkf ensemble, except for 03/15 cold start spin-up cycle.
Recentering at 07/19 enkf spin-up cycle should use 07/19 deterministic spin-up analysis results.

Testing executed and progress status with results:
Fallback test for prep_cyc and GSI hybrid (a,b,c,e,f) (d after c):
a) Remove com directory for a cycle (like 11Z) and then run the following cycle (12Z). Both deterministic full cycle and enkf cycle should start to run with 2-h forecast from 10Z cycle. At the same time, check the GSI to see if it uses 2-h ensemble forecasts for hybrids. (enkf prep cyc used data from 10Z; det prep cyc used data from 10Z - Test success)
b) Remove com directory for two continue cycles for deterministic cycle (14z/15z), the next cycle (16z) should run with 3-h forecast from previous 3-h cycle (13z). ( det prep cyc used data from 13Z. The spinup jobs failed as designed - Test success)
c) Remove com directory for two continue cycles for det/enkf (15/16z) and then run EnKF/Det cycle (17), it should use 3-h forecast from previous 14z cycle. GSI is using 3-h ensemble forecast from 14 Z for hybrid (17z det spinup jobs failed as expected. Set all 17Z det spinup in ecflow to complete) (17z det fallback to 14z worked; enkf prep cyc ensmean and enkf prep cyc mem* used 14z data; det gsi used 14z enkf restart 3 hours files - Test success)
d) After C finish: Then remove 14Z Enkf com and run 17Z GSI, it should use GFS ensemble frecast for hybrid. (17Z Det GSI analysis used enkfgdas 06Z 9 hour 80 member, but no DBZ and FED data used - Test success)
e) Remove 19Z enkf spin-up com directory and run 20z enkf cycle to see if it uses 18z 2-h forecast to start. (Run only enkf 20z with manual enkf prep cyc ensmean and prepcyc mem* manually submit; enkf prep ensmean used 18Z data - Test success)
f) Remove deterministic spin-up cycle at 20Z and run 21Z deterministic cycle to check if prep_cyc uses 1-h forecast from full cycle to start (Spinup failed
example). (21z det prep cyc used 20z det restart instead of 20z spinup because it has been removed; det gsi manually run and used 18z enkf restart files - Test success)
g) After F finish:Remove 20Z full cycle com and rerun 21Z full cycle to check if it uses 2-h forecast from 19z full cycle to start. (det prepcyc used 19z 2 hours RESTART, enkf used 18z 3 hours RESTART data - Test success)
Fallback test for blending and recentering
● Remove 18z ensemble com and run 19Z ensemble spin-up cycle, blending will find 3-h ensemble forecast from 16Z ensemble forecasts. (det prep_cyc spinup 19Z failed as designed. det prep cyc for 19z used 17Z det RESTART files. det gsi used enkf 16z RESTART files, enkf blend_ics blending_fv3.py used 16z 3 hours RESTART file - Test success)
● The same test, do not run 19Z spin-up but run 19Z full det (removing the 19Z spin-up cycle running directory) to check if recentering uses 19Z full cycle analysis results for recentering. (enkf recenter can use 19Z det full cycle analysis results - Test success)
Fallback test for surface and smoke cycle
● Remove 15z full cycle com and surface file and then run 16 spinup cycle to check if surface and smoke cycle use 2-h forecast from 02/14z restart files. (det prep cyc spinup used det 14 RESTART file for smoke; surface/$PDY.16000 file used - Test success)
● Remove 14z full cycle com and surface file and then run 16 spinup cycle to check if surface and smoke cycle use 3-h forecast from 01/13z restart files (det prep cyc spinup used det 13z RESTART for smoke, surface used 20260127.160000.sfc_data.nc.2026012713 - Test success)

Thank you @hu5970 for his contribution and work around the clock with me to test it.