### PR TITLE
align the dependency indentation and fix the jedivar depencency

### DIFF
--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -91,11 +91,11 @@ def fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
             cloudana_dep = f'\n    <taskdep task="nonvar_cldana{ensindexstr}"/>'
     elif os.getenv("DO_JEDI", "FALSE").upper() == "TRUE":
         if os.getenv("DO_ENSEMBLE", "FALSE").upper() == "TRUE":
-            jedidep = f'\n<taskdep task="getkf_solver"/>'
+            jedidep = f'\n    <taskdep task="getkf_solver"/>'
         elif do_spinup:
-            jedidep = f'\n<taskdep task="jedivar_spinup"/>'
+            jedidep = f'\n    <taskdep task="jedivar_spinup"/>'
         else:
-            jedidep = f'\n<taskdep task="jedivar"/>'
+            jedidep = f'\n    <taskdep task="jedivar"/>'
     else:
         if os.getenv("DO_RECENTER", "FALSE").upper() == "TRUE":
             if os.getenv("DO_ENSEMBLE", "FALSE").upper() == "TRUE":

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import textwrap
 from rocoto_funcs.base import xml_task, get_cascade_env
 
 # begin of jedivar --------------------------------------------------------
@@ -74,28 +75,21 @@ def jedivar(xmlFile, expdir, do_spinup=False):
         HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
 
     ens_dep = ""
+    need_ens_dep = False
     if realtime.upper() == "TRUE":
         ens_dep = ""
 
     elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "1":  # rrfsens
         RUN = 'rrfs'
-        ens_dep0 = ""
+        need_ens_dep = True
         for enshrs in range(1, int(ens_bec_look_back_hrs) + 1):
-            ens_depm = ""
             for i in range(1, int(ens_size) + 1):
                 ensindexstr = f'mem{i:03d}'
-                ens_depm = ens_depm + f'\n       <datadep age="00:05:00"><cyclestr offset="-{enshrs}:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/fcst/enkf/</cyclestr>{ensindexstr}/<cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'
-            ens_dep0 = ens_dep0 + f'''
-     <and>{ens_depm}
-     </and>'''
-
-        ens_dep = f'''
-    <or>
-     {ens_dep0}
-    </or>'''
+                ens_dep = ens_dep + f'\n    <datadep age="00:05:00"><cyclestr offset="-{enshrs}:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/fcst/enkf/</cyclestr>{ensindexstr}/<cyclestr>mpasout.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'
 
     elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "2":  # interpolated GDAS/GEFS
         RUN = 'rrfs'
+        need_ens_dep = True
         ens_dep = f'''
     <or>
       <datadep age="00:05:00"><cyclestr  offset="0:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
@@ -122,34 +116,31 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     coldhrs = coldhrs.split(' ')
     strneqs = ""
     streqs = ""
-    if coldstart_cyc_do_da.upper() == "FALSE":
-        spaces = " " * 4
-        strneqs = '<or>'
+    if need_ens_dep and coldstart_cyc_do_da.upper() == "FALSE":  # if no DA at coldstart cycs, skip checking ensembles
+        spaces = " " * 6
         streqs = '<or>'
+        strneqs = ""
         for hr in coldhrs:
             hr = f"{int(hr):02d}"
-            strneqs += '\n' + spaces + f'  <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>'
             streqs += '\n' + spaces + f'  <streq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></streq>'
-        strneqs += '\n' + spaces + '</or>'
+            strneqs += '\n' + spaces + f'  <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>'
         streqs += '\n' + spaces + '</or>'
-        da_dep = f'''<or>
-    <and>
-    {strneqs}
-    {iodadep}{ens_dep}
-    </and>
-    {streqs}
-    </or>
-        '''
+        ens_dep_indented = textwrap.indent(ens_dep, "    ")  # four extra spaces
+        final_ens_dep = f'''
+    <or>
+      {streqs}
+      <and>{strneqs}{ens_dep_indented}
+      </and>
+    </or>'''
+
     else:
-        da_dep = f'''
-        {iodadep}{ens_dep}
-        '''
+        final_ens_dep = ens_dep
     #
     dependencies = f'''
   <dependency>
   <and>{timedep}
     {prep_ic_dep}
-    {da_dep}
+    {iodadep}{final_ens_dep}
   </and>
   </dependency>'''
     #

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -78,9 +78,9 @@ def mpassit(xmlFile, expdir, do_ensemble=False, do_ensmean_post=False):
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
     if do_ensmean_post:
-        taskdep = f'\n   <metataskdep metatask="ensmean"/>'
+        taskdep = f'  <metataskdep metatask="ensmean"/>'
     else:
-        taskdep = f'\n   <taskdep task="fcst{ensindexstr}"/>'
+        taskdep = f'  <taskdep task="fcst{ensindexstr}"/>'
 
     dependencies = f'''
   <dependency>

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -78,11 +78,11 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     for hr in coldhrs:
         hr = f"{hr:0>2}"
         streqs = streqs + f"\n        <streq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></streq>"
-        strneqs = strneqs + f"\n        <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>"
+        strneqs = strneqs + f"\n      <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>"
     streqs = streqs.lstrip('\n')
     strneqs = strneqs.lstrip('\n')
-    datadep_prod = f'''\n        <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;{ensdirstr}/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
-    datadep_spinup = f'''\n        <taskdep task="fcst_spinup" cycle_offset="-1:00:00"/>'''
+    datadep_prod = f'''\n      <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;{ensdirstr}/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
+    datadep_spinup = f'''\n      <taskdep task="fcst_spinup" cycle_offset="-1:00:00"/>'''
     if spinup_mode == 0:  # no parallel spinup cycles
         datadep = datadep_prod
     elif spinup_mode == 1:  # a spinup cycle
@@ -96,8 +96,8 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         # cold start cycles wait for the latest satbias updated from the -1h cycles
         spaces = " " * 6
         satbias_dep = '\n' + spaces + '<or>'
-        satbias_dep += '\n' + spaces + f' <taskdep task="jedivar" cycle_offset="-{cyc_interval}:00:00"/>'
-        satbias_dep += '\n' + spaces + f' <datadep><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/jedivar/&WGF;/satbias_jumpstart</cyclestr></datadep>'
+        satbias_dep += '\n' + spaces + f'  <taskdep task="jedivar" cycle_offset="-{cyc_interval}:00:00"/>'
+        satbias_dep += '\n' + spaces + f'  <datadep><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/jedivar/&WGF;/satbias_jumpstart</cyclestr></datadep>'
         satbias_dep += '\n' + spaces + '</or>'
     #
     timedep = ""
@@ -120,9 +120,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
       </or>{icdep}{satbias_dep}
     </and>
     <and>
-      <and>
 {strneqs}{datadep}
-      </and>
     </and>
    </or>
   </and>
@@ -149,7 +147,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         for hr in prodswitch_hrs.split(' '):
             hr = f"{hr:0>2}"
             streqs = streqs + f"\n        <streq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></streq>"
-            strneqs = strneqs + f"\n        <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>"
+            strneqs = strneqs + f"\n      <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>"
         streqs = streqs.lstrip('\n')
         strneqs = strneqs.lstrip('\n')
         datadep_spinup = datadep_spinup.lstrip('\n')[2:]
@@ -164,9 +162,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
 {datadep_spinup}
     </and>
     <and>
-      <and>
 {strneqs}{datadep_prod}
-      </and>
     </and>
    </or>
   </and>


### PR DESCRIPTION
1. align the dependency indentation so that the rrfs.xml file is easier to read and understand
2. The current `jedivar` dependency does not work correctly under some situations. Thanks @Ruifang-Li for identifying this. This PR fixes this and streamlines the dependency decision in jedivar.py