### PR TITLE
[rrfs-mpas-jedi] Add check for mpassit output file size

### DIFF
--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -73,10 +73,18 @@ for (( ii=0; ii<"${num_fhrs}"; ii=ii+"${group_total_num}" )); do
       ${MPI_RUN_CMD} ./mpassit.x namelist.mpassit
       # check the status, copy output to UMBRELLA_MPASSIT_DATA
       if [[ -s "./mpassit.${timestr}.nc" ]]; then
-        mv "./mpassit.${timestr}.nc" "${UMBRELLA_MPASSIT_DATA}/."
-        mv namelist.mpassit "namelist.mpassit_${fhr}"
+	SIZE=$(du -sb "./mpassit.${timestr}.nc" | awk '{ print $1 }')
+	chars=`echo -n $SIZE | wc -c`
+	# check for incomplete output files
+	if [[ $chars -gt 8 ]] ; then
+          mv "./mpassit.${timestr}.nc" "${UMBRELLA_MPASSIT_DATA}/."
+          mv namelist.mpassit "namelist.mpassit_${fhr}"
+	else
+	  echo "FATAL ERROR: failed to generate full mpassit.${timestr}.nc"
+	  err_exit
+	fi
       else
-        echo "FATAL ERROR: failed to genereate mpassit.${timestr}.nc"
+        echo "FATAL ERROR: failed to generate mpassit.${timestr}.nc"
         err_exit
       fi
     else

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -72,17 +72,9 @@ for (( ii=0; ii<"${num_fhrs}"; ii=ii+"${group_total_num}" )); do
       source prep_step
       ${MPI_RUN_CMD} ./mpassit.x namelist.mpassit
       # check the status, copy output to UMBRELLA_MPASSIT_DATA
-      if [[ -s "./mpassit.${timestr}.nc" ]]; then
-	SIZE=$(du -sb "./mpassit.${timestr}.nc" | awk '{ print $1 }')
-	chars=`echo -n $SIZE | wc -c`
-	# check for incomplete output files
-	if [[ $chars -gt 8 ]] ; then
-          mv "./mpassit.${timestr}.nc" "${UMBRELLA_MPASSIT_DATA}/."
-          mv namelist.mpassit "namelist.mpassit_${fhr}"
-	else
-	  echo "FATAL ERROR: failed to generate full mpassit.${timestr}.nc"
-	  err_exit
-	fi
+      if [[ -f "./mpassit.${timestr}.nc" ]] && (( $(stat -c%s "./mpassit.${timestr}.nc") > 104857600 )); then
+        mv "./mpassit.${timestr}.nc" "${UMBRELLA_MPASSIT_DATA}/."
+        mv namelist.mpassit "namelist.mpassit_${fhr}"
       else
         echo "FATAL ERROR: failed to generate mpassit.${timestr}.nc"
         err_exit


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- With a recent MPASSIT bug (since fixed), workflow MPASSIT group tasks were succeeding even when individual MPASSIT jobs were core dumping.  This PR adds a check for output file sizes, and causes the task to fail if any output files are incomplete.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tests were run for a 3-km CONUS RRFSv2 retro on Gaea C6.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:
