### PR TITLE
[dev-sci] Bugfix to add copying of `INPUT` directory for ensemble mean 

### DIFF
--- a/scripts/exrrfs_calc_ensmean.sh
+++ b/scripts/exrrfs_calc_ensmean.sh
@@ -219,6 +219,14 @@ done
 #
 #-----------------------------------------------------------------------
 #
+# Copy INPUT into INPUT.gsi for parallel GSI and JEDI runs
+#
+#-----------------------------------------------------------------------
+#
+cp -r ${ensmeandir} ${ensmeandir}.gsi
+#
+#-----------------------------------------------------------------------
+#
 # touch a file to show completion of the task
 #
 touch ${COMOUT}/calc_ensmean_complete.txt


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

#1304 added support for the JEDI-based EnKF to run in parallel with GSI-based EnKF. After this PR, the GSI-based observer tasks link in the restart files from `INPUT.gsi`. However, I forgot to copy the ensemble mean directory into `INPUT.gsi` which caused the observer to produce no diagnostic files and the subsequent GSI-based EnKF to complete with zero increments.  This PR adds a simple bugfix to now also copy `INPUT` input `INPUT.gsi` for the ensemble mean directory. 

## TESTS CONDUCTED: 
This change was tested with 12 cycles running overnight to confirm that all GSI observer and GSI-based EnKF tasks complete successfully and produce reasonable increments. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None
