### PR TITLE
[rrfs-nco] NCO cleanup job

### DIFF
--- a/ecf/scripts/clean/jrrfs_clean.ecf
+++ b/ecf/scripts/clean/jrrfs_clean.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter:shared,select=1:ncpus=1:mem=10G
 #PBS -l debug=true
 set -x
@@ -17,21 +17,17 @@ export cyc="%CYC%"
 ############################################################
 
 module list
-export WGF="det"
 
+export CLEAN_MODE=post
+
+export KEEP_RESTART=${KEEP_RESTART:-%KEEP_RESTART:NO%}
+export KEEP_DET_RESTART=${KEEP_DET_RESTART:-%KEEP_DET_RESTART:NO%}
+export KEEP_ENKF_RESTART=${KEEP_ENKF_RESTART:-%KEEP_ENKF_RESTART:NO%}
+export KEEP_TMP=${KEEP_TMP:-%KEEP_TMP:NO%}
 ############################################################
 # CALL executable job script here
 ############################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} 
-ls -d ${DATAROOT}/rrfs_*_${cyc}_v1.0_${envir}
-rm -rf ${DATAROOT}/rrfs_*_${cyc}_v1.0_${envir}
-rm -rf ${DATAROOT}/rrfs_*_${cyc}.*.*
-
-cd ${DATAROOT}
-rm -rf ${DATA}
-#${HOMErrfs}/scripts/exrrfs_clean.sh
+${HOMErrfs}/jobs/JRRFS_CLEANUP
 
 %include <tail.h>
 

--- a/ecf/scripts/preclean/jrrfs_clean_early.ecf
+++ b/ecf/scripts/preclean/jrrfs_clean_early.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter:shared,select=1:ncpus=1:mem=10G
 #PBS -l debug=true
 set -x
@@ -17,24 +17,12 @@ export cyc="%CYC%"
 ############################################################
 
 module list
-export WGF="det"
 
+export CLEAN_MODE=pre
 ############################################################
 # CALL executable job script here
 ############################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} 
-
-for old_dir in ${DATAROOT}/rrfs_*_${cyc}_v1.0_${envir}; do
-  if [ -d "$old_dir" ]; then
-    mv ${old_dir} ${old_dir}_$$
-  fi
-done
-
-cd ${DATAROOT}
-rm -rf ${DATA}
-#${HOMErrfs}/scripts/exrrfs_clean.sh
+${HOMErrfs}/jobs/JRRFS_CLEANUP
 
 %include <tail.h>
 

--- a/jobs/JRRFS_CLEANUP
+++ b/jobs/JRRFS_CLEANUP
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+date
+export PS4='+ $SECONDS + '
+set -x
+
+# Setup working directory
+export DATA=${DATA:-${DATAROOT:?}/${jobid:?}}
+mkdir -p $DATA
+cd $DATA
+
+export cycle=${cycle:-t${cyc}z}
+setpdy.sh
+. ./PDY
+
+export NET=${NET:-rrfs}
+export COMIN=${COMIN:-$(compath.py ${envir}/${NET}/$rrfs_ver)}
+
+env
+
+# Execute the script
+$HOMErrfs/scripts/exrrfs_cleanup.sh
+export err=$?; err_chk
+
+# Remove the Temporary working directory
+if [ "${KEEPDATA^^}" != YES ]; then
+  rm -rf $DATA
+fi
+
+date

--- a/scripts/exrrfs_cleanup.sh
+++ b/scripts/exrrfs_cleanup.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -x
+
+#####################################################
+# pre cycle cleanup
+#####################################################
+if [ "${CLEAN_MODE}" == "pre" ]; then
+  echo "Performing pre-cycle cleanup to rename any existing shared workding dir for cyc $cyc."
+  for old_dir in ${DATAROOT}/rrfs_*_${cyc}_${rrfs_ver_2d}_${envir}; do
+    if [ -d "$old_dir" ]; then
+      mv ${old_dir} ${old_dir}_$$
+    fi
+  done
+  echo "Pre-cycle cleanup complated."
+fi
+
+#####################################################
+# post cycle cleanup
+#####################################################
+
+if [ "${CLEAN_MODE}" == "post" ]; then
+  echo "Performing post-cycle cleanup for cyc $cyc."
+
+  # cleanup shared working directory
+  if [ "${KEEP_TMP^^}" != YES ]; then
+    echo "Cleaning up shared workding directories for cyc $cyc ."
+    if ls ${DATAROOT}/rrfs_*_${cyc}_${rrfs_ver_2d}_${envir} >/dev/null 2>&1; then
+      rm -rf ${DATAROOT}/rrfs_*_${cyc}_${rrfs_ver_2d}_${envir}
+    fi
+  else
+    echo "\$KEEP_TMP is set to YES. Skipping tmp cleanup."
+  fi
+
+  # cleanup restart files for the current cycle
+  if [ "${KEEP_RESTART^^}" != YES ]; then
+    # remove RESTART files for the current cycle only
+    # 1h restart from CYCm1
+    # 2h restart from CYCm2
+    # 3h restart from CYCm3
+    Restart_1h=$($NDATE -01 $PDY$cyc)
+    Restart_2h=$($NDATE -02 $PDY$cyc)
+    Restart_3h=$($NDATE -03 $PDY$cyc)
+
+    # rrfs
+    if [ "${KEEP_DET_RESTART^^}" != YES ]; then
+      echo "Cleaning up det RESTART files for cyc $cyc ."
+      for Restart_cyc in $Restart_1h $Restart_2h $Restart_3h; do
+        date_to_remove=${Restart_cyc:0:8}
+        cyc_to_remove=${Restart_cyc:8:2}
+        com_to_remove=${COMIN}/rrfs.${date_to_remove}/${cyc_to_remove}/forecast/RESTART
+        if ls ${com_to_remove}/${PDY}.${cyc}0000.* >/dev/null 2>&1; then
+           rm ${com_to_remove}/${PDY}.${cyc}0000.*
+        fi
+      done
+    fi
+  
+    # enkf
+    if [ "${KEEP_ENKF_RESTART^^}" != YES ]; then
+      echo "Cleaning up enkf RESTART files for cyc $cyc ."
+      for Restart_cyc in $Restart_1h $Restart_2h $Restart_3h; do
+        date_to_remove=${Restart_cyc:0:8}
+        cyc_to_remove=${Restart_cyc:8:2}
+        for imem in {01..30}; do
+          com_to_remove=${COMIN}/enkfrrfs.${date_to_remove}/${cyc_to_remove}/m0${imem}/forecast/RESTART
+          if ls ${com_to_remove}/${PDY}.${cyc}0000.* >/dev/null 2>&1; then
+             rm ${com_to_remove}/${PDY}.${cyc}0000.*
+          fi
+        done
+      done
+    fi
+  else
+    echo "\$KEEP_RESTART is set to YES. Skipping RESTART cleanup."
+  fi
+
+  echo "Post-cycle cleanup completed."
+fi
+


### PR DESCRIPTION



## DESCRIPTION OF CHANGES: 
- Add J-job and ex-script for RRFS cleanup jobs.
- Add logic to remove old RESTART files for det and enkf.
  - Remove 1h restart files from CYCm1
  - Remove 2h restart files from CYCm2
  - Remove 3h restart files from CYCm3

## TESTS CONDUCTED: 
- Tested in NCO realtime parallel

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #1251 
- Improves disk usage due to #1200 and #1252 

