### PR TITLE
enable smart,flexible mpassit,upp groups at different cycles

### DIFF
--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -25,28 +25,13 @@ dx=${MPASSIT_DX:-12000.0}
 ref_lat=${MPASSIT_REF_LAT:-"39.0"}
 ref_lon=${MPASSIT_REF_LON:-"-97.5"}
 #
-#
-# find forecst length for this cycle
-#
-fcst_len_hrs_cycles=${FCST_LEN_HRS_CYCLES:-"01 01"}
-fcst_len_hrs_thiscyc=$("${USHrrfs}/find_fcst_length.sh" "${fcst_len_hrs_cycles}" "${cyc}" )
-echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
-#
 # loop through forecast history files for this group
 #
-fhr_string=$( seq 0 $((10#${HISTORY_INTERVAL})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ' )
-read -ra fhr_all <<< "${fhr_string}"  # convert fhr_string to an array
-num_fhrs=${#fhr_all[@]}
-group_total_num=$((10#${GROUP_TOTAL_NUM}))
+read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
 group_index=$((10#${GROUP_INDEX}))
 
-for (( ii=0; ii<"${num_fhrs}"; ii=ii+"${group_total_num}" )); do
-    i=$(( ii + "${group_index}" - 1 ))
-    if (( i >= num_fhrs )); then
-      break
-    fi
+for fhr in "${fhr_all[@]}"; do
     # get forecast hour and string
-    fhr=${fhr_all[$i]}
     CDATEp=$(${NDATE} "${fhr}" "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S) 
     # decide the history files   

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -35,8 +35,6 @@ echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
 # loop through forecast history files for this group
 #
 read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
-group_index=$((10#${GROUP_INDEX}))
-
 for fhr in "${fhr_all[@]}"; do
     if (( 10#${fhr} > 10#${fcst_len_hrs_thiscyc} )); then
       break

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -25,12 +25,22 @@ dx=${MPASSIT_DX:-12000.0}
 ref_lat=${MPASSIT_REF_LAT:-"39.0"}
 ref_lon=${MPASSIT_REF_LON:-"-97.5"}
 #
+#
+# find forecst length for this cycle
+#
+fcst_len_hrs_cycles=${FCST_LEN_HRS_CYCLES:-"01 01"}
+fcst_len_hrs_thiscyc=$("${USHrrfs}/find_fcst_length.sh" "${fcst_len_hrs_cycles}" "${cyc}" )
+echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
+#
 # loop through forecast history files for this group
 #
 read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
 group_index=$((10#${GROUP_INDEX}))
 
 for fhr in "${fhr_all[@]}"; do
+    if (( 10#${fhr} > 10#${fcst_len_hrs_thiscyc} )); then
+      break
+    fi
     # get forecast hour and string
     CDATEp=$(${NDATE} "${fhr}" "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S) 

--- a/scripts/exrrfs_upp.sh
+++ b/scripts/exrrfs_upp.sh
@@ -23,10 +23,19 @@ done < crtmfiles.upp
 #
 YYJJJHH=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%y%j%H)
 #
+# find forecst length for this cycle
+#
+fcst_len_hrs_cycles=${FCST_LEN_HRS_CYCLES:-"01 01"}
+fcst_len_hrs_thiscyc=$( "${USHrrfs}/find_fcst_length.sh"  "${fcst_len_hrs_cycles}"  "${cyc}" )
+echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
+#
 # loop through forecast history files for this group
 #
 read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
 for fhr in "${fhr_all[@]}"; do
+    if (( 10#${fhr} > 10#${fcst_len_hrs_thiscyc} )); then
+      break
+    fi
     # get forecast hour and string
     CDATEp=$( ${NDATE} "${fhr}"  "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)

--- a/scripts/exrrfs_upp.sh
+++ b/scripts/exrrfs_upp.sh
@@ -23,27 +23,11 @@ done < crtmfiles.upp
 #
 YYJJJHH=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%y%j%H)
 #
-# find forecst length for this cycle
-#
-fcst_len_hrs_cycles=${FCST_LEN_HRS_CYCLES:-"01 01"}
-fcst_len_hrs_thiscyc=$( "${USHrrfs}/find_fcst_length.sh"  "${fcst_len_hrs_cycles}"  "${cyc}" )
-echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
-#
 # loop through forecast history files for this group
 #
-fhr_string=$( seq 0 $((10#${HISTORY_INTERVAL})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ' )
-read -ra fhr_all <<< "${fhr_string}"  # convert fhr_string to an array
-num_fhrs=${#fhr_all[@]}
-group_total_num=$((10#${GROUP_TOTAL_NUM}))
-group_index=$((10#${GROUP_INDEX}))
-
-for (( ii=0; ii<num_fhrs; ii=ii+group_total_num )); do
-    i=$(( ii + group_index - 1 ))
-    if (( i >= num_fhrs )); then
-      break
-    fi
+read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
+for fhr in "${fhr_all[@]}"; do
     # get forecast hour and string
-    fhr=${fhr_all[$i]}
     CDATEp=$( ${NDATE} "${fhr}"  "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
     timestr2=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H:%M:%S)
@@ -57,7 +41,7 @@ for (( ii=0; ii<num_fhrs; ii=ii+group_total_num )); do
       fi
       sleep 60s
     done
-    # run mpassit
+    # run UPP
     if [[ -s "${mpassit_file}" ]] ; then
 
       ln -snf "${mpassit_file}" .

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -22,6 +22,7 @@ export MPI_RUN_CMD=${MPI_RUN_CMD:-"srun"}
 export USE_CONV_SAT_INFO=${USE_CONV_SAT_INFO:-true}
 export EMPTY_OBS_SPACE_ACTION=${EMPTY_OBS_SPACE_ACTION:-"skip output"}
 export MPASOUT_SAVE2COM_HRS=${MPASOUT_SAVE2COM_HRS:-""}  # cycling mpasout.nc is saved by the 'save_for_next' task; specify other mpasout hours if needed, e.g. "02 03", "24", "24 48"
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; setting this variable will overwrite POST_GROUP_TOT_NUM
 
 # PREP_LBC_LOOK_BACK_HRS
 if ${REALTIME:-false}; then

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -42,8 +42,8 @@ for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=1
-export UPP_GROUP_TOTAL_NUM=1
+export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -43,7 +43,6 @@ for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -43,7 +43,6 @@ for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -42,8 +42,8 @@ for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=2
-export UPP_GROUP_TOTAL_NUM=2
+export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -36,7 +36,6 @@ for i in {0..23..6}; do arr[$i]="01"; done # 1hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 export ENSMEAN_GROUP_TOTAL_NUM=3
 
 export IC_OFFSET=30

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -35,8 +35,8 @@ for i in {0..23};    do arr[$i]="01"; done # 1hr fcst
 for i in {0..23..6}; do arr[$i]="01"; done # 1hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=1
-export UPP_GROUP_TOTAL_NUM=1
+export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 export ENSMEAN_GROUP_TOTAL_NUM=3
 
 export IC_OFFSET=30

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -35,8 +35,8 @@ for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=2
-export UPP_GROUP_TOTAL_NUM=2
+export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=30
 export LBC_OFFSET=6

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -36,7 +36,6 @@ for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=30
 export LBC_OFFSET=6

--- a/workflow/exp/exp.ens_na12km
+++ b/workflow/exp/exp.ens_na12km
@@ -36,8 +36,8 @@ for i in {0..23};    do arr[$i]="01"; done # 1hr fcst
 for i in {0..23..6}; do arr[$i]="01"; done # 1hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=1
-export UPP_GROUP_TOTAL_NUM=1
+export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 export ENSMEAN_GROUP_TOTAL_NUM=3
 
 export IC_OFFSET=30

--- a/workflow/exp/exp.ens_na12km
+++ b/workflow/exp/exp.ens_na12km
@@ -37,7 +37,6 @@ for i in {0..23..6}; do arr[$i]="01"; done # 1hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 export ENSMEAN_GROUP_TOTAL_NUM=3
 
 export IC_OFFSET=30

--- a/workflow/exp/exp.na12km
+++ b/workflow/exp/exp.na12km
@@ -42,8 +42,8 @@ for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="12"; done # 12hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=1
-export UPP_GROUP_TOTAL_NUM=1
+export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/exp.na12km
+++ b/workflow/exp/exp.na12km
@@ -43,7 +43,6 @@ for i in {0..23..6}; do arr[$i]="12"; done # 12hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=1 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/rt_jet/exp.rt_jet_conus3km
+++ b/workflow/exp/rt_jet/exp.rt_jet_conus3km
@@ -32,8 +32,8 @@ for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=2
-export UPP_GROUP_TOTAL_NUM=2
+export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=0
 export LBC_OFFSET=3

--- a/workflow/exp/rt_jet/exp.rt_jet_conus3km
+++ b/workflow/exp/rt_jet/exp.rt_jet_conus3km
@@ -33,7 +33,6 @@ for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=0
 export LBC_OFFSET=3

--- a/workflow/exp/rt_jet/exp.rt_jet_ens_conus3km
+++ b/workflow/exp/rt_jet/exp.rt_jet_ens_conus3km
@@ -33,7 +33,6 @@ for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=30
 export LBC_OFFSET=6

--- a/workflow/exp/rt_jet/exp.rt_jet_ens_conus3km
+++ b/workflow/exp/rt_jet/exp.rt_jet_ens_conus3km
@@ -32,8 +32,8 @@ for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
 for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=2
-export UPP_GROUP_TOTAL_NUM=2
+export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=30
 export LBC_OFFSET=6

--- a/workflow/exp/rt_ursa/exp.rrfsv2x
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x
@@ -42,7 +42,6 @@ for i in 00; do arr[$i]="36"; done # 36hr fcst at 00Z
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/rt_ursa/exp.rrfsv2x
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x
@@ -41,8 +41,8 @@ for i in {0..23..12}; do arr[$i]="24"; done # 24hr fcst every 12hrs
 for i in 00; do arr[$i]="36"; done # 36hr fcst at 00Z
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
-export MPASSIT_GROUP_TOTAL_NUM=2
-export UPP_GROUP_TOTAL_NUM=2
+export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 
 export IC_OFFSET=6
 export LBC_OFFSET=6

--- a/workflow/exp/rt_ursa/exp.rrfsv2x_ens
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x_ens
@@ -34,7 +34,6 @@ for i in {0..23};    do arr[$i]="01"; done # 3hr fcst
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 #export HISTORY_INTERVAL=none
 #export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
-#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 export DO_POST=false
 
 export IC_OFFSET=30

--- a/workflow/exp/rt_ursa/exp.rrfsv2x_ens
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x_ens
@@ -33,8 +33,8 @@ for i in {0..23};    do arr[$i]="01"; done # 3hr fcst
 #for i in {0..23..6}; do arr[$i]="03"; done # 3hr fcst every 6hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 #export HISTORY_INTERVAL=none
-#export MPASSIT_GROUP_TOTAL_NUM=2
-#export UPP_GROUP_TOTAL_NUM=2
+#export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
+#export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; if set, POST_GROUP_TOT_NUM will be ignored
 export DO_POST=false
 
 export IC_OFFSET=30

--- a/workflow/rocoto_funcs/base.py
+++ b/workflow/rocoto_funcs/base.py
@@ -190,7 +190,7 @@ def wflow_log(xmlFile, log_fpath):
 def wflow_cycledefs(xmlFile, dcCycledef):
     text = ""
     for key, value in dcCycledef.items():
-        if isinstance(value, dict):  #  a dictionary value containing "valid_hours" or "exclude_hours"
+        if isinstance(value, dict):  # a dictionary value containing "valid_hours" or "exclude_hours"
             if "valid_hours" in value:
                 valid_hours = value["valid_hours"]
                 mycycledef = value["cycledef"]

--- a/workflow/rocoto_funcs/base.py
+++ b/workflow/rocoto_funcs/base.py
@@ -190,7 +190,17 @@ def wflow_log(xmlFile, log_fpath):
 def wflow_cycledefs(xmlFile, dcCycledef):
     text = ""
     for key, value in dcCycledef.items():
-        text = text + f'\n  <cycledef group="{key}">{value}</cycledef>'
+        if isinstance(value, dict):  #  a dictionary value containing "valid_hours" or "exclude_hours"
+            if "valid_hours" in value:
+                valid_hours = value["valid_hours"]
+                mycycledef = value["cycledef"]
+                text = text + f'\n  <cycledef group="{key}" valid_hours="{valid_hours}">{mycycledef}</cycledef>'
+            else:
+                exclude_hours = value["exclude_hours"]
+                mycycledef = value["cycledef"]
+                text = text + f'\n  <cycledef group="{key}" exclude_hours="{exclude_hours}">{mycycledef}</cycledef>'
+        else:
+            text = text + f'\n  <cycledef group="{key}">{value}</cycledef>'
     xmlFile.write(f'{text}\n')
 
 # objTask

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -9,14 +9,22 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
     meta_id = 'mpassit'
     cycledefs = dcGrpInfo['cycledef']
     group_hours = dcGrpInfo["hours"]
+    parts = group_hours.split('-')
+    if len(parts) == 1:
+        end_hr = int(parts[0])
+        str_hours = parts[0]
+    else:
+        step = 1
+        if len(parts) == 3:
+            step = int(parts[2])
+        bgn_hr = int(parts[0])
+        end_hr = int(parts[1])
+        str_hours = " ".join(str(i) for i in range(bgn_hr, end_hr + step, step))
     #
-    history_interval = os.getenv('HISTORY_INTERVAL', '1')
-    fcst_len_hrs_cycles = os.getenv('FCST_LEN_HRS_CYCLES', '03 03')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
-        'HISTORY_INTERVAL': f'{history_interval}',
-        'FCST_LEN_HRS_CYCLES': f'{fcst_len_hrs_cycles}',
-        'GROUP_HOURS': f'{group_hours}',
+        'GROUP_INDEX': f'{index:02d}',
+        'GROUP_HOURS': f'{str_hours}',
         'MPASSIT_NX': os.getenv('MPASSIT_NX', 'MPASSIT_NX_not_defined'),
         'MPASSIT_NY': os.getenv('MPASSIT_NY', 'MPASSIT_NY_not_defined'),
         'MPASSIT_DX': os.getenv('MPASSIT_DX', 'MPASSIT_DX_not_defined'),
@@ -62,12 +70,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         starttime = get_cascade_env(f"STARTTIME_{meta_id}".upper())
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
-    listHours = group_hours.split('-')
-    if len(listHours) > 1:
-        end_hours = listHours[1]
-    else:
-        end_hours = listHours[0]
-    extra_dep = f'  <datadep age="00:05:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_fcst_@H_&rrfs_ver;/&WGF;{memdir}</cyclestr><cyclestr offset="{end_hours}:00:00">/diag.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'
+    extra_dep = f'  <datadep age="00:05:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_fcst_@H_&rrfs_ver;/&WGF;{memdir}</cyclestr><cyclestr offset="{end_hr}:00:00">/diag.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'
     #
     if do_ensmean_post:
         extra_dep = f'  <metataskdep metatask="ensmean"/>'

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -7,20 +7,16 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 
 def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_post=False):
     meta_id = 'mpassit'
-    cycledefs = 'prod'
+    cycledefs = dcGrpInfo['cycledef']
+    group_hours = dcGrpInfo["hours"]
     #
-    mpassit_group_total_num = int(os.getenv('MPASSIT_GROUP_TOTAL_NUM', '1'))
     history_interval = os.getenv('HISTORY_INTERVAL', '1')
     fcst_len_hrs_cycles = os.getenv('FCST_LEN_HRS_CYCLES', '03 03')
-    group_indices = ''.join(f'{i:02d} ' for i in range(
-        1, int(mpassit_group_total_num) + 1, int(history_interval))).strip()
-
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'HISTORY_INTERVAL': f'{history_interval}',
         'FCST_LEN_HRS_CYCLES': f'{fcst_len_hrs_cycles}',
-        'GROUP_TOTAL_NUM': f'{mpassit_group_total_num}',
-        'GROUP_INDEX': f'#group_index#',
+        'GROUP_HOURS': f'{group_hours}',
         'MPASSIT_NX': os.getenv('MPASSIT_NX', 'MPASSIT_NX_not_defined'),
         'MPASSIT_NY': os.getenv('MPASSIT_NY', 'MPASSIT_NY_not_defined'),
         'MPASSIT_DX': os.getenv('MPASSIT_DX', 'MPASSIT_DX_not_defined'),
@@ -32,40 +28,29 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         dcTaskEnv['CHEM_GROUPS'] = os.getenv('CHEM_GROUPS', 'smoke')
 
     if not do_ensemble:
-        # metatask (nested or not)
-        meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="group_index">{group_indices}</var>
-'''
-        meta_end = f'</metatask>\n'
-        task_id = f'{meta_id}_g#group_index#'
-
-        ensindexstr = ""
+        metatask = False
+        task_id = f'{meta_id}_g{index:02d}'
+        meta_bgn = ""
+        meta_end = ""
         memdir = ""
     else:
-        # metatask (nested or not)
-        ens_size = int(os.getenv('ENS_SIZE', '2'))
         if not do_ensmean_post:
+            ens_size = int(os.getenv('ENS_SIZE', '2'))
+            metatask = True
             ens_indices = ''.join(f'{i:03d} ' for i in range(1, int(ens_size) + 1)).strip()
             meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="ens_index">{ens_indices}</var>
-<metatask name="{meta_id}_m#ens_index#">
-<var name="group_index">{group_indices}</var>'''
-            meta_end = f'</metatask>\n</metatask>\n'
-            task_id = f'{meta_id}_m#ens_index#_g#group_index#'
-            dcTaskEnv['ENS_INDEX'] = "#ens_index#"
-            ensindexstr = "_m#ens_index#"
-            memdir = "/mem#ens_index#"
-        else:
-            # metatask (nested or not)
-            meta_id = "mpassit_ensmean"
-            meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="group_index">{group_indices}</var>
-'''
+<metatask name="{meta_id}_g{index:02d}">
+<var name="ens_index">{ens_indices}</var>'''
             meta_end = f'</metatask>\n'
-            task_id = f'{meta_id}_g#group_index#'
+            task_id = f'{meta_id}_g{index:02d}_m#ens_index#'
+            dcTaskEnv['ENS_INDEX'] = "#ens_index#"
+            memdir = "/mem#ens_index#"
+        else:  # do_ensmean_post
+            metatask = False
+            meta_id = "mpassit_ensmean"
+            task_id = f'{meta_id}_g{index:02d}'
+            meta_bgn = ""
+            meta_end = ""
             memdir = "/ensmean"
 
     dcTaskEnv['MEMDIR'] = f'{memdir}'
@@ -77,17 +62,22 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         starttime = get_cascade_env(f"STARTTIME_{meta_id}".upper())
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
-    if do_ensmean_post:
-        taskdep = f'  <metataskdep metatask="ensmean"/>'
+    listHours = group_hours.split('-')
+    if len(listHours) > 1:
+        end_hours = listHours[1]
     else:
-        taskdep = f'  <taskdep task="fcst{ensindexstr}"/>'
+        end_hours = listHours[0]
+    extra_dep = f'  <datadep age="00:05:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_fcst_@H_&rrfs_ver;/&WGF;{memdir}</cyclestr><cyclestr offset="{end_hours}:00:00">/diag.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'
+    #
+    if do_ensmean_post:
+        extra_dep = f'  <metataskdep metatask="ensmean"/>'
 
     dependencies = f'''
   <dependency>
   <and>{timedep}
-  {taskdep}
+  {extra_dep}
   </and>
   </dependency>'''
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, True, meta_id, meta_bgn, meta_end, "MPASSIT")
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, metatask, meta_id, meta_bgn, meta_end, "MPASSIT")
 # end of mpassit --------------------------------------------------------

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -5,7 +5,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of mpassit --------------------------------------------------------
 
 
-def mpassit(xmlFile, expdir, do_ensemble=False, do_ensmean_post=False):
+def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_post=False):
     meta_id = 'mpassit'
     cycledefs = 'prod'
     #

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -23,6 +23,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
     #
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
+        'FCST_LEN_HRS_CYCLES': os.getenv('FCST_LEN_HRS_CYCLES', '03 03'),
         'GROUP_INDEX': f'{index:02d}',
         'GROUP_HOURS': f'{str_hours}',
         'MPASSIT_NX': os.getenv('MPASSIT_NX', 'MPASSIT_NX_not_defined'),
@@ -40,6 +41,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         task_id = f'{meta_id}_g{index:02d}'
         meta_bgn = ""
         meta_end = ""
+        ensindexstr = ""
         memdir = ""
     else:
         if not do_ensmean_post:
@@ -52,6 +54,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
             meta_end = f'</metatask>\n'
             task_id = f'{meta_id}_g{index:02d}_m#ens_index#'
             dcTaskEnv['ENS_INDEX'] = "#ens_index#"
+            ensindexstr = "_m#ens_index#"
             memdir = "/mem#ens_index#"
         else:  # do_ensmean_post
             metatask = False
@@ -60,6 +63,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
             meta_bgn = ""
             meta_end = ""
             memdir = "/ensmean"
+            ensindexstr = "_ensmean"
 
     dcTaskEnv['MEMDIR'] = f'{memdir}'
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
@@ -70,15 +74,18 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         starttime = get_cascade_env(f"STARTTIME_{meta_id}".upper())
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
-    extra_dep = f'  <datadep age="00:05:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_fcst_@H_&rrfs_ver;/&WGF;{memdir}</cyclestr><cyclestr offset="{end_hr}:00:00">/diag.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>'
+    extra_dep = f'''
+    <or>
+      <datadep age="00:05:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_fcst_@H_&rrfs_ver;/&WGF;{memdir}</cyclestr><cyclestr offset="{end_hr}:00:00">/diag.@Y-@m-@d_@H.@M.@S.nc</cyclestr></datadep>
+      <taskdep task="fcst{ensindexstr}"/>
+    </or>'''
     #
     if do_ensmean_post:
-        extra_dep = f'  <metataskdep metatask="ensmean"/>'
+        extra_dep = f'    <metataskdep metatask="ensmean"/>'
 
     dependencies = f'''
   <dependency>
-  <and>{timedep}
-  {extra_dep}
+  <and>{timedep}{extra_dep}
   </and>
   </dependency>'''
     #

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -114,7 +114,7 @@ def setup_xml(HOMErrfs, expdir):
             if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
                 for index, dcGrpInfo in enumerate(listPostGrpInfo):
                     mpassit(xmlFile, expdir, index, dcGrpInfo)
-                upp(xmlFile, expdir)
+                    upp(xmlFile, expdir, index, dcGrpInfo)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":
                 hofx(xmlFile, expdir)
 
@@ -154,12 +154,14 @@ def setup_xml(HOMErrfs, expdir):
             if os.getenv('DO_CYC', 'FALSE').upper() == "TRUE":
                 save_for_next(xmlFile, expdir, do_ensemble=True)
             if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
-                mpassit(xmlFile, expdir, do_ensemble=True)
-                upp(xmlFile, expdir, do_ensemble=True)
+                for index, dcGrpInfo in enumerate(listPostGrpInfo):
+                    mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True)
+                    upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True)
             if do_ensmean_post == "TRUE":
                 ensmean(xmlFile, expdir)
-                mpassit(xmlFile, expdir, do_ensemble=True, do_ensmean_post=True)
-                upp(xmlFile, expdir, do_ensemble=True, do_ensmean_post=True)
+                for index, dcGrpInfo in enumerate(listPostGrpInfo):
+                    mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True, do_ensmean_post=True)
+                    upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True, do_ensmean_post=True)
 
 # ---------------------------------------------------------------------------
         if os.getenv("DO_CLEAN", 'FALSE').upper() == "TRUE":  # write out the clean task if needed, usually for realtime runs

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -49,11 +49,7 @@ def setup_xml(HOMErrfs, expdir):
     dcCycledef = smart_cycledefs()
     # create post groups smartly and update dcCycleDef accordingly
     if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
-        dcPostGrpInfo = smart_post_groups(dcCycledef)
-        print(dcCycledef, '\n')
-        print(dcPostGrpInfo)
-        import sys
-        sys.exit()
+        listPostGrpInfo = smart_post_groups(dcCycledef)
 
     fPath = f"{expdir}/rrfs.xml"
     with open(fPath, 'w') as xmlFile:
@@ -116,7 +112,8 @@ def setup_xml(HOMErrfs, expdir):
                     save_for_next(xmlFile, expdir)
             #
             if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
-                mpassit(xmlFile, expdir)
+                for index, dcGrpInfo in enumerate(listPostGrpInfo):
+                    mpassit(xmlFile, expdir, index, dcGrpInfo)
                 upp(xmlFile, expdir)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":
                 hofx(xmlFile, expdir)

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -5,6 +5,7 @@ import stat
 from rocoto_funcs.base import header_begin, header_entities, header_end, \
     wflow_begin, wflow_log, wflow_cycledefs, wflow_end
 from rocoto_funcs.smart_cycledefs import smart_cycledefs
+from rocoto_funcs.smart_post_groups import smart_post_groups
 from rocoto_funcs.ungrib_ic import ungrib_ic
 from rocoto_funcs.ungrib_lbc import ungrib_lbc
 from rocoto_funcs.ic import ic
@@ -46,6 +47,13 @@ def setup_xml(HOMErrfs, expdir):
     #
     # create cycledefs smartly
     dcCycledef = smart_cycledefs()
+    # create post groups smartly and update dcCycleDef accordingly
+    if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
+        dcPostGrpInfo = smart_post_groups(dcCycledef)
+        print(dcCycledef, '\n')
+        print(dcPostGrpInfo)
+        import sys
+        sys.exit()
 
     fPath = f"{expdir}/rrfs.xml"
     with open(fPath, 'w') as xmlFile:

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -169,14 +169,16 @@ def setup_xml(HOMErrfs, expdir):
 
     fPath = f"{expdir}/run_rocoto.sh"
     extra = ""
-    if machine in ['orion', 'hercules']:
-        extra = "\nmodule load contrib"
+    if machine in ['orion']:
+        extra = "\nmodule use /work/noaa/zrtrr/gge/rocoto/modulefiles"
+    elif machine in ['hercules']:
+        extra = "\nmodule use /work/noaa/zrtrr/gge/hercules/rocoto/modulefiles"
     elif machine in ['gaeac6']:
-        extra = "\nmodule use /ncrc/proj/epic/rocoto/modulefiles"
+        extra = "\nmodule use /gpfs/f6/arfs-gsl/world-shared/gge/rocoto/modulefiles"
     elif machine in ['wcoss2']:
         extra = "\nmodule use /apps/ops/test/nco/modulefiles/core"
     elif machine in ['derecho']:
-        extra = "\nsource /etc/profile.d/z00_modules.sh\nmodule use /glade/work/epicufsrt/contrib/derecho/modulefiles"
+        extra = "\nsource /etc/profile.d/z00_modules.sh\nmodule use /glade/work/geguo/rocoto/modulefiles"
     with open(fPath, 'w') as rocotoFile:
         text = \
             f'''#!/usr/bin/env bash
@@ -184,7 +186,7 @@ def setup_xml(HOMErrfs, expdir):
 ## */5 * * * * {fPath}
 
 source /etc/profile{extra}
-module load rocoto
+module load rocoto/1.3.7g
 cd {expdir}
 rocotorun -w rrfs.xml -d rrfs.db
 '''

--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+import os
+import sys
+import math
+from datetime import datetime, timedelta
+
+
+def smart_post_groups(dcCycleDef):
+    # determine "cycles_by_fcst_length"
+    fcst_lengths = os.getenv('FCST_LEN_HRS_CYCLES', '')
+    fcst_lengths = list(map(int, fcst_lengths.split()))  # collapses spaces into one separator and ignore leading/trailing spaces
+    if len(fcst_lengths) != 24:
+        print(f'FATAL ERROR: wrong FCST_LEN_HRS_CYCLES="{FCST_LEN_HRS_CYCLES}"')
+        sys.exit()
+    max_fcst_length = max(fcst_lengths)
+    cycles_by_fcst_length = {}
+    for index, length in enumerate(fcst_lengths):
+        if length in cycles_by_fcst_length:
+            cycles_by_fcst_length[length].append(index)
+        else:
+            cycles_by_fcst_length[length] = [index]
+    cycles_by_fcst_length_sorted = dict(sorted(cycles_by_fcst_length.items()))
+    #
+    # construct groups based on the configuration in the exp file
+    groups = []
+    size = int(os.getenv('POST_GROUP_SIZE', '6'))
+    spec = os.getenv('POST_GROUP_SPEC', '')
+    if spec == "":  # automatic grouping by size if spec is non defined
+        ngroups = math.floor(max_fcst_length / size + 0.5)
+        for i in range(ngroups):
+            bgn_hr = i * size +1
+            if i == 0:
+                bgn_hr = 0
+            end_hr = (i + 1) * size
+            if (i + 1) == ngroups:
+                end_hr = max_fcst_length
+            groups.append(f'{bgn_hr}-{end_hr}')
+        print(f"MPASSIT/UPP automatic grouping: {groups}")
+
+    else:  # POST_GROUP_SPEC is defined, has the highest priority, ignore POST_GROUP_SIZE
+        groups = spec.split()
+        print(f"MPASSIT/UPP customized grouping: {groups}")
+
+    # determine how many post cycledefs are needed
+    num_post_cycledefs = 0  # the number of post cycledefs needed
+    dcCycles_by_postgrp = {}  # cycles in each cycledef
+    dc_iPost_cycledefs = {}  # for each entry in the "groups" list, its corresponding index in dcCycles_by_postgrp
+    igroup = -1
+    for key,value in cycles_by_fcst_length_sorted.items():
+        for index,item in enumerate(groups):
+            bgn_hr, end_hr = item.split('-')
+            if key >= int(bgn_hr) and key <= int(end_hr):
+                if index != igroup:  # need a new cycledef_post
+                    num_post_cycledefs = num_post_cycledefs +1
+                    dcCycles_by_postgrp[num_post_cycledefs-1] = value
+                    dc_iPost_cycledefs[index] = num_post_cycledefs - 1
+                    # check and define the entreis before index
+                    for j in range(index):
+                        if j not in dc_iPost_cycledefs:
+                            dc_iPost_cycledefs[j] = num_post_cycledefs - 1
+                    igroup = index
+                else:  # combine cycles if using the same cycldef_post
+                    dcCycles_by_postgrp[num_post_cycledefs-1].extend(value)
+                break
+    # ~~~~~~~~~~~~~
+    # update dcCycledef accordingly
+    for i in range(num_post_cycledefs-1):
+        for j in range(i+1, num_post_cycledefs):
+            dcCycles_by_postgrp[i].extend(dcCycles_by_postgrp[j])
+    #
+    cycledef_prod = dcCycleDef['prod']
+    for index, valid_hours in dcCycles_by_postgrp.items():
+        if index == 0:  # the first post group uses the prod cycledef
+            continue
+
+        valid_hours = sorted(valid_hours)
+        valid_str = " ".join(f"{i}" for i in valid_hours)
+        all_hours = [i for i in range(24)]
+        exclude_str = ''
+        if len(valid_hours) > 12:  # use exclude_hours for this situation
+            exclude_hours = [x for x in all_hours if x not in set(valid_hours)]
+            exclude_str = " ".join(f"{i:02d}" for i in exclude_hours)
+
+        if exclude_str == '':
+            dcCycleDef[f'post{index:02d}'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_prod}'}
+        else:  # use exclude_hours if exclude_str non-empty
+            dcCycleDef[f'post{index:02d}'] = {'exclude_hours': f'{exclude_str}', "cycledef": f'{cycledef_prod}'}
+    # ~~~~~~~~~~~~~
+    # construct dcGroupInfo: hours and cycledef for each post group
+    dcGroupInfo = []
+    for index,item in enumerate(groups):
+        ipos = dc_iPost_cycledefs[index]
+        if ipos == 0:
+            mycycledef = "prod"
+        else:
+            mycycledef = f'post{ipos:02d}'
+        dcTmp = {"hours": f'{item}', "cycledef": f'{mycycledef}'}
+        dcGroupInfo.append(dcTmp)
+    # ~~~~~~~~~~~~~
+    # debug:
+    # print(cycles_by_fcst_length_sorted, "\n")
+    # print(dc_iPost_cycledefs, "\n")
+    # print(dcCycleDef, "\n")
+    # print(dcGroupInfo)
+    # ~~~~~~~~~~~~~
+    return dcGroupInfo

--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import math
-from datetime import datetime, timedelta
 
 
 def smart_post_groups(dcCycleDef):
@@ -10,7 +9,7 @@ def smart_post_groups(dcCycleDef):
     fcst_lengths = os.getenv('FCST_LEN_HRS_CYCLES', '')
     fcst_lengths = list(map(int, fcst_lengths.split()))  # collapses spaces into one separator and ignore leading/trailing spaces
     if len(fcst_lengths) != 24:
-        print(f'FATAL ERROR: wrong FCST_LEN_HRS_CYCLES="{FCST_LEN_HRS_CYCLES}"')
+        print(f'FATAL ERROR: wrong FCST_LEN_HRS_CYCLES="{fcst_lengths}"')
         sys.exit()
     max_fcst_length = max(fcst_lengths)
     cycles_by_fcst_length = {}
@@ -28,7 +27,7 @@ def smart_post_groups(dcCycleDef):
     if spec == "":  # automatic grouping by size if spec is non defined
         ngroups = math.floor(max_fcst_length / size + 0.5)
         for i in range(ngroups):
-            bgn_hr = i * size +1
+            bgn_hr = i * size + 1
             if i == 0:
                 bgn_hr = 0
             end_hr = (i + 1) * size
@@ -46,13 +45,13 @@ def smart_post_groups(dcCycleDef):
     dcCycles_by_postgrp = {}  # cycles in each cycledef
     dc_iPost_cycledefs = {}  # for each entry in the "groups" list, its corresponding index in dcCycles_by_postgrp
     igroup = -1
-    for key,value in cycles_by_fcst_length_sorted.items():
-        for index,item in enumerate(groups):
+    for key, value in cycles_by_fcst_length_sorted.items():
+        for index, item in enumerate(groups):
             bgn_hr, end_hr = item.split('-')
             if key >= int(bgn_hr) and key <= int(end_hr):
                 if index != igroup:  # need a new cycledef_post
-                    num_post_cycledefs = num_post_cycledefs +1
-                    dcCycles_by_postgrp[num_post_cycledefs-1] = value
+                    num_post_cycledefs = num_post_cycledefs + 1
+                    dcCycles_by_postgrp[num_post_cycledefs - 1] = value
                     dc_iPost_cycledefs[index] = num_post_cycledefs - 1
                     # check and define the entreis before index
                     for j in range(index):
@@ -60,12 +59,12 @@ def smart_post_groups(dcCycleDef):
                             dc_iPost_cycledefs[j] = num_post_cycledefs - 1
                     igroup = index
                 else:  # combine cycles if using the same cycldef_post
-                    dcCycles_by_postgrp[num_post_cycledefs-1].extend(value)
+                    dcCycles_by_postgrp[num_post_cycledefs - 1].extend(value)
                 break
     # ~~~~~~~~~~~~~
     # update dcCycledef accordingly
-    for i in range(num_post_cycledefs-1):
-        for j in range(i+1, num_post_cycledefs):
+    for i in range(num_post_cycledefs - 1):
+        for j in range(i + 1, num_post_cycledefs):
             dcCycles_by_postgrp[i].extend(dcCycles_by_postgrp[j])
     #
     cycledef_prod = dcCycleDef['prod']
@@ -88,7 +87,7 @@ def smart_post_groups(dcCycleDef):
     # ~~~~~~~~~~~~~
     # construct listGroupInfo: hours and cycledef for each post group
     listGroupInfo = []
-    for index,item in enumerate(groups):
+    for index, item in enumerate(groups):
         ipos = dc_iPost_cycledefs[index]
         if ipos == 0:
             mycycledef = "prod"

--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -22,12 +22,11 @@ def smart_post_groups(dcCycleDef):
     #
     # construct groups based on the configuration in the exp file
     groups = []
-    size = int(os.getenv('POST_GROUP_SIZE', '6'))
+    ngroups = int(os.getenv('POST_GROUP_TOT_NUM', '1'))
     spec = os.getenv('POST_GROUP_SPEC', '')
-    if spec == "":  # automatic grouping by size if spec is non defined
+    if spec == "":  # automatic grouping if POST_GROUP_SPEC is non defined
         history_interval = int(os.getenv('HISTORY_INTERVAL', '1'))
-        step = size * history_interval
-        ngroups = math.floor(max_fcst_length / step + 0.5)
+        step = math.floor(max_fcst_length / ngroups + 0.5)
         for i in range(ngroups):
             bgn_hr = i * step + 1
             if i == 0:
@@ -39,7 +38,7 @@ def smart_post_groups(dcCycleDef):
         str_groups = " ".join(f"{s}" for s in groups)
         print(f'MPASSIT/UPP automatic grouping: "{str_groups}"\n')
 
-    else:  # POST_GROUP_SPEC is defined, has the highest priority, ignore POST_GROUP_SIZE
+    else:  # POST_GROUP_SPEC is defined, has the highest priority, ignore POST_GROUP_TOT_NUM
         groups = spec.split()
         str_groups = " ".join(f"{s}" for s in groups)
         print(f'MPASSIT/UPP customized grouping: "{str_groups}"\n')

--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -25,15 +25,17 @@ def smart_post_groups(dcCycleDef):
     size = int(os.getenv('POST_GROUP_SIZE', '6'))
     spec = os.getenv('POST_GROUP_SPEC', '')
     if spec == "":  # automatic grouping by size if spec is non defined
-        ngroups = math.floor(max_fcst_length / size + 0.5)
+        history_interval = int(os.getenv('HISTORY_INTERVAL', '1'))
+        step = size * history_interval
+        ngroups = math.floor(max_fcst_length / step + 0.5)
         for i in range(ngroups):
-            bgn_hr = i * size + 1
+            bgn_hr = i * step + 1
             if i == 0:
                 bgn_hr = 0
-            end_hr = (i + 1) * size
+            end_hr = (i + 1) * step
             if (i + 1) == ngroups:
                 end_hr = max_fcst_length
-            groups.append(f'{bgn_hr}-{end_hr}')
+            groups.append(f'{bgn_hr}-{end_hr}-{history_interval}')
         print(f"MPASSIT/UPP automatic grouping: {groups}\n")
 
     else:  # POST_GROUP_SPEC is defined, has the highest priority, ignore POST_GROUP_SIZE
@@ -47,7 +49,12 @@ def smart_post_groups(dcCycleDef):
     igroup = -1
     for key, value in cycles_by_fcst_length_sorted.items():
         for index, item in enumerate(groups):
-            bgn_hr, end_hr = item.split('-')
+            parts = item.split("-")
+            if len(parts) == 1:
+                bgn_hr = end_hr = parts[0]
+            else:
+                bgn_hr = parts[0]
+                end_hr = parts[1]
             if key >= int(bgn_hr) and key <= int(end_hr):
                 if index != igroup:  # need a new cycledef_post
                     num_post_cycledefs = num_post_cycledefs + 1
@@ -101,5 +108,6 @@ def smart_post_groups(dcCycleDef):
     # print(dc_iPost_cycledefs, "\n")
     # print(dcCycleDef, "\n")
     # print(listGroupInfo)
+    # sys.exit()
     # ~~~~~~~~~~~~~
     return listGroupInfo

--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -36,11 +36,13 @@ def smart_post_groups(dcCycleDef):
             if (i + 1) == ngroups:
                 end_hr = max_fcst_length
             groups.append(f'{bgn_hr}-{end_hr}-{history_interval}')
-        print(f"MPASSIT/UPP automatic grouping: {groups}\n")
+        str_groups = " ".join(f"{s}" for s in groups)
+        print(f'MPASSIT/UPP automatic grouping: "{str_groups}"\n')
 
     else:  # POST_GROUP_SPEC is defined, has the highest priority, ignore POST_GROUP_SIZE
         groups = spec.split()
-        print(f"MPASSIT/UPP customized grouping: {groups}\n")
+        str_groups = " ".join(f"{s}" for s in groups)
+        print(f'MPASSIT/UPP customized grouping: "{str_groups}"\n')
 
     # determine how many post cycledefs are needed
     num_post_cycledefs = 0  # the number of post cycledefs needed

--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -35,11 +35,11 @@ def smart_post_groups(dcCycleDef):
             if (i + 1) == ngroups:
                 end_hr = max_fcst_length
             groups.append(f'{bgn_hr}-{end_hr}')
-        print(f"MPASSIT/UPP automatic grouping: {groups}")
+        print(f"MPASSIT/UPP automatic grouping: {groups}\n")
 
     else:  # POST_GROUP_SPEC is defined, has the highest priority, ignore POST_GROUP_SIZE
         groups = spec.split()
-        print(f"MPASSIT/UPP customized grouping: {groups}")
+        print(f"MPASSIT/UPP customized grouping: {groups}\n")
 
     # determine how many post cycledefs are needed
     num_post_cycledefs = 0  # the number of post cycledefs needed
@@ -86,8 +86,8 @@ def smart_post_groups(dcCycleDef):
         else:  # use exclude_hours if exclude_str non-empty
             dcCycleDef[f'post{index:02d}'] = {'exclude_hours': f'{exclude_str}', "cycledef": f'{cycledef_prod}'}
     # ~~~~~~~~~~~~~
-    # construct dcGroupInfo: hours and cycledef for each post group
-    dcGroupInfo = []
+    # construct listGroupInfo: hours and cycledef for each post group
+    listGroupInfo = []
     for index,item in enumerate(groups):
         ipos = dc_iPost_cycledefs[index]
         if ipos == 0:
@@ -95,12 +95,12 @@ def smart_post_groups(dcCycleDef):
         else:
             mycycledef = f'post{ipos:02d}'
         dcTmp = {"hours": f'{item}', "cycledef": f'{mycycledef}'}
-        dcGroupInfo.append(dcTmp)
+        listGroupInfo.append(dcTmp)
     # ~~~~~~~~~~~~~
     # debug:
     # print(cycles_by_fcst_length_sorted, "\n")
     # print(dc_iPost_cycledefs, "\n")
     # print(dcCycleDef, "\n")
-    # print(dcGroupInfo)
+    # print(listGroupInfo)
     # ~~~~~~~~~~~~~
-    return dcGroupInfo
+    return listGroupInfo

--- a/workflow/rocoto_funcs/upp.py
+++ b/workflow/rocoto_funcs/upp.py
@@ -9,14 +9,21 @@ def upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_post=Fa
     meta_id = 'upp'
     cycledefs = dcGrpInfo['cycledef']
     group_hours = dcGrpInfo["hours"]
+    parts = group_hours.split('-')
+    if len(parts) == 1:
+        str_hours = parts[0]
+    else:
+        step = 1
+        if len(parts) == 3:
+            step = int(parts[2])
+        bgn_hr = int(parts[0])
+        end_hr = int(parts[1])
+        str_hours = " ".join(str(i) for i in range(bgn_hr, end_hr + step, step))
     #
-    history_interval = os.getenv('HISTORY_INTERVAL', '1')
-    fcst_len_hrs_cycles = os.getenv('FCST_LEN_HRS_CYCLES', '03 03')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
-        'HISTORY_INTERVAL': f'{history_interval}',
-        'FCST_LEN_HRS_CYCLES': f'{fcst_len_hrs_cycles}',
-        'GROUP_HOURS': f'{group_hours}',
+        'GROUP_INDEX': f'{index:02d}',
+        'GROUP_HOURS': f'{str_hours}',
         'UPP_DOMAIN': os.getenv('UPP_DOMAIN', ''),
     }
 

--- a/workflow/rocoto_funcs/upp.py
+++ b/workflow/rocoto_funcs/upp.py
@@ -22,6 +22,7 @@ def upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_post=Fa
     #
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
+        'FCST_LEN_HRS_CYCLES': os.getenv('FCST_LEN_HRS_CYCLES', '03 03'),
         'GROUP_INDEX': f'{index:02d}',
         'GROUP_HOURS': f'{str_hours}',
         'UPP_DOMAIN': os.getenv('UPP_DOMAIN', ''),

--- a/workflow/rocoto_funcs/upp.py
+++ b/workflow/rocoto_funcs/upp.py
@@ -5,65 +5,51 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of upp --------------------------------------------------------
 
 
-def upp(xmlFile, expdir, do_ensemble=False, do_ensmean_post=False):
+def upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_post=False):
     meta_id = 'upp'
-    cycledefs = 'prod'
+    cycledefs = dcGrpInfo['cycledef']
+    group_hours = dcGrpInfo["hours"]
     #
-    fcst_len_hrs_cycles = os.getenv('FCST_LEN_HRS_CYCLES', '03 03')
-    upp_group_total_num = int(os.getenv('UPP_GROUP_TOTAL_NUM', '1'))
     history_interval = os.getenv('HISTORY_INTERVAL', '1')
-    group_indices = ''.join(f'{i:02d} ' for i in range(1, int(upp_group_total_num) + 1, int(history_interval))).strip()
-
+    fcst_len_hrs_cycles = os.getenv('FCST_LEN_HRS_CYCLES', '03 03')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'HISTORY_INTERVAL': f'{history_interval}',
         'FCST_LEN_HRS_CYCLES': f'{fcst_len_hrs_cycles}',
-        'GROUP_TOTAL_NUM': f'{upp_group_total_num}',
-        'GROUP_INDEX': f'#group_index#',
+        'GROUP_HOURS': f'{group_hours}',
         'UPP_DOMAIN': os.getenv('UPP_DOMAIN', ''),
     }
 
     if not do_ensemble:
-        # metatask (nested or not)
-        meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="group_index">{group_indices}</var>
-'''
-        meta_end = f'</metatask>\n'
-        task_id = f'{meta_id}_g#group_index#'
+        metatask = False
+        task_id = f'{meta_id}_g{index:02d}'
+        meta_bgn = ""
+        meta_end = ""
         ensindexstr = ""
         memdir = ""
     else:
         if not do_ensmean_post:
-            # metatask (nested or not)
             ens_size = int(os.getenv('ENS_SIZE', '2'))
+            metatask = True
             ens_indices = ''.join(f'{i:03d} ' for i in range(1, int(ens_size) + 1)).strip()
             meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="ens_index">{ens_indices}</var>
-<metatask name="{meta_id}_m#ens_index#">
-<var name="group_index">{group_indices}</var>
-'''
-            meta_end = f'</metatask>\n</metatask>\n'
-            task_id = f'{meta_id}_m#ens_index#_g#group_index#'
+<metatask name="{meta_id}_g{index:02d}">
+<var name="ens_index">{ens_indices}</var>'''
+            meta_end = f'</metatask>\n'
+            task_id = f'{meta_id}_g{index:02d}_m#ens_index#'
             dcTaskEnv['ENS_INDEX'] = "#ens_index#"
             ensindexstr = "_m#ens_index#"
             memdir = "/mem#ens_index#"
-
-        else:
-            # metatask (nested or not)
+        else:  # do_ensmean_post
+            metatask = False
             meta_id = "upp_ensmean"
-            meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="group_index">{group_indices}</var>
-'''
-            meta_end = f'</metatask>\n'
-            task_id = f'{meta_id}_g#group_index#'
+            task_id = f'{meta_id}_g{index:02d}'
+            meta_bgn = ""
+            meta_end = ""
             memdir = "/ensmean"
             ensindexstr = "_ensmean"
 
     dcTaskEnv['MEMDIR'] = f'{memdir}'
-
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
@@ -75,9 +61,9 @@ def upp(xmlFile, expdir, do_ensemble=False, do_ensmean_post=False):
     dependencies = f'''
   <dependency>
   <and>{timedep}
-    <metataskdep metatask="mpassit{ensindexstr}"/>
+    <taskdep task="mpassit_g{index:02d}{ensindexstr}"/>
   </and>
   </dependency>'''
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, True, meta_id, meta_bgn, meta_end, "UPP")
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, metatask, meta_id, meta_bgn, meta_end, "UPP")
 # end of upp --------------------------------------------------------

--- a/workflow/tools/load_rocoto.sh
+++ b/workflow/tools/load_rocoto.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# shellcheck disable=all
+# Check if the script is sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Usage: source ${0}"
+  exit 1
+fi
+
+### scripts continues here...
+ushdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck disable=SC1091
+source "${ushdir}/detect_machine.sh"
+
+case ${MACHINE} in
+  wcoss2)
+    BASEDIR=/to/be/added
+    ;;
+  hera)
+    BASEDIR=/scratch4/BMC/zrtrr/gge/rocoto_hera/modulefiles
+    ;;
+  ursa)
+    BASEDIR=/scratch4/BMC/zrtrr/gge/rocoto/modulefiles
+    ;;
+  derecho)
+    BASEDIR=/glade/work/geguo/rocoto/modulefiles
+    ;;
+  jet)
+    BASEDIR=/lfs5/BMC/nrtrr/gge/rocoto/modulefiles
+    ;;
+  orion)
+    BASEDIR=/work/noaa/zrtrr/gge/rocoto/modulefiles
+    ;;
+  hercules)
+    BASEDIR=/work/noaa/zrtrr/gge/hercules/rocoto/modulefiles
+    ;;
+  gaeac?)
+    if [[ -d /gpfs/f5 ]]; then
+      BASEDIR=/to/be/added
+    elif [[ -d /gpfs/f6 ]]; then
+      BASEDIR=/gpfs/f6/arfs-gsl/world-shared/gge/rocoto/modulefiles
+    else
+      echo "unsupported gaea cluster: ${MACHINE}"
+    fi
+    ;;
+  *)
+    BASEDIR=/unknown/location
+    echo "platform not supported: ${MACHINE}"
+    ;;
+esac
+module use ${BASEDIR}
+module load rocoto/1.3.7g

--- a/workflow/tools/qrocoto/rboot
+++ b/workflow/tools/qrocoto/rboot
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 get_parm_type(){

--- a/workflow/tools/qrocoto/rcheck
+++ b/workflow/tools/qrocoto/rcheck
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 get_parm_type(){

--- a/workflow/tools/qrocoto/rcomplete
+++ b/workflow/tools/qrocoto/rcomplete
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 get_parm_type(){

--- a/workflow/tools/qrocoto/rinfo
+++ b/workflow/tools/qrocoto/rinfo
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 

--- a/workflow/tools/qrocoto/rrun
+++ b/workflow/tools/qrocoto/rrun
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 # rrun [xmlfile] [offset] [cycles] [tasks] [-m=metatasks]

--- a/workflow/tools/qrocoto/rstat
+++ b/workflow/tools/qrocoto/rstat
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 # rstat [xmlfile] [offset] [cycles] [tasks] [-m=metatasks]

--- a/workflow/tools/qrocoto/rstat.all
+++ b/workflow/tools/qrocoto/rstat.all
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 # rstat [xmlfile] [offset] [cycles] [tasks] [-m=metatasks]

--- a/workflow/tools/qrocoto/rtasks
+++ b/workflow/tools/qrocoto/rtasks
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 # rtasks [xmlfile] task [num]

--- a/workflow/tools/qrocoto/rwind
+++ b/workflow/tools/qrocoto/rwind
@@ -4,7 +4,7 @@
 # by Guoqing Ge, 2019/04
 #
 fulltasks="yes"
-module load rocoto
+module load rocoto/1.3.7g
 #known major xml files for different systems
 xmlarray=("RTMA_3D.xml" "HRRR_primary.xml" "RAP_primary.xml" "FV3LAM_wflow.xml" "rrfs.xml")
 get_parm_type(){


### PR DESCRIPTION
## Short description
This PR allows to smartly run different number of mpassit/upp groups at different cycles to accommodate different forecast lengths.

## Details
In regional RRFS experiments, we may want to run `36h` forecasts at `00/12z`, `18h` forecasts at `03/06/09/15/18/21z` and `3h` forecasts at other cycles. 

At `00/12z`, we may use 6 mpassit/upp groups to speed up the post-processing, with each group handling `6` forecast files.  
At `03/06/09/15/18/21z`, it may still be okay to use 6 groups, but with each processing `3`forecast files.  
However, at `01/02/04/05/07/08/10/11/13/14/16/17/19/20/22/23z`, we only have 3 forecast files to process. One group will be enough and the other 5 groups will do nothing. So we don't need 6 groups at all for these cycles.

The current mpassit/upp implementation in rrfs-workflow does not support flexible groups at different cycles. As a result, we must launch 6 (group or meta) tasks during the above 16 short cycles. In this situation, 5 of the 6 tasks simply wait for and then consume resources to do nothing. This really limits the efficient use of our precious computing resources.

The situation gets even more pronounced when we run 168-240 hours (7-10 days) global forecasts (for the Water in the West Atmospheric River Project) at 00/12z while only 6~9 hours forecasts at other cycles.

Further, we would like mpassit/upp tasks to run concurrently along with the long forecasts. For example, completing a 7-day global forecast takes roughly 10 hours. Post-processing could begin as soon as the first few forecast outputs become available, rather than waiting 10 hours for the entire forecast to finish.

All these require us to allow smart/flexible mpassit/upp groups at different cycles based on the need of those cycles.    

We have considered several candidate approaches:

1. Create separate MPASSIT/UPP tasks for different cycles.  
For example, `upp_short`, `upp_medium`, `upp_medium2`, `upp_long`.  
However, this would introduce inconsistent task names across cycles, making the workflow harder to maintain, monitor, and document.

2. Modify the `Rocoto` workflow manager to support a variable number of metatasks by cycle.  
The logic most closely related to metatask expansion can be found in the Rocoto source code at this link:
https://github.com/christopherwharrop/rocoto/blob/79304a1c47a18ee68c45a52799935c481d0d6d56/lib/workflowmgr/workflowdoc.rb#L1037-L1062  
After reviewing the relevant code, it appears that adding this capability would be nontrivial. It would require fundamental changes to Rocoto’s overall design rather than a localized enhancement. Investing significant development effort on this front is likely not justified.

#### 3. Explicitly expand metatasks into concrete tasks in `rrfs.xml` in the workflow generation stage
Inspection of the Rocoto workflow database shows that all metatasks defined in the XML are ultimately expanded into individual tasks internally. All Rocoto operations act on these expanded tasks. For example, `rocotostat` displays concrete task names (`upp_g01`, `upp_g02`, …) rather than the template form (`upp` or `upp_g#group_index#`).

This observation motivates a simpler solution: explicitly generate and write out the expanded tasks directly in `rrfs.xml`.
Doing so provides the required flexibility to vary the number of MPASSIT/UPP groups by cycle. Since we already use Python to generate `rrfs.xml`, implementing this change is preferred.

## Implementation

`POST_GROUP_TOT_NUM` specifies the number of mpassit/upp groups.  
The final group absorbs leftovers, the first group contains the extra f000h file.

`setup_rocoto.py` automatically generates mpassit/upp groups (eg. `upp_g00, upp_g01, upp_g02, ...`) and provide the associated cycledefs (eg. `prod, post01, ...`) (NOTE: the number of required cycledefs is smaller than the number of mpassit/upp groups).

To support smart groups, a relevant PR has been created to the Rocoto repository: https://github.com/christopherwharrop/rocoto/pull/123, which adds the `exclude_hours` and `valid_hours` attributes to `cycledef` and hence we can has a more readable/maintainable cycledefs as follows:
```
  <cycledef group="ic">  202405060000 202405070000 12:00:00</cycledef>
  <cycledef group="lbc"> 202405060000 202405070000 12:00:00</cycledef>
  <cycledef group="prod">202405060000 202405070000 01:00:00</cycledef>
  <cycledef group="post01" valid_hours="0 3 6 9 12 15 18 21">202405060000 202405070000 01:00:00</cycledef>
  <cycledef group="post02" valid_hours="0 12">202405060000 202405070000 01:00:00</cycledef>
  <cycledef group="post03" valid_hours="0">202405060000 202405070000 01:00:00</cycledef>
```
This Rocoto update can also significantly simplifies the definition of spinup cycles. We will work on that part in a future PR.
While waiting for the HPC admins to install this new Rocoto officially, a working `rocoto/1.3.7g` version has been deployed on all supported platforms and integrated into rrfs-workflow.


## More
This PR also allows the customization of mpassit/upp groups through the `POST_GROUP_SPEC` variable.  
`POST_GROUP_SPEC` has the highest priority. If it is defined, the `POST_GROUP_TOT_NUM` setting is ignored.  
Example `POST_GROUP_SPEC` settings:
```
POST_GROUP_SPEC="0-10 11-20 21-30 31-36"
POST_GROUP_SPEC="0-1 2-12 13-24 25-36"
POST_GROUP_SPEC="0-18-3  19-36-3  37-54-3  55-72-3  73-90-3  91-108-3  109-126-3  127-144-3  145-168-3"
```
`POST_GROUP_SPEC` takes a spaces-separated string and each segment follows one of the following formats: `start`, `start-stop` or `start-stop-step`.