### PR TITLE
[dev-sci] Minor changes to support radar reflectivity assimilation in JEDI-based EnKF

### DIFF
--- a/jobs/JRRFS_ANALYSIS_ENKF_JEDI
+++ b/jobs/JRRFS_ANALYSIS_ENKF_JEDI
@@ -67,10 +67,10 @@ the specified cycle.
 #
 export CYCLE_TYPE=${CYCLE_TYPE:-prod}
 if [ "${CYCLE_TYPE}" = "spinup" ]; then
-  export enkfworkdir="${CYCLE_DIR}/enkfupdt_${OB_TYPE}_jedi_spinup"
+  export enkfworkdir="${CYCLE_DIR}/enkfupdt_jedi_spinup"
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}_spinup"
 else
-  export enkfworkdir="${CYCLE_DIR}/enkfupdt_${OB_TYPE}_jedi"
+  export enkfworkdir="${CYCLE_DIR}/enkfupdt_jedi"
   export COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/${cyc}"
 fi
 rm -fr ${enkfworkdir}

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -3550,8 +3550,10 @@ MODULES_RUN_TASK_FP script.
         {%- elif do_nonvar_cldanal%}
         <taskdep task="&CLDANL_NONVAR_TN;_prod{{ uscore_ensmem_name }}"/>
         {%- elif do_enkf_radar_ref %}
+        <and>
         <taskdep task="&ENKF_RADAR_REF_TN;"/>
         <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
+        </and>
         {%- else %}
         <and>
           <taskdep task="&RUN_ENKFUPDT_TN;"/>
@@ -3626,11 +3628,15 @@ MODULES_RUN_TASK_FP script.
         {%- elif do_nonvar_cldanal%}
         <taskdep task="&CLDANL_NONVAR_TN;_prod{{ uscore_ensmem_name }}"/>
         {%- elif do_enkf_radar_ref %}
+        <and>
         <taskdep task="&ENKF_RADAR_REF_TN;"/>
         <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
+        </and>
         {%- else %}
+        <and>
         <taskdep task="&RUN_ENKFUPDT_TN;"/>
         <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
+        </and>
        {%- endif %}
       {%- else %}
       <taskdep task="&PREP_CYC_TN;_prod{{ uscore_ensmem_name }}"/>

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -3551,6 +3551,7 @@ MODULES_RUN_TASK_FP script.
         <taskdep task="&CLDANL_NONVAR_TN;_prod{{ uscore_ensmem_name }}"/>
         {%- elif do_enkf_radar_ref %}
         <taskdep task="&ENKF_RADAR_REF_TN;"/>
+        <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
         {%- else %}
         <and>
           <taskdep task="&RUN_ENKFUPDT_TN;"/>
@@ -3626,8 +3627,10 @@ MODULES_RUN_TASK_FP script.
         <taskdep task="&CLDANL_NONVAR_TN;_prod{{ uscore_ensmem_name }}"/>
         {%- elif do_enkf_radar_ref %}
         <taskdep task="&ENKF_RADAR_REF_TN;"/>
+        <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
         {%- else %}
         <taskdep task="&RUN_ENKFUPDT_TN;"/>
+        <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
        {%- endif %}
       {%- else %}
       <taskdep task="&PREP_CYC_TN;_prod{{ uscore_ensmem_name }}"/>

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -1607,6 +1607,9 @@ MODULES_RUN_TASK_FP script.
       <and>
         <metataskdep metatask="run_ensemble_observer_spinup"/>
         <taskdep task="&IODA_BUFR_TN;_spinup"/>
+        {%- if do_enkf_radar_ref %}
+        <taskdep task="&PROCESS_RADAR_REF_TN;_spinup"/>
+        {%- endif %}
       </and>
     </dependency>
   </task>
@@ -1645,14 +1648,6 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <taskdep task="&RUN_ENKFUPDT_TN;_spinup"/>
-        <taskdep task="&RUN_ENKFUPDT_JEDI_TN;_spinup"/>
-        {%- if do_retro %}
-        <and> 
-        {%- for m in range(1, num_ens_members+1) %}
-          <datadep age="00:00:00:01"><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H/mem{{ "%04d" % m }}/observer_gsi_spinup/diag_conv_dbz_ges.@Y@m@d@H.nc4.gz</cyclestr></datadep>
-        {%- endfor %}
-        </and> 
-        {%- endif %}
       </and>
     </dependency>
   </task>
@@ -1701,8 +1696,8 @@ MODULES_RUN_TASK_FP script.
              <taskdep task="&ENKF_RADAR_REF_TN;_spinup"/>
            {%- else %}
              <taskdep task="&RUN_ENKFUPDT_TN;"/>
-             <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
            {%- endif %}
+             <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
         </and>
         {%- elif do_envar_radar_ref and not do_envar_radar_ref_once %}
         <or>
@@ -2198,8 +2193,8 @@ MODULES_RUN_TASK_FP script.
              <taskdep task="&ENKF_RADAR_REF_TN;"/>
            {%- else %}
              <taskdep task="&RUN_ENKFUPDT_TN;"/>
-             <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
            {%- endif %}
+             <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
         </and>
         {%- elif do_envar_radar_ref and not do_envar_radar_ref_once %}
         <or>
@@ -2764,6 +2759,9 @@ MODULES_RUN_TASK_FP script.
       <and>
         <metataskdep metatask="run_ensemble_observer"/>
         <taskdep task="&IODA_BUFR_TN;_prod"/>
+        {%- if do_enkf_radar_ref %}
+        <taskdep task="&PROCESS_RADAR_REF_TN;_prod"/>
+        {%- endif %}
       </and>
     </dependency>
   </task>
@@ -2800,14 +2798,6 @@ MODULES_RUN_TASK_FP script.
     <dependency>
       <and>
         <taskdep task="&RUN_ENKFUPDT_TN;"/>
-        <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
-        {%- if do_retro %}
-        <and> 
-        {%- for m in range(1, num_ens_members+1) %}
-          <datadep age="00:00:00:01"><cyclestr>&NWGES_BASEDIR;/@Y@m@d@H/mem{{ "%04d" % m }}/observer_gsi/diag_conv_dbz_ges.@Y@m@d@H.nc4.gz</cyclestr></datadep>
-        {%- endfor %}
-        </and> 
-        {%- endif %}
       </and>
     </dependency>
   </task>
@@ -3314,8 +3304,8 @@ MODULES_RUN_TASK_FP script.
              <taskdep task="&ENKF_RADAR_REF_TN;"/>
            {%- else %}
              <taskdep task="&RUN_ENKFUPDT_TN;"/>
-             <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
            {%- endif %}
+             <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
         </and>
         {%- elif do_envar_radar_ref and not do_envar_radar_ref_once %}
         <or>
@@ -3397,6 +3387,7 @@ MODULES_RUN_TASK_FP script.
           </and>
           {%- elif do_enkf_radar_ref %}
           <taskdep task="&ENKF_RADAR_REF_TN;"/>
+          <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
           {%- elif do_enkfupdate %}
           <taskdep task="&RUN_ENKFUPDT_TN;"/>
           <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>

--- a/parm/rdas-atmosphere-templates-fv3_c13_dbz_getkf_observer.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_dbz_getkf_observer.yaml
@@ -1,5 +1,5 @@
 # This is overwritten in the testing but allows command line test of jcb
-algorithm: 3dvar
+algorithm: local_ensemble_da_observer
 
 # Search path for model and obs for JCB (relative for the submodule, or can be absolute)
 # --------------------------------------------------------------------------------------
@@ -11,73 +11,82 @@ app_path_observation_chronicle: rdas/observation_chronicle/atmosphere
 
 # Places where we deviate from the generic file name of a yaml
 # ------------------------------------------------------------
-final_increment_file: atmosphere_final_increment
-#output_file: atmosphere_output
-output_ensemble_increments_file: atmosphere_output_ensemble_increments_gaussian
+output_ensemble_increments_file: atmosphere_output_ensemble_increments
 model_file: atmosphere_model_pseudo
 initial_condition_file: atmosphere_background
-background_error_file: atmosphere_background_error_hybrid3denvar_mgbf
-#background_error_file: atmosphere_background_error_3dvar_gsibec
-#background_error_file: atmosphere_background_error_3dvar_bumpID
 
 # Global analysis things
 # ----------------------
 window_length: PT6H
 bound_to_include: begin
-minimizer: DRPCG
-final_diagnostics_departures: oman
-final_j_evaluation: true
-number_of_outer_loops: 2
-distribution: RoundRobin
 empty_obs_space_action: create output
+atmosphere_number_ensemble_members: 30
 
-analysis_variables:
+# Local Ensemble DA (LETKF)
+# -------------------------
+local_ensemble_da_solver: Deterministic GETKF
+
+increment_variables:
 - eastward_wind
 - northward_wind
 - air_temperature
-- water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
-#- air_pressure_thickness
-- air_pressure_at_surface
-
-control_variables:
-- eastward_wind
-- northward_wind
-- virtual_temperature
-- water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
-- air_pressure_at_surface
-
-state_variables_to_inverse:
-- eastward_wind
-- northward_wind
-- air_temperature
-- water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
-- geopotential_height_times_gravity_at_surface
 - air_pressure_thickness
-- air_pressure_at_surface
+- water_vapor_mixing_ratio_wrt_moist_air
+- ozone_mass_mixing_ratio
+- cloud_liquid_water
+- cloud_liquid_ice
+- rain_water
+- snow_water
+- graupel
+- upward_air_velocity
+- equivalent_reflectivity_factor
 
-# Testing
-# -------
-do_testing: false
+# Veritcal localization for GETKF
+vl_fraction_of_retained_variance: 0.850
+vl_lengthscale: 0.50
+vl_lengthscale_units: logp
+inflation_rtps: 1.0
+inflation_rtpp: 0.0
+inflation_mult: 1.0
+
+# Horizontal localization for GETKF
+obs_distribution_localizations:
+  obs_distribution:
+    name: RoundRobin
+    halo size: 500e3
+  obs_localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 300e3
+override_obs_distribution_localizations:
+  override: true
+  mrms_refl:
+    obs_distribution:
+      name: RoundRobin
+      halo size: 100e3
+    obs_localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 18e3
+
+# Driver
+driver_update_obs_config_with_geometry_info: false
+driver_run_as_observer_only: true
+driver_read_HX_from_disk: false
+driver_do_posterior_observer: false
+driver_save_posterior_mean: false
+driver_save_posterior_ensemble: false
+driver_save_prior_mean: false
+driver_save_posterior_mean_increment: false
+driver_save_posterior_ensemble_increments: false
 
 # Model things
 # ------------
-fv3lam_nml: input_lam_C775_NP14X14.nml
-atmosphere_layout_x: 14
-atmosphere_layout_y: 14
-atmosphere_npx_ges: 420 #not sure if correct
-atmosphere_npy_ges: 252 #not sure if correct
+fv3lam_nml: input_lam_C775_NP16X10.nml
 atmosphere_npz_ges: 65
-atmosphere_npx_anl: 420 #not sure if correct
-atmosphere_npy_anl: 252 #not sure if correct
-atmosphere_npz_anl: 65
+atmosphere_layout_x: 16
+atmosphere_layout_y: 10
 atmosphere_ntiles: 1
 atmosphere_io_layout_x: 1
 atmosphere_io_layout_y: 1
-gradient_norm_reduction: 1e-3
-ninner: 50
 
 # Background
 atmosphere_background_path: "./"
@@ -85,10 +94,10 @@ atmosphere_background_ensemble_path: "data/inputs/mem%mem%"
 
 atmosphere_background_time_iso: @ATMOSPHERE_BACKGROUND_TIME_ISO@
 atmosphere_background_time_prefix: ""
-filename_core: fv3_dynvars # fv_core.res.tile1.nc
-filename_trcr: fv3_tracer  # fv_tracer.res.tile1.nc
-filename_phys: fv3_phyvars # phy_data.nc
-filename_sfcd: fv3_sfcdata # sfc_data.nc
+filename_core: fv_core.res.tile1.nc
+filename_trcr: fv_tracer.res.tile1.nc
+filename_phys: phy_data.nc
+filename_sfcd: sfc_data.nc
 filename_sfcw: fv_srf_wnd.res.tile1.nc
 filename_cplr: coupler.res
 
@@ -121,6 +130,7 @@ state_variables:
 - cloud_ice_number_concentration
 - rain_number_concentration
 - upward_air_velocity
+- equivalent_reflectivity_factor
 
 eastward_wind: ua
 northward_wind: va
@@ -146,120 +156,78 @@ rain_number_concentration: rain_nc
 upward_air_velocity: W
 equivalent_reflectivity_factor: ref_f3d
 
-
-# Background error
-atmosphere_bump_data_directory: DATA/berror
-atmosphere_gsibec_path: DATA/berror
-atmosphere_number_ensemble_members: 30
-atmosphere_layout_gsib_x: 14
-atmosphere_layout_gsib_y: 14
-gsibec_lats: 127
-gsibec_lons: 211
-lat_start: -14.726005
-lat_end: 14.726005
-lon_start: -25.076254
-lon_end: 25.076254
-north_pole_lat: 51.499999
-north_pole_lon: 82.500018
-gsi_bands: 14
-
-# Ensemble localization
-mgbf_nml: mgbf_p196_14x14.nml
-mgbf_nx: 224
-mgbf_ny: 224
-mgbf_dx: 30.0e3
-mgbf_dy: 30.0e3
-mgbf_lonlat: [261, 40]
-mgbf_lat0: 40
-mgbf_lon0: 261
+abi_simulated_channels: 7-16
 
 # Forecasting
 atmosphere_forecast_length: PT6H
 atmosphere_forecast_timestep: PT1H
 
-# Write final increment on Gaussian grid in variational
-atmosphere_final_increment_prefix: "./anl/atminc."
-
-
 # Observation things
 # ------------------
 observations:
 # Upper-air conventional
-- adpupa_airTemperature_120
-- adpupa_airTemperature_132
-- adpupa_specificHumidity_120
-- adpupa_specificHumidity_132
-- adpupa_stationPressure_120
-- adpupa_winds_220
-- adpupa_winds_232
+#- adpupa_airTemperature_120
+#- adpupa_airTemperature_132
+#- adpupa_specificHumidity_120
+#- adpupa_specificHumidity_132
+#- adpupa_stationPressure_120
+#- adpupa_winds_220
+#- adpupa_winds_232
 
 - aircar_airTemperature_133
 - aircar_specificHumidity_133
 - aircar_winds_233
 
-- aircft_airTemperature_130
-- aircft_airTemperature_131
-- aircft_airTemperature_134
-- aircft_airTemperature_135
-- aircft_specificHumidity_134
-- aircft_winds_230
-- aircft_winds_231
-- aircft_winds_234
-- aircft_winds_235
+#- aircft_airTemperature_130
+#- aircft_airTemperature_131
+#- aircft_airTemperature_134
+#- aircft_airTemperature_135
+#- aircft_specificHumidity_134
+#- aircft_winds_230
+#- aircft_winds_231
+#- aircft_winds_234
+#- aircft_winds_235
 
-- proflr_winds_227
-- vadwnd_winds_224
-- rassda_airTemperature_126
+#- proflr_winds_227
+#- vadwnd_winds_224
+#- rassda_airTemperature_126
 
 # Surface conventional
-- adpsfc_airTemperature_181
-- adpsfc_airTemperature_183
-- adpsfc_airTemperature_187
-- adpsfc_specificHumidity_181
-- adpsfc_specificHumidity_183
-- adpsfc_specificHumidity_187
-- adpsfc_stationPressure_181
-- adpsfc_stationPressure_187
-- adpsfc_winds_281
-- adpsfc_winds_284
-- adpsfc_winds_287
-- msonet_airTemperature_188
-- msonet_specificHumidity_188
-- msonet_stationPressure_188
-- msonet_winds_288
+#- adpsfc_airTemperature_181
+#- adpsfc_airTemperature_183
+#- adpsfc_airTemperature_187
+#- adpsfc_specificHumidity_181
+#- adpsfc_specificHumidity_183
+#- adpsfc_specificHumidity_187
+#- adpsfc_stationPressure_181
+#- adpsfc_stationPressure_187
+#- adpsfc_winds_281
+#- adpsfc_winds_284
+#- adpsfc_winds_287
+#- msonet_airTemperature_188
+#- msonet_specificHumidity_188
+#- msonet_stationPressure_188
+#- msonet_winds_288
 
-- sfcshp_airTemperature_180
-- sfcshp_airTemperature_182
-- sfcshp_airTemperature_183
-- sfcshp_specificHumidity_180
-- sfcshp_specificHumidity_182
-- sfcshp_specificHumidity_183
-- sfcshp_stationPressure_180
-- sfcshp_stationPressure_182
-- sfcshp_winds_280
-- sfcshp_winds_282
-- sfcshp_winds_284
+#- sfcshp_airTemperature_180
+#- sfcshp_airTemperature_182
+#- sfcshp_airTemperature_183
+#- sfcshp_specificHumidity_180
+#- sfcshp_specificHumidity_182
+#- sfcshp_specificHumidity_183
+#- sfcshp_stationPressure_180
+#- sfcshp_stationPressure_182
+#- sfcshp_winds_280
+#- sfcshp_winds_282
+#- sfcshp_winds_284
 
 # Remote
 #- gnss_zenithTotalDelay
-- satwnd_winds_245_270
-- satwnd_winds_245_272
-- satwnd_winds_246_270
-- satwnd_winds_246_272
-- satwnd_winds_247_270
-- satwnd_winds_247_272
+#- satwnd_winds_245_270
+#- satwnd_winds_245_272
 
-# SatRad
-#- abi_g16
-#- abi_g18
-#- amsua_n19
-#- amsua_metop-b
-#- amsua_metop-c
-#- atms_npp
-#- atms_n20
-#- atms_n21
-#- cris-fsr_n20
-#- cris-fsr_n21
+# Radar
+- mrms_refl
 
 # Analysis iuse flag (default: passivate)
 # Upper-air conventional
@@ -322,22 +290,12 @@ iuse_sfcshp_winds_284: passivate
 iuse_gnss_zenithTotalDelay: passivate
 iuse_satwnd_winds_245_270: passivate
 iuse_satwnd_winds_245_272: passivate
-iuse_satwnd_winds_246_270: passivate
-iuse_satwnd_winds_246_272: passivate
-iuse_satwnd_winds_247_270: passivate
-iuse_satwnd_winds_247_272: passivate
 
 # SatRad
 iuse_abi_g16: passivate
-iuse_abi_g18: passivate
-iuse_amsua_n19: passivate
-iuse_amsua_metop-b: passivate
-iuse_amsua_metop-c: passivate
-iuse_atms_npp: passivate
-iuse_atms_n20: passivate
-iuse_atms_n21: passivate
-iuse_cris-fsr_n20: passivate
-iuse_cris-fsr_n21: passivate
+
+# Radar
+iuse_mrms_refl: accept
 
 crtm_coefficient_path: "Data/crtm"
 
@@ -364,38 +322,3 @@ atmosphere_obsbiasout_prefix: APREFIX
 atmosphere_obsbiasout_suffix: ".satbias.nc"
 atmosphere_obsbiascovout_prefix: APREFIX
 atmosphere_obsbiascovout_suffix: ".satbias_cov.nc"
-
-
-# Local Ensemble DA (LETKF)
-# -------------------------
-local_ensemble_da_solver: GETKF
-
-increment_variables:
-- eastward_wind
-- northward_wind
-- air_temperature
-- air_pressure_thickness
-- water_vapor_mixing_ratio_wrt_moist_air
-- cloud_liquid_ice
-- cloud_liquid_water
-- ozone_mass_mixing_ratio
-
-# Veritcal localization for GETKF
-vl_fraction_of_retained_variance: 0.750
-vl_lengthscale: 2.1
-vl_lengthscale_units: logp
-inflation_rtps: 0.85
-inflation_rtpp: 0.0
-inflation_mult: 1.0
-
-# Driver
-driver_update_obs_config_with_geometry_info: true
-driver_save_posterior_mean: false
-driver_save_posterior_ensemble: false
-driver_save_prior_mean: false
-driver_save_posterior_mean_increment: false
-driver_save_posterior_ensemble_increments: true
-
-# Diagnostics
-atmosphere_ensemble_increment_prefix: "./anl/mem%{member}%/atminc."
-atmosphere_posterior_output_gaussian: "./mem%{member}%/atmanl."

--- a/parm/rdas-atmosphere-templates-fv3_c13_dbz_getkf_solver.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_dbz_getkf_solver.yaml
@@ -1,5 +1,5 @@
 # This is overwritten in the testing but allows command line test of jcb
-algorithm: 3dvar
+algorithm: local_ensemble_da_observer
 
 # Search path for model and obs for JCB (relative for the submodule, or can be absolute)
 # --------------------------------------------------------------------------------------
@@ -11,73 +11,82 @@ app_path_observation_chronicle: rdas/observation_chronicle/atmosphere
 
 # Places where we deviate from the generic file name of a yaml
 # ------------------------------------------------------------
-final_increment_file: atmosphere_final_increment
-#output_file: atmosphere_output
-output_ensemble_increments_file: atmosphere_output_ensemble_increments_gaussian
+output_ensemble_increments_file: atmosphere_output_ensemble_increments
 model_file: atmosphere_model_pseudo
 initial_condition_file: atmosphere_background
-background_error_file: atmosphere_background_error_hybrid3denvar_mgbf
-#background_error_file: atmosphere_background_error_3dvar_gsibec
-#background_error_file: atmosphere_background_error_3dvar_bumpID
 
 # Global analysis things
 # ----------------------
 window_length: PT6H
 bound_to_include: begin
-minimizer: DRPCG
-final_diagnostics_departures: oman
-final_j_evaluation: true
-number_of_outer_loops: 2
-distribution: RoundRobin
 empty_obs_space_action: create output
+atmosphere_number_ensemble_members: 30
 
-analysis_variables:
+# Local Ensemble DA (LETKF)
+# -------------------------
+local_ensemble_da_solver: Deterministic GETKF
+
+increment_variables:
 - eastward_wind
 - northward_wind
 - air_temperature
-- water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
-#- air_pressure_thickness
-- air_pressure_at_surface
-
-control_variables:
-- eastward_wind
-- northward_wind
-- virtual_temperature
-- water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
-- air_pressure_at_surface
-
-state_variables_to_inverse:
-- eastward_wind
-- northward_wind
-- air_temperature
-- water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
-- geopotential_height_times_gravity_at_surface
 - air_pressure_thickness
-- air_pressure_at_surface
+- water_vapor_mixing_ratio_wrt_moist_air
+- ozone_mass_mixing_ratio
+- cloud_liquid_water
+- cloud_liquid_ice
+- rain_water
+- snow_water
+- graupel
+- upward_air_velocity
+- equivalent_reflectivity_factor
 
-# Testing
-# -------
-do_testing: false
+# Veritcal localization for GETKF
+vl_fraction_of_retained_variance: 0.850
+vl_lengthscale: 0.50
+vl_lengthscale_units: logp
+inflation_rtps: 1.0
+inflation_rtpp: 0.0
+inflation_mult: 1.0
+
+# Horizontal localization for GETKF
+obs_distribution_localizations:
+  obs_distribution:
+    name: Halo
+    halo size: 500e3
+  obs_localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 300e3
+override_obs_distribution_localizations:
+  override: true
+  mrms_refl:
+    obs_distribution:
+      name: Halo
+      halo size: 100e3
+    obs_localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 18e3
+
+# Driver
+driver_update_obs_config_with_geometry_info: false
+driver_run_as_observer_only: false
+driver_read_HX_from_disk: true
+driver_do_posterior_observer: false
+driver_save_posterior_mean: false
+driver_save_posterior_ensemble: false
+driver_save_prior_mean: false
+driver_save_posterior_mean_increment: false
+driver_save_posterior_ensemble_increments: true
 
 # Model things
 # ------------
-fv3lam_nml: input_lam_C775_NP14X14.nml
-atmosphere_layout_x: 14
-atmosphere_layout_y: 14
-atmosphere_npx_ges: 420 #not sure if correct
-atmosphere_npy_ges: 252 #not sure if correct
+fv3lam_nml: input_lam_C775_NP16X10.nml
 atmosphere_npz_ges: 65
-atmosphere_npx_anl: 420 #not sure if correct
-atmosphere_npy_anl: 252 #not sure if correct
-atmosphere_npz_anl: 65
+atmosphere_layout_x: 16
+atmosphere_layout_y: 10
 atmosphere_ntiles: 1
 atmosphere_io_layout_x: 1
 atmosphere_io_layout_y: 1
-gradient_norm_reduction: 1e-3
-ninner: 50
 
 # Background
 atmosphere_background_path: "./"
@@ -85,10 +94,10 @@ atmosphere_background_ensemble_path: "data/inputs/mem%mem%"
 
 atmosphere_background_time_iso: @ATMOSPHERE_BACKGROUND_TIME_ISO@
 atmosphere_background_time_prefix: ""
-filename_core: fv3_dynvars # fv_core.res.tile1.nc
-filename_trcr: fv3_tracer  # fv_tracer.res.tile1.nc
-filename_phys: fv3_phyvars # phy_data.nc
-filename_sfcd: fv3_sfcdata # sfc_data.nc
+filename_core: fv_core.res.tile1.nc
+filename_trcr: fv_tracer.res.tile1.nc
+filename_phys: phy_data.nc
+filename_sfcd: sfc_data.nc
 filename_sfcw: fv_srf_wnd.res.tile1.nc
 filename_cplr: coupler.res
 
@@ -121,6 +130,7 @@ state_variables:
 - cloud_ice_number_concentration
 - rain_number_concentration
 - upward_air_velocity
+- equivalent_reflectivity_factor
 
 eastward_wind: ua
 northward_wind: va
@@ -146,120 +156,78 @@ rain_number_concentration: rain_nc
 upward_air_velocity: W
 equivalent_reflectivity_factor: ref_f3d
 
-
-# Background error
-atmosphere_bump_data_directory: DATA/berror
-atmosphere_gsibec_path: DATA/berror
-atmosphere_number_ensemble_members: 30
-atmosphere_layout_gsib_x: 14
-atmosphere_layout_gsib_y: 14
-gsibec_lats: 127
-gsibec_lons: 211
-lat_start: -14.726005
-lat_end: 14.726005
-lon_start: -25.076254
-lon_end: 25.076254
-north_pole_lat: 51.499999
-north_pole_lon: 82.500018
-gsi_bands: 14
-
-# Ensemble localization
-mgbf_nml: mgbf_p196_14x14.nml
-mgbf_nx: 224
-mgbf_ny: 224
-mgbf_dx: 30.0e3
-mgbf_dy: 30.0e3
-mgbf_lonlat: [261, 40]
-mgbf_lat0: 40
-mgbf_lon0: 261
+abi_simulated_channels: 7-16
 
 # Forecasting
 atmosphere_forecast_length: PT6H
 atmosphere_forecast_timestep: PT1H
 
-# Write final increment on Gaussian grid in variational
-atmosphere_final_increment_prefix: "./anl/atminc."
-
-
 # Observation things
 # ------------------
 observations:
 # Upper-air conventional
-- adpupa_airTemperature_120
-- adpupa_airTemperature_132
-- adpupa_specificHumidity_120
-- adpupa_specificHumidity_132
-- adpupa_stationPressure_120
-- adpupa_winds_220
-- adpupa_winds_232
+#- adpupa_airTemperature_120
+#- adpupa_airTemperature_132
+#- adpupa_specificHumidity_120
+#- adpupa_specificHumidity_132
+#- adpupa_stationPressure_120
+#- adpupa_winds_220
+#- adpupa_winds_232
 
 - aircar_airTemperature_133
 - aircar_specificHumidity_133
 - aircar_winds_233
 
-- aircft_airTemperature_130
-- aircft_airTemperature_131
-- aircft_airTemperature_134
-- aircft_airTemperature_135
-- aircft_specificHumidity_134
-- aircft_winds_230
-- aircft_winds_231
-- aircft_winds_234
-- aircft_winds_235
+#- aircft_airTemperature_130
+#- aircft_airTemperature_131
+#- aircft_airTemperature_134
+#- aircft_airTemperature_135
+#- aircft_specificHumidity_134
+#- aircft_winds_230
+#- aircft_winds_231
+#- aircft_winds_234
+#- aircft_winds_235
 
-- proflr_winds_227
-- vadwnd_winds_224
-- rassda_airTemperature_126
+#- proflr_winds_227
+#- vadwnd_winds_224
+#- rassda_airTemperature_126
 
 # Surface conventional
-- adpsfc_airTemperature_181
-- adpsfc_airTemperature_183
-- adpsfc_airTemperature_187
-- adpsfc_specificHumidity_181
-- adpsfc_specificHumidity_183
-- adpsfc_specificHumidity_187
-- adpsfc_stationPressure_181
-- adpsfc_stationPressure_187
-- adpsfc_winds_281
-- adpsfc_winds_284
-- adpsfc_winds_287
-- msonet_airTemperature_188
-- msonet_specificHumidity_188
-- msonet_stationPressure_188
-- msonet_winds_288
+#- adpsfc_airTemperature_181
+#- adpsfc_airTemperature_183
+#- adpsfc_airTemperature_187
+#- adpsfc_specificHumidity_181
+#- adpsfc_specificHumidity_183
+#- adpsfc_specificHumidity_187
+#- adpsfc_stationPressure_181
+#- adpsfc_stationPressure_187
+#- adpsfc_winds_281
+#- adpsfc_winds_284
+#- adpsfc_winds_287
+#- msonet_airTemperature_188
+#- msonet_specificHumidity_188
+#- msonet_stationPressure_188
+#- msonet_winds_288
 
-- sfcshp_airTemperature_180
-- sfcshp_airTemperature_182
-- sfcshp_airTemperature_183
-- sfcshp_specificHumidity_180
-- sfcshp_specificHumidity_182
-- sfcshp_specificHumidity_183
-- sfcshp_stationPressure_180
-- sfcshp_stationPressure_182
-- sfcshp_winds_280
-- sfcshp_winds_282
-- sfcshp_winds_284
+#- sfcshp_airTemperature_180
+#- sfcshp_airTemperature_182
+#- sfcshp_airTemperature_183
+#- sfcshp_specificHumidity_180
+#- sfcshp_specificHumidity_182
+#- sfcshp_specificHumidity_183
+#- sfcshp_stationPressure_180
+#- sfcshp_stationPressure_182
+#- sfcshp_winds_280
+#- sfcshp_winds_282
+#- sfcshp_winds_284
 
 # Remote
 #- gnss_zenithTotalDelay
-- satwnd_winds_245_270
-- satwnd_winds_245_272
-- satwnd_winds_246_270
-- satwnd_winds_246_272
-- satwnd_winds_247_270
-- satwnd_winds_247_272
+#- satwnd_winds_245_270
+#- satwnd_winds_245_272
 
-# SatRad
-#- abi_g16
-#- abi_g18
-#- amsua_n19
-#- amsua_metop-b
-#- amsua_metop-c
-#- atms_npp
-#- atms_n20
-#- atms_n21
-#- cris-fsr_n20
-#- cris-fsr_n21
+# Radar
+- mrms_refl
 
 # Analysis iuse flag (default: passivate)
 # Upper-air conventional
@@ -322,22 +290,12 @@ iuse_sfcshp_winds_284: passivate
 iuse_gnss_zenithTotalDelay: passivate
 iuse_satwnd_winds_245_270: passivate
 iuse_satwnd_winds_245_272: passivate
-iuse_satwnd_winds_246_270: passivate
-iuse_satwnd_winds_246_272: passivate
-iuse_satwnd_winds_247_270: passivate
-iuse_satwnd_winds_247_272: passivate
 
 # SatRad
 iuse_abi_g16: passivate
-iuse_abi_g18: passivate
-iuse_amsua_n19: passivate
-iuse_amsua_metop-b: passivate
-iuse_amsua_metop-c: passivate
-iuse_atms_npp: passivate
-iuse_atms_n20: passivate
-iuse_atms_n21: passivate
-iuse_cris-fsr_n20: passivate
-iuse_cris-fsr_n21: passivate
+
+# Radar
+iuse_mrms_refl: accept
 
 crtm_coefficient_path: "Data/crtm"
 
@@ -364,38 +322,3 @@ atmosphere_obsbiasout_prefix: APREFIX
 atmosphere_obsbiasout_suffix: ".satbias.nc"
 atmosphere_obsbiascovout_prefix: APREFIX
 atmosphere_obsbiascovout_suffix: ".satbias_cov.nc"
-
-
-# Local Ensemble DA (LETKF)
-# -------------------------
-local_ensemble_da_solver: GETKF
-
-increment_variables:
-- eastward_wind
-- northward_wind
-- air_temperature
-- air_pressure_thickness
-- water_vapor_mixing_ratio_wrt_moist_air
-- cloud_liquid_ice
-- cloud_liquid_water
-- ozone_mass_mixing_ratio
-
-# Veritcal localization for GETKF
-vl_fraction_of_retained_variance: 0.750
-vl_lengthscale: 2.1
-vl_lengthscale_units: logp
-inflation_rtps: 0.85
-inflation_rtpp: 0.0
-inflation_mult: 1.0
-
-# Driver
-driver_update_obs_config_with_geometry_info: true
-driver_save_posterior_mean: false
-driver_save_posterior_ensemble: false
-driver_save_prior_mean: false
-driver_save_posterior_mean_increment: false
-driver_save_posterior_ensemble_increments: true
-
-# Diagnostics
-atmosphere_ensemble_increment_prefix: "./anl/mem%{member}%/atminc."
-atmosphere_posterior_output_gaussian: "./mem%{member}%/atmanl."

--- a/parm/rdas-atmosphere-templates-fv3_c13_getkf_observer.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_getkf_observer.yaml
@@ -39,9 +39,27 @@ increment_variables:
 vl_fraction_of_retained_variance: 0.850
 vl_lengthscale: 0.50
 vl_lengthscale_units: logp
-inflation_rtps: 0.95
+inflation_rtps: 1.0
 inflation_rtpp: 0.0
 inflation_mult: 1.0
+
+# Horizontal localization for GETKF
+obs_distribution_localizations:
+  obs_distribution:
+    name: RoundRobin
+    halo size: 500e3
+  obs_localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 300e3
+override_obs_distribution_localizations:
+  override: true
+  mrms_refl:
+    obs_distribution:
+      name: RoundRobin
+      halo size: 100e3
+    obs_localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 18e3
 
 # Driver
 driver_update_obs_config_with_geometry_info: false

--- a/parm/rdas-atmosphere-templates-fv3_c13_getkf_solver.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_getkf_solver.yaml
@@ -39,9 +39,27 @@ increment_variables:
 vl_fraction_of_retained_variance: 0.850
 vl_lengthscale: 0.50
 vl_lengthscale_units: logp
-inflation_rtps: 0.95
+inflation_rtps: 1.0
 inflation_rtpp: 0.0
 inflation_mult: 1.0
+
+# Horizontal localization for GETKF
+obs_distribution_localizations:
+  obs_distribution:
+    name: RoundRobin
+    halo size: 500e3
+  obs_localizations:
+  - localization method: Horizontal Gaspari-Cohn
+    lengthscale: 300e3
+override_obs_distribution_localizations:
+  override: true
+  mrms_refl:
+    obs_distribution:
+      name: RoundRobin
+      halo size: 100e3
+    obs_localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 18e3
 
 # Driver
 driver_update_obs_config_with_geometry_info: false

--- a/parm/rdas-atmosphere-templates-fv3_na3km.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_na3km.yaml
@@ -273,7 +273,7 @@ iuse_adpupa_winds_220: passivate
 iuse_adpupa_winds_232: passivate
 
 iuse_aircar_airTemperature_133: accept
-iuse_aircar_specificHumidity_133: passivate
+iuse_aircar_specificHumidity_133: accept
 iuse_aircar_winds_233: accept
 
 iuse_aircft_airTemperature_130: passivate

--- a/scripts/exrrfs_analysis_enkf_jedi.sh
+++ b/scripts/exrrfs_analysis_enkf_jedi.sh
@@ -172,7 +172,11 @@ for imem in  $(seq 1 $nens); do
   ln -snf ${bkpath}/fv_core.res.tile1.nc       data/inputs/${memcharv0}/fv_core.res.tile1.nc
   ln -snf ${bkpath}/fv_tracer.res.tile1.nc     data/inputs/${memcharv0}/fv_tracer.res.tile1.nc
   ln -snf ${bkpath}/sfc_data.nc                data/inputs/${memcharv0}/sfc_data.nc
-  ln -snf ${bkpath}/phy_data.nc                data/inputs/${memcharv0}/phy_data.nc
+  if [[ "${DO_ENKF_RADAR_REF}" == "TRUE" ]]; then
+    ln -snf ${bkpath}/phy_data.nc_prepdbz      data/inputs/${memcharv0}/phy_data.nc
+  else
+    ln -snf ${bkpath}/phy_data.nc              data/inputs/${memcharv0}/phy_data.nc
+  fi
   ln -snf ${bkpath}/fv_srf_wnd.res.tile1.nc    data/inputs/${memcharv0}/fv_srf_wnd.res.tile1.nc
   ln -snf ${bkpath}/coupler.res                data/inputs/${memcharv0}/coupler.res
 

--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -1258,6 +1258,22 @@ cp -rL ${modelinputdir} ${jedidir}
 #
 #-----------------------------------------------------------------------
 #
+# If performing reflectivity analysis, prepare phy_data.nc files
+#
+#-----------------------------------------------------------------------
+#
+
+if [[ "${DO_ENVAR_RADAR_REF}" = "TRUE" || "${DO_ENKF_RADAR_REF}" == "TRUE" ]]; then
+  if [[ ${BKTYPE} == 0 || ${BKTYPE} == 3 ]]; then
+    cd ${jedidir}
+    cp ${USHdir}/prep_phydata_dbz.py .
+    python prep_phydata_dbz.py phy_data.nc
+  fi
+fi
+
+#
+#-----------------------------------------------------------------------
+#
 # Print message indicating successful completion of script.
 #
 #-----------------------------------------------------------------------

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -68,7 +68,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/RDASApp
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = 184d30a
+hash = 6e3dbe8
 local_path = RDASApp
 required = True
 

--- a/ush/run_jcb.py
+++ b/ush/run_jcb.py
@@ -5,6 +5,8 @@ import re
 from datetime import datetime, timedelta
 from jcb import render
 from wxflow import parse_j2yaml
+from collections.abc import Mapping, Sequence
+from pathlib import Path
 
 def update_cycle_times(config, cycle_str):
     cycle_time = datetime.strptime(cycle_str, "%Y%m%d%H")
@@ -82,6 +84,32 @@ def patch_solver_struct(cfg_plain, ctest_yaml):
 
     return cfg_plain
 
+def to_plain(obj):
+    # Common pattern in wxflow/JCB style objects
+    for attr in ("to_dict", "as_dict", "dict"):
+        if hasattr(obj, attr) and callable(getattr(obj, attr)):
+            return to_plain(getattr(obj, attr)())
+
+    # dict-like
+    if isinstance(obj, Mapping):
+        return {str(k): to_plain(v) for k, v in obj.items()}
+
+    # list-like (but not strings/bytes)
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return [to_plain(v) for v in obj]
+
+    # pathlib, numpy scalars, etc.
+    if isinstance(obj, Path):
+        return str(obj)
+    try:
+        import numpy as np
+        if isinstance(obj, np.generic):
+            return obj.item()
+    except Exception:
+        pass
+
+    return obj
+
 if __name__ == "__main__":
     if len(sys.argv) != 4:
         print("Usage: run.py YYYYMMDDHH jcb_config jedi_yaml")
@@ -103,9 +131,10 @@ if __name__ == "__main__":
 
     # Render (returns wxflow/JCB wrapper objects)
     rendered = render(cycle_config)
+    rendered_plain = to_plain(rendered)
 
     # Dump to plain YAML text, then load back to plain dicts/lists
-    yaml_text = yaml.safe_dump(rendered, default_flow_style=False, sort_keys=False)
+    yaml_text = yaml.safe_dump(rendered_plain, default_flow_style=False, sort_keys=False)
     cfg_plain = yaml.safe_load(yaml_text)
 
     # If solver, structurally patch obsfiles to observer rundir jdiag


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

This PR contains a few minor changes needed to facilitate dBZ assimilation using GETKF in FV3-JEDI. These include: 
* Updated dependencies for `RUN_ENKFUPDT_JEDI_TN` task if assimilating dBZ obs 
* Updated the prep_cyc task to now run the `prep_phydata_dbz.py` utility so that it can be done in parallel for each member. Also now linking the resulting files in `exrrfs_analysis_enkf_jedi.sh`
* New JCB config files for GETKF with dBZ 
* Updated all JCB config files for new method of specifying horizontal localization
* Updated RDASApp hash

I should note that the `prep_phydata_dbz.py` utility is now being run in different locations for EnKF (prep_cyc task) and Jedivar (jedivar task itself). I plan to clean this up in a future PR so that it is only run in the prep_cyc task. 

## TESTS CONDUCTED: 
I have completed 4 days of cycling so far and results are as expected. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
None
