### PR TITLE
Hotfix: 1. default PREP_LBC_LOOK_BACK_HRS for retros, 2. herbie_get_GFS_from_aws

### DIFF
--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -25,7 +25,7 @@ export MPASOUT_SAVE2COM_HRS=${MPASOUT_SAVE2COM_HRS:-""}  # cycling mpasout.nc is
 
 # PREP_LBC_LOOK_BACK_HRS
 if ${REALTIME:-false}; then
-  export PREP_LBC_LOOK_BACK_HRS=${PREP_LBC_LOOK_BACK_HRS:-13} # Python range(0,13) will make it 0-12
+  export PREP_LBC_LOOK_BACK_HRS=${PREP_LBC_LOOK_BACK_HRS:-13}
 else
   LBC_CYCS=$(echo "${LBC_CYCS}" | xargs) # trim any leading, trailing and extra spaces
   lbc_step_hrs=$(( 24*3/(${#LBC_CYCS}+1) -1 ))

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -28,7 +28,7 @@ if ${REALTIME:-false}; then
   export PREP_LBC_LOOK_BACK_HRS=${PREP_LBC_LOOK_BACK_HRS:-13} # Python range(0,13) will make it 0-12
 else
   LBC_CYCS=$(echo "${LBC_CYCS}" | xargs) # trim any leading, trailing and extra spaces
-  lbc_step_hrs=$(( 24*3/(${#LBC_CYCS}+1) ))
+  lbc_step_hrs=$(( 24*3/(${#LBC_CYCS}+1) -1 ))
   export PREP_LBC_LOOK_BACK_HRS=${PREP_LBC_LOOK_BACK_HRS:-${lbc_step_hrs}}
 fi
 

--- a/workflow/tools/herbie_get_GFS_from_aws
+++ b/workflow/tools/herbie_get_GFS_from_aws
@@ -6,9 +6,10 @@ import sys
 args = sys.argv
 nargs = len(args) - 1
 if nargs < 2:
-    print(f"{args[0]} YYYYMMDDHH-YYYYMMDDHH fhr-fhr\n")
+    print(f"{args[0]} YYYYMMDDHH-YYYYMMDDHH fhr-fhr [fhr_interval]\n")
     print(f'  the first parameter specifies the cycle range')
     print(f'  the second parameter specifies the fhr range, example: 0-70')
+    print(f'  the third optional parameter specifies the fhr interval, 1 or 3 (default to 1)')
     exit()
 
 print(f'each cycle data will be downloaded to ./tmp/ temporarily and then moved to ./downloads/')
@@ -24,6 +25,8 @@ fhr_range = args[2]
 model = "gfs"  # gfs, rap
 dest_path = "./downloads"
 fhr_interval = 1
+if nargs > 2:
+    fhr_interval = int(args[3])
 cyc_interval = 6
 
 two_dates = date_range.split("-")
@@ -40,6 +43,8 @@ while cur_date <= date2:
         shutil.rmtree(tmp_dir)  # remove temporary directory to avoid contamination
     for product in ["pgrb2.0p25", "pgrb2b.0p25"]:
         for fhr in range(int(fhrs[0]), int(fhrs[1]) + 1, fhr_interval):
+            if fhr > 120 and (fhr - 120) % 3 != 0:
+                continue # GFS only outputs every 3h after 120h
             sdate = datetime.strftime(cur_date, "%Y-%m-%d %H:%M")
             HB = Herbie(
                 sdate,


### PR DESCRIPTION
HOTFIX: 
1. update the default `PREP_LBC_LOOK_BACK_HRS` value for retros to be consistent with the change in PR #1263
2. update `herbie_get_GFS_from_aws` to match the 3-hourly GFS output after f120.
