### PR TITLE
[rrfs-nco] Refinements to dbnet alerts

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -342,9 +342,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
 	if [[ $SENDDBN = 'YES' ]]; then
            if (( 10#$cyc % 3 == 0 )); then
              $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
-		     ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2
+                  ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2
              $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job \
-		     ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2.idx
+                  ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2.idx
 	   fi
 	fi
       fi

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -290,10 +290,17 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
       fi
 
-# may need to add limit on cycle hours for this?  Or would that be handled in the processing of dbn_alerts?
       if [[ ${SENDDBN} = "YES" ]] ; then
+
+	      # only 3 hourly cycles
+              if (( 10#$cyc % 3 == 0 )); then
+	      # hourly to 60, then three hourly
+              if (( 10#$fhr <= 60 || 10#$fhr%3 == 0 )) ; then
+
         $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2
         $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
+	      fi
+	      fi
       fi 
     fi
     count=$count+1

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -340,6 +340,13 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
           -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
           -new_grid ${gridspecs} ${COMOUT}/${prslev_subh_dom}
         wgrib2 ${COMOUT}/${prslev_subh_dom} -s > ${COMOUT}/${prslev_subh_dom}.idx
+
+	if [[ $SENDDBN = 'YES ]]; then
+           if (( 10#$cyc % 3 == 0 )); then
+        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2
+        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2.idx
+	   fi
+	fi
       fi
     done
   fi

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -291,17 +291,15 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fi
 
       if [[ ${SENDDBN} = "YES" ]] ; then
-
-	      # only 3 hourly cycles
-              if (( 10#$cyc % 3 == 0 )); then
-	      # hourly to 60, then three hourly
-              if (( 10#$fhr <= 60 || 10#$fhr%3 == 0 )) ; then
-
-        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2
-        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
-	      fi
-	      fi
-      fi 
+        if (( 10#$cyc % 3 == 0 )); then
+          if (( 10#$fhr <= 60 || 10#$fhr%3 == 0 )) ; then
+            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
+                ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2
+            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job \
+                ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
+          fi
+        fi
+      fi  #SENDDBN
     fi
     count=$count+1
   done
@@ -341,10 +339,12 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
           -new_grid ${gridspecs} ${COMOUT}/${prslev_subh_dom}
         wgrib2 ${COMOUT}/${prslev_subh_dom} -s > ${COMOUT}/${prslev_subh_dom}.idx
 
-	if [[ $SENDDBN = 'YES ]]; then
+	if [[ $SENDDBN = 'YES' ]]; then
            if (( 10#$cyc % 3 == 0 )); then
-        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2
-        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2.idx
+             $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
+		     ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2
+             $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE_WIDX} $job \
+		     ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.subh.f${fhr}.${domain}.grib2.idx
 	   fi
 	fi
       fi


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Limits the cycles and forecast hours for which prslev output gets alerted to help limit things to the overall volume (1 TB/day) agreed to with NCO DF.
- Adds alerts for subh output which are also in the plan. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- Tested the script logic additions (if tests) in a standalone script to confirm that it works as intended.  
 
### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #818 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

