### PR TITLE
add versions to prgenv and python module loads in app_build.sh

### DIFF
--- a/ecf/include/head.h
+++ b/ecf/include/head.h
@@ -55,6 +55,7 @@ if [ -d /apps/ops/prod ]; then # On WCOSS2
   set -x
   . ${ECF_ROOT}/versions/run.ver
   set +x
+  module load prod_util/${prod_util_ver}
   module load prod_envir/${prod_envir_ver}
   echo "Listing modules from head.h:"
   module list

--- a/sorc/app_build.sh
+++ b/sorc/app_build.sh
@@ -264,47 +264,6 @@ if [ "${PARALSTART}" = false ]; then
   ENABLE_RRFS_WAR="on"
 fi
 
-# check out external components specified in External.cfg
-if [ "${EXTRN}" = true ]; then
-  cd ${SORC_DIR}
-  # remove existing components
-  printf "... checking if external components exist ...\n"
-  if [ -d "${SORC_DIR}/UFS_UTILS" ]; then
-    printf "... removing UFS_UTILS ...\n"
-    rm -rf "${SORC_DIR}/UFS_UTILS"
-  fi
-  if [ -d "${SORC_DIR}/ufs-weather-model" ]; then
-    printf "... removing ufs-weather-model ...\n"
-    rm -rf "${SORC_DIR}/ufs-weather-model"
-  fi
-  if [ -d "${SORC_DIR}/UPP" ]; then
-    printf "... removing UPP ...\n"
-    rm -rf "${SORC_DIR}/UPP"
-  fi
-  if [ -d "${SORC_DIR}/rrfs_utl" ]; then
-    printf "... removing rrfs_utl ...\n"
-    rm -rf "${SORC_DIR}/rrfs_utl"
-  fi
-  if [ -d "${SORC_DIR}/gsi" ]; then
-    printf "... removing GSI ...\n"
-    rm -rf "${SORC_DIR}/gsi"
-  fi
-  if [ -d "${SORC_DIR}/AQM-utils" ]; then
-    printf "... removing AQM-utils ...\n"
-    rm -rf "${SORC_DIR}/AQM-utils"
-  fi
-
-  # run check-out
-  python --version 1>/dev/null 2>/dev/null
-  if [[ $(which python) == "/usr/bin/python" ]]; then
-       module unload python
-       module load PrgEnv-intel/${PrgEnv_intel_ver}
-       module load python/${python_ver}
-  fi
-  printf "... checking out external components ...\n"
-  ./manage_externals/checkout_externals
-fi
-
 # choose default apps to build
 if [ "${DEFAULT_BUILD}" = true ]; then
   BUILD_UFS="on"
@@ -358,6 +317,47 @@ if [ "${PLATFORM}" = "wcoss2" ]; then
   if [ -f ${BUILD_VERSION_FILE} ]; then
     . ${BUILD_VERSION_FILE}
   fi
+fi
+
+# check out external components specified in External.cfg
+if [ "${EXTRN}" = true ]; then
+  cd ${SORC_DIR}
+  # remove existing components
+  printf "... checking if external components exist ...\n"
+  if [ -d "${SORC_DIR}/UFS_UTILS" ]; then
+    printf "... removing UFS_UTILS ...\n"
+    rm -rf "${SORC_DIR}/UFS_UTILS"
+  fi
+  if [ -d "${SORC_DIR}/ufs-weather-model" ]; then
+    printf "... removing ufs-weather-model ...\n"
+    rm -rf "${SORC_DIR}/ufs-weather-model"
+  fi
+  if [ -d "${SORC_DIR}/UPP" ]; then
+    printf "... removing UPP ...\n"
+    rm -rf "${SORC_DIR}/UPP"
+  fi
+  if [ -d "${SORC_DIR}/rrfs_utl" ]; then
+    printf "... removing rrfs_utl ...\n"
+    rm -rf "${SORC_DIR}/rrfs_utl"
+  fi
+  if [ -d "${SORC_DIR}/gsi" ]; then
+    printf "... removing GSI ...\n"
+    rm -rf "${SORC_DIR}/gsi"
+  fi
+  if [ -d "${SORC_DIR}/AQM-utils" ]; then
+    printf "... removing AQM-utils ...\n"
+    rm -rf "${SORC_DIR}/AQM-utils"
+  fi
+
+  # run check-out
+  python --version 1>/dev/null 2>/dev/null
+  if [[ $(which python) == "/usr/bin/python" ]]; then
+       module unload python
+       module load PrgEnv-intel/${PrgEnv_intel_ver}
+       module load python/${python_ver}
+  fi
+  printf "... checking out external components ...\n"
+  ./manage_externals/checkout_externals
 fi
 
 # set MODULE_FILE for this platform/compiler combination

--- a/sorc/app_build.sh
+++ b/sorc/app_build.sh
@@ -298,8 +298,8 @@ if [ "${EXTRN}" = true ]; then
   python --version 1>/dev/null 2>/dev/null
   if [[ $(which python) == "/usr/bin/python" ]]; then
        module unload python
-       module load PrgEnv-intel
-       module load python
+       module load PrgEnv-intel/${PrgEnv_intel_ver}
+       module load python/${python_ver}
   fi
   printf "... checking out external components ...\n"
   ./manage_externals/checkout_externals

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -28,6 +28,7 @@ export netcdf_ver=4.9.2
 export pnetcdf_ver=1.12.2
 export pio_ver=2.5.10
 export PrgEnv_intel_ver=8.5.0
+export python_ver=3.8.6
 export sigio_ver=2.3.2
 export sfcio_ver=1.4.1
 export sp_ver=2.4.0


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Addresses [comments by Wei ](https://github.com/NOAA-EMC/rrfs-workflow/pull/1297#discussion_r2764212580)
- [add back in prod_util module load in ecf/include/head.h to facilitate EMC runs. In this file, prod_util_ver is set in source of ECF_ROOT version file, so no need to add prod_util_ver to RRFS build.ver](https://github.com/NOAA-EMC/rrfs-workflow/pull/1298/changes/434bac14aa2b24e6d5267cfdd15929010d611de3)
- in sorc/app_build.sh, moved sourcing of build.ver (to define module version variables) to below the module loads of prgenv-intel and python 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- successfully rebuilt code via `app_build.sh --extrn`

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

