### PR TITLE
[rrfs-nco] Remove reference to dev ecflow server in exrrfs_blend_ics.sh

### DIFF
--- a/ecf/defs/rrfs_nco_para.def
+++ b/ecf/defs/rrfs_nco_para.def
@@ -19,6 +19,59 @@ extern /prod_clone/primary/00/gfs/v16.3/enkfgdas/post
 extern /prod_clone/primary/06/gfs/v16.3/enkfgdas/post
 extern /prod_clone/primary/12/gfs/v16.3/enkfgdas/post
 extern /prod_clone/primary/18/gfs/v16.3/enkfgdas/post
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/dump/jobsproc_rrfs_dump_erly
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/prep/jobsproc_rrfs_prep_erly
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/02z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/02z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/03z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/03z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/09z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/09z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/10z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/10z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/11z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/06/obsproc/v1.2/rrfs/11z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump_erly
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep_erly
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/13z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/13z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/14z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/14z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/18z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/18z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/19z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/19z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/21z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/21z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/22z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/22z/prep/jobsproc_rrfs_prep
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/23z/dump/jobsproc_rrfs_dump
+extern /prod_clone/primary/18/obsproc/v1.2/rrfs/23z/prep/jobsproc_rrfs_prep
+
 
 suite para
   family primary
@@ -320,7 +373,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/00/obsproc/v1.2/rrfs/00z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/00z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/23z/enkf/forecast==complete or /para/primary/18/rrfs/v1.0/22z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/23z/enkf/forecast==complete or /para/primary/18/rrfs/v1.0/22z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -2566,7 +2619,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /para/primary/00/obsproc/v1.2/rrfs/00z/dump/jobsproc_rrfs_dump_erly==complete and /para/primary/00/obsproc/v1.2/rrfs/00z/prep/jobsproc_rrfs_prep_erly==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/dump/jobsproc_rrfs_dump_erly==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/00z/prep/jobsproc_rrfs_prep_erly==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -6749,7 +6802,7 @@ suite para
                   trigger :TIME >= 0135 and :TIME < 0435
               endfamily
               family prep
-                trigger :TIME >= 0145 and :TIME < 0745 and /prod_clone/primary/12/nsst/v1.2/jnsst==complete and /para/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump==complete
+                trigger :TIME >= 0145 and :TIME < 0745 and /prod_clone/primary/12/nsst/v1.2/jnsst==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump==complete
                 task jrrfs_det_prep_cyc
                   trigger /para/primary/00/rrfs/v1.0/00z/det/forecast/jrrfs_det_save_restart_long_1==complete or /para/primary/18/rrfs/v1.0/23z/det/forecast/jrrfs_det_save_restart_f2==complete or /para/primary/18/rrfs/v1.0/22z/det/forecast/jrrfs_det_save_restart_f3==complete
               endfamily
@@ -6757,7 +6810,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/01z/prep/jobsproc_rrfs_prep==complete and (/para/primary/00/rrfs/v1.0/00z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/18/rrfs/v1.0/22z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/prep/jobsproc_rrfs_prep==complete and (/para/primary/00/rrfs/v1.0/00z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/18/rrfs/v1.0/22z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -7245,7 +7298,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /para/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/01z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/01z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -7714,7 +7767,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/00/obsproc/v1.2/rrfs/02z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/02z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/00/rrfs/v1.0/01z/enkf/forecast==complete or /para/primary/00/rrfs/v1.0/00z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/02z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/02z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/00/rrfs/v1.0/01z/enkf/forecast==complete or /para/primary/00/rrfs/v1.0/00z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -8202,7 +8255,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /para/primary/00/obsproc/v1.2/rrfs/02z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/02z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/02z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/02z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -9030,7 +9083,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/00/obsproc/v1.2/rrfs/03z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/03z/prep/jobsproc_rrfs_prep==complete and (/para/primary/00/rrfs/v1.0/02z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/00z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/03z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/03z/prep/jobsproc_rrfs_prep==complete and (/para/primary/00/rrfs/v1.0/02z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/00z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -9537,7 +9590,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /para/primary/00/obsproc/v1.2/rrfs/03z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/03z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/03z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/03z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -10020,7 +10073,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/00/obsproc/v1.2/rrfs/04z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/00/rrfs/v1.0/03z/enkf/forecast==complete or /para/primary/00/rrfs/v1.0/02z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/00/rrfs/v1.0/03z/enkf/forecast==complete or /para/primary/00/rrfs/v1.0/02z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -10028,7 +10081,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep==complete and /para/primary/00/rrfs/v1.0/03z/enkf/forecast==complete
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep==complete and /para/primary/00/rrfs/v1.0/03z/enkf/forecast==complete
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -10527,7 +10580,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /para/primary/00/obsproc/v1.2/rrfs/04z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/04z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -11352,7 +11405,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/00/obsproc/v1.2/rrfs/05z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/02z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/02z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -11360,7 +11413,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep==complete and /para/primary/00/rrfs/v1.0/04z/enkf/forecast==complete
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep==complete and /para/primary/00/rrfs/v1.0/04z/enkf/forecast==complete
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -11859,7 +11912,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /para/primary/00/obsproc/v1.2/rrfs/05z/dump/jobsproc_rrfs_dump==complete and /para/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/00/obsproc/v1.2/rrfs/05z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -12301,62 +12354,6 @@ suite para
           endfamily
         endfamily
       endfamily # rrfs
-      family obsproc
-        family v1.2
-          family rrfs
-            family 00z
-              family prep
-                task jobsproc_rrfs_prep_erly
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump_erly
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 00z
-            family 01z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 01z
-            family 02z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 02z
-            family 03z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 03z
-            family 04z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 04z
-            family 05z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 05z
-          endfamily # rrfs
-        endfamily # v1.2
-      endfamily # obsproc
     endfamily # 00
     family 06 
       family rrfs
@@ -12671,7 +12668,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/06/obsproc/v1.2/rrfs/06z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep==complete and (/para/primary/00/rrfs/v1.0/05z/enkf/forecast==complete or /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep==complete and (/para/primary/00/rrfs/v1.0/05z/enkf/forecast==complete or /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -12679,7 +12676,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep==complete and /para/primary/00/rrfs/v1.0/05z/enkf/forecast==complete
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep==complete and /para/primary/00/rrfs/v1.0/05z/enkf/forecast==complete
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -14936,7 +14933,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /para/primary/06/obsproc/v1.2/rrfs/06z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/18/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/06z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -19145,7 +19142,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/06/obsproc/v1.2/rrfs/07z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -19153,7 +19150,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/00/rrfs/v1.0/04z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -19560,151 +19557,181 @@ suite para
                 task jrrfs_enkf_blend_ics_mem001
                   trigger ./jrrfs_enkf_make_ics_mem001==complete
                   edit MEMBER_NAME '001'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem002
                   edit MEMBER_NAME '002'
                 task jrrfs_enkf_blend_ics_mem002
                   trigger ./jrrfs_enkf_make_ics_mem002==complete
                   edit MEMBER_NAME '002'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem003
                   edit MEMBER_NAME '003'
                 task jrrfs_enkf_blend_ics_mem003
                   trigger ./jrrfs_enkf_make_ics_mem003==complete
                   edit MEMBER_NAME '003'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem004
                   edit MEMBER_NAME '004'
                 task jrrfs_enkf_blend_ics_mem004
                   trigger ./jrrfs_enkf_make_ics_mem004==complete
                   edit MEMBER_NAME '004'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem005
                   edit MEMBER_NAME '005'
                 task jrrfs_enkf_blend_ics_mem005
                   trigger ./jrrfs_enkf_make_ics_mem005==complete
                   edit MEMBER_NAME '005'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem006
                   edit MEMBER_NAME '006'
                 task jrrfs_enkf_blend_ics_mem006
                   trigger ./jrrfs_enkf_make_ics_mem006==complete
                   edit MEMBER_NAME '006'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem007
                   edit MEMBER_NAME '007'
                 task jrrfs_enkf_blend_ics_mem007
                   trigger ./jrrfs_enkf_make_ics_mem007==complete
                   edit MEMBER_NAME '007'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem008
                   edit MEMBER_NAME '008'
                 task jrrfs_enkf_blend_ics_mem008
                   trigger ./jrrfs_enkf_make_ics_mem008==complete
                   edit MEMBER_NAME '008'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem009
                   edit MEMBER_NAME '009'
                 task jrrfs_enkf_blend_ics_mem009
                   trigger ./jrrfs_enkf_make_ics_mem009==complete
                   edit MEMBER_NAME '009'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem010
                   edit MEMBER_NAME '010'
                 task jrrfs_enkf_blend_ics_mem010
                   trigger ./jrrfs_enkf_make_ics_mem010==complete
                   edit MEMBER_NAME '010'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem011
                   edit MEMBER_NAME '011'
                 task jrrfs_enkf_blend_ics_mem011
                   trigger ./jrrfs_enkf_make_ics_mem011==complete
                   edit MEMBER_NAME '011'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem012
                   edit MEMBER_NAME '012'
                 task jrrfs_enkf_blend_ics_mem012
                   trigger ./jrrfs_enkf_make_ics_mem012==complete
                   edit MEMBER_NAME '012'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem013
                   edit MEMBER_NAME '013'
                 task jrrfs_enkf_blend_ics_mem013
                   trigger ./jrrfs_enkf_make_ics_mem013==complete
                   edit MEMBER_NAME '013'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem014
                   edit MEMBER_NAME '014'
                 task jrrfs_enkf_blend_ics_mem014
                   trigger ./jrrfs_enkf_make_ics_mem014==complete
                   edit MEMBER_NAME '014'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem015
                   edit MEMBER_NAME '015'
                 task jrrfs_enkf_blend_ics_mem015
                   trigger ./jrrfs_enkf_make_ics_mem015==complete
                   edit MEMBER_NAME '015'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem016
                   edit MEMBER_NAME '016'
                 task jrrfs_enkf_blend_ics_mem016
                   trigger ./jrrfs_enkf_make_ics_mem016==complete
                   edit MEMBER_NAME '016'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem017
                   edit MEMBER_NAME '017'
                 task jrrfs_enkf_blend_ics_mem017
                   trigger ./jrrfs_enkf_make_ics_mem017==complete
                   edit MEMBER_NAME '017'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem018
                   edit MEMBER_NAME '018'
                 task jrrfs_enkf_blend_ics_mem018
                   trigger ./jrrfs_enkf_make_ics_mem018==complete
                   edit MEMBER_NAME '018'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem019
                   edit MEMBER_NAME '019'
                 task jrrfs_enkf_blend_ics_mem019
                   trigger ./jrrfs_enkf_make_ics_mem019==complete
                   edit MEMBER_NAME '019'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem020
                   edit MEMBER_NAME '020'
                 task jrrfs_enkf_blend_ics_mem020
                   trigger ./jrrfs_enkf_make_ics_mem020==complete
                   edit MEMBER_NAME '020'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem021
                   edit MEMBER_NAME '021'
                 task jrrfs_enkf_blend_ics_mem021
                   trigger ./jrrfs_enkf_make_ics_mem021==complete
                   edit MEMBER_NAME '021'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem022
                   edit MEMBER_NAME '022'
                 task jrrfs_enkf_blend_ics_mem022
                   trigger ./jrrfs_enkf_make_ics_mem022==complete
                   edit MEMBER_NAME '022'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem023
                   edit MEMBER_NAME '023'
                 task jrrfs_enkf_blend_ics_mem023
                   trigger ./jrrfs_enkf_make_ics_mem023==complete
                   edit MEMBER_NAME '023'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem024
                   edit MEMBER_NAME '024'
                 task jrrfs_enkf_blend_ics_mem024
                   trigger ./jrrfs_enkf_make_ics_mem024==complete
                   edit MEMBER_NAME '024'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem025
                   edit MEMBER_NAME '025'
                 task jrrfs_enkf_blend_ics_mem025
                   trigger ./jrrfs_enkf_make_ics_mem025==complete
                   edit MEMBER_NAME '025'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem026
                   edit MEMBER_NAME '026'
                 task jrrfs_enkf_blend_ics_mem026
                   trigger ./jrrfs_enkf_make_ics_mem026==complete
                   edit MEMBER_NAME '026'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem027
                   edit MEMBER_NAME '027'
                 task jrrfs_enkf_blend_ics_mem027
                   trigger ./jrrfs_enkf_make_ics_mem027==complete
                   edit MEMBER_NAME '027'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem028
                   edit MEMBER_NAME '028'
                 task jrrfs_enkf_blend_ics_mem028
                   trigger ./jrrfs_enkf_make_ics_mem028==complete
                   edit MEMBER_NAME '028'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem029
                   edit MEMBER_NAME '029'
                 task jrrfs_enkf_blend_ics_mem029
                   trigger ./jrrfs_enkf_make_ics_mem029==complete
                   edit MEMBER_NAME '029'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem030
                   edit MEMBER_NAME '030'
                 task jrrfs_enkf_blend_ics_mem030
                   trigger ./jrrfs_enkf_make_ics_mem030==complete
                   edit MEMBER_NAME '030'
+                  event 1 skip_ensinit
               endfamily
               family prep
                 trigger ./ics==complete
@@ -19928,7 +19955,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean_spinup
                   trigger ./jrrfs_enkf_recenter_spinup==complete
                 task jrrfs_enkf_observer_gsi_ensmean_spinup
-                  trigger ./jrrfs_enkf_calc_ensmean_spinup==complete and /para/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep==complete and /para/primary/06/obsproc/v1.2/rrfs/07z/dump/jobsproc_rrfs_dump == complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post == complete
+                  trigger ./jrrfs_enkf_calc_ensmean_spinup==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/prep/jobsproc_rrfs_prep==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/07z/dump/jobsproc_rrfs_dump == complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post == complete
                 task jrrfs_enkf_observer_gsi_spinup_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean_spinup==complete
                   edit MEMBER_NAME '001'
@@ -20151,8 +20178,10 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem001
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem001==complete
                   edit MEMBER_NAME '001'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem001
                   trigger ./jrrfs_enkf_forecast_ensinit_mem001==complete
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                   edit MEMBER_NAME '001'
                 task jrrfs_enkf_forecast_spinup_mem001
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem001==complete
@@ -20164,9 +20193,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem002
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem002==complete
                   edit MEMBER_NAME '002'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem002
                   trigger ./jrrfs_enkf_forecast_ensinit_mem002==complete
                   edit MEMBER_NAME '002'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem002
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem002==complete
                   edit MEMBER_NAME '002'
@@ -20177,9 +20208,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem003
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem003==complete
                   edit MEMBER_NAME '003'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem003
                   trigger ./jrrfs_enkf_forecast_ensinit_mem003==complete
                   edit MEMBER_NAME '003'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem003
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem003==complete
                   edit MEMBER_NAME '003'
@@ -20190,9 +20223,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem004
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem004==complete
                   edit MEMBER_NAME '004'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem004
                   trigger ./jrrfs_enkf_forecast_ensinit_mem004==complete
                   edit MEMBER_NAME '004'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem004
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem004==complete
                   edit MEMBER_NAME '004'
@@ -20203,9 +20238,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem005
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem005==complete
                   edit MEMBER_NAME '005'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem005
                   trigger ./jrrfs_enkf_forecast_ensinit_mem005==complete
                   edit MEMBER_NAME '005'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem005
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem005==complete
                   edit MEMBER_NAME '005'
@@ -20216,9 +20253,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem006
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem006==complete
                   edit MEMBER_NAME '006'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem006
                   trigger ./jrrfs_enkf_forecast_ensinit_mem006==complete
                   edit MEMBER_NAME '006'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem006
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem006==complete
                   edit MEMBER_NAME '006'
@@ -20229,9 +20268,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem007
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem007==complete
                   edit MEMBER_NAME '007'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem007
                   trigger ./jrrfs_enkf_forecast_ensinit_mem007==complete
                   edit MEMBER_NAME '007'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem007
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem007==complete
                   edit MEMBER_NAME '007'
@@ -20242,9 +20283,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem008
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem008==complete
                   edit MEMBER_NAME '008'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem008
                   trigger ./jrrfs_enkf_forecast_ensinit_mem008==complete
                   edit MEMBER_NAME '008'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem008
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem008==complete
                   edit MEMBER_NAME '008'
@@ -20255,9 +20298,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem009
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem009==complete
                   edit MEMBER_NAME '009'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem009
                   trigger ./jrrfs_enkf_forecast_ensinit_mem009==complete
                   edit MEMBER_NAME '009'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem009
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem009==complete
                   edit MEMBER_NAME '009'
@@ -20268,9 +20313,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem010
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem010==complete
                   edit MEMBER_NAME '010'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem010
                   trigger ./jrrfs_enkf_forecast_ensinit_mem010==complete
                   edit MEMBER_NAME '010'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem010
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem010==complete
                   edit MEMBER_NAME '010'
@@ -20281,9 +20328,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem011
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem011==complete
                   edit MEMBER_NAME '011'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem011
                   trigger ./jrrfs_enkf_forecast_ensinit_mem011==complete
                   edit MEMBER_NAME '011'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem011
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem011==complete
                   edit MEMBER_NAME '011'
@@ -20294,9 +20343,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem012
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem012==complete
                   edit MEMBER_NAME '012'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem012
                   trigger ./jrrfs_enkf_forecast_ensinit_mem012==complete
                   edit MEMBER_NAME '012'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem012
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem012==complete
                   edit MEMBER_NAME '012'
@@ -20307,9 +20358,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem013
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem013==complete
                   edit MEMBER_NAME '013'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem013
                   trigger ./jrrfs_enkf_forecast_ensinit_mem013==complete
                   edit MEMBER_NAME '013'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem013
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem013==complete
                   edit MEMBER_NAME '013'
@@ -20320,9 +20373,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem014
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem014==complete
                   edit MEMBER_NAME '014'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem014
                   trigger ./jrrfs_enkf_forecast_ensinit_mem014==complete
                   edit MEMBER_NAME '014'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem014
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem014==complete
                   edit MEMBER_NAME '014'
@@ -20333,9 +20388,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem015
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem015==complete
                   edit MEMBER_NAME '015'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem015
                   trigger ./jrrfs_enkf_forecast_ensinit_mem015==complete
                   edit MEMBER_NAME '015'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem015
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem015==complete
                   edit MEMBER_NAME '015'
@@ -20346,9 +20403,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem016
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem016==complete
                   edit MEMBER_NAME '016'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem016
                   trigger ./jrrfs_enkf_forecast_ensinit_mem016==complete
                   edit MEMBER_NAME '016'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem016
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem016==complete
                   edit MEMBER_NAME '016'
@@ -20359,9 +20418,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem017
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem017==complete
                   edit MEMBER_NAME '017'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem017
                   trigger ./jrrfs_enkf_forecast_ensinit_mem017==complete
                   edit MEMBER_NAME '017'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem017
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem017==complete
                   edit MEMBER_NAME '017'
@@ -20372,9 +20433,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem018
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem018==complete
                   edit MEMBER_NAME '018'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem018
                   trigger ./jrrfs_enkf_forecast_ensinit_mem018==complete
                   edit MEMBER_NAME '018'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem018
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem018==complete
                   edit MEMBER_NAME '018'
@@ -20385,9 +20448,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem019
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem019==complete
                   edit MEMBER_NAME '019'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem019
                   trigger ./jrrfs_enkf_forecast_ensinit_mem019==complete
                   edit MEMBER_NAME '019'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem019
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem019==complete
                   edit MEMBER_NAME '019'
@@ -20398,9 +20463,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem020
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem020==complete
                   edit MEMBER_NAME '020'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem020
                   trigger ./jrrfs_enkf_forecast_ensinit_mem020==complete
                   edit MEMBER_NAME '020'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem020
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem020==complete
                   edit MEMBER_NAME '020'
@@ -20411,9 +20478,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem021
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem021==complete
                   edit MEMBER_NAME '021'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem021
                   trigger ./jrrfs_enkf_forecast_ensinit_mem021==complete
                   edit MEMBER_NAME '021'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem021
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem021==complete
                   edit MEMBER_NAME '021'
@@ -20424,9 +20493,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem022
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem022==complete
                   edit MEMBER_NAME '022'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem022
                   trigger ./jrrfs_enkf_forecast_ensinit_mem022==complete
                   edit MEMBER_NAME '022'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem022
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem022==complete
                   edit MEMBER_NAME '022'
@@ -20437,9 +20508,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem023
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem023==complete
                   edit MEMBER_NAME '023'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem023
                   trigger ./jrrfs_enkf_forecast_ensinit_mem023==complete
                   edit MEMBER_NAME '023'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem023
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem023==complete
                   edit MEMBER_NAME '023'
@@ -20450,9 +20523,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem024
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem024==complete
                   edit MEMBER_NAME '024'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem024
                   trigger ./jrrfs_enkf_forecast_ensinit_mem024==complete
                   edit MEMBER_NAME '024'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem024
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem024==complete
                   edit MEMBER_NAME '024'
@@ -20463,9 +20538,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem025
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem025==complete
                   edit MEMBER_NAME '025'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem025
                   trigger ./jrrfs_enkf_forecast_ensinit_mem025==complete
                   edit MEMBER_NAME '025'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem025
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem025==complete
                   edit MEMBER_NAME '025'
@@ -20476,9 +20553,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem026
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem026==complete
                   edit MEMBER_NAME '026'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem026
                   trigger ./jrrfs_enkf_forecast_ensinit_mem026==complete
                   edit MEMBER_NAME '026'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem026
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem026==complete
                   edit MEMBER_NAME '026'
@@ -20489,9 +20568,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem027
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem027==complete
                   edit MEMBER_NAME '027'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem027
                   trigger ./jrrfs_enkf_forecast_ensinit_mem027==complete
                   edit MEMBER_NAME '027'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem027
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem027==complete
                   edit MEMBER_NAME '027'
@@ -20502,9 +20583,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem028
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem028==complete
                   edit MEMBER_NAME '028'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem028
                   trigger ./jrrfs_enkf_forecast_ensinit_mem028==complete
                   edit MEMBER_NAME '028'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem028
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem028==complete
                   edit MEMBER_NAME '028'
@@ -20515,9 +20598,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem029
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem029==complete
                   edit MEMBER_NAME '029'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem029
                   trigger ./jrrfs_enkf_forecast_ensinit_mem029==complete
                   edit MEMBER_NAME '029'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem029
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem029==complete
                   edit MEMBER_NAME '029'
@@ -20528,9 +20613,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem030
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem030==complete
                   edit MEMBER_NAME '030'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem030
                   trigger ./jrrfs_enkf_forecast_ensinit_mem030==complete
                   edit MEMBER_NAME '030'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem030
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem030==complete
                   edit MEMBER_NAME '030'
@@ -20590,7 +20677,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/06/obsproc/v1.2/rrfs/08z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/07z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/07z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -20598,7 +20685,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/07z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/07z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete)
                   edit CYCLE_TYPE 'spinup' 
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -21097,7 +21184,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /para/primary/06/obsproc/v1.2/rrfs/08z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/08z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -21906,7 +21993,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/06/obsproc/v1.2/rrfs/09z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/09z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/08z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/09z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/09z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/08z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/06/rrfs/v1.0/06z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -22394,7 +22481,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /para/primary/06/obsproc/v1.2/rrfs/09z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/09z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/09z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/09z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -22860,7 +22947,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/06/obsproc/v1.2/rrfs/10z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/10z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/09z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/08z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/10z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/10z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/09z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/08z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -23348,7 +23435,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /para/primary/06/obsproc/v1.2/rrfs/10z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/10z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/10z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/10z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -24157,7 +24244,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/06/obsproc/v1.2/rrfs/11z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/11z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/10z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/06/rrfs/v1.0/08z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/11z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/11z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/10z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/06/rrfs/v1.0/08z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -24645,7 +24732,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /para/primary/06/obsproc/v1.2/rrfs/11z/dump/jobsproc_rrfs_dump==complete and /para/primary/06/obsproc/v1.2/rrfs/11z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/11z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/06/obsproc/v1.2/rrfs/11z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -25084,60 +25171,6 @@ suite para
           endfamily
         endfamily
       endfamily
-      family obsproc
-        family v1.2
-          family rrfs
-            family 06z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 06z
-            family 07z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 07z
-            family 08z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 08z
-            family 09z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 09z
-            family 10z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 10z
-            family 11z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 11z
-          endfamily # rrfs
-        endfamily # v1.2
-      endfamily # obsproc
     endfamily # 06 
     family 12
       family rrfs
@@ -25437,7 +25470,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/11z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/10z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/06/rrfs/v1.0/11z/enkf/forecast==complete or /para/primary/06/rrfs/v1.0/10z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -27683,7 +27716,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump_erly==complete and /para/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep_erly==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump_erly==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep_erly==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -31873,7 +31906,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/13z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/13z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/12z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/06/rrfs/v1.0/10z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/13z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/13z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/12z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/06/rrfs/v1.0/10z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -32361,7 +32394,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/13z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/13z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/13z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/13z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -32830,7 +32863,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/14z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/14z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/13z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/14z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/14z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/13z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -33318,7 +33351,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/14z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/14z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/14z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/14z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -34146,7 +34179,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/15z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/12z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/12z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -34154,7 +34187,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or/para/primary/12/rrfs/v1.0/12z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or/para/primary/12/rrfs/v1.0/12z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -34653,7 +34686,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/15z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/15z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -35134,7 +35167,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/16z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/15z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/15z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -35142,7 +35175,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/15z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/15z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -35641,7 +35674,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/16z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/16z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -36465,7 +36498,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -36473,7 +36506,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or/para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or/para/primary/12/rrfs/v1.0/14z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -36972,7 +37005,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/06/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -37411,62 +37444,6 @@ suite para
           endfamily
         endfamily
       endfamily
-      family obsproc
-        family v1.2
-          family rrfs
-            family 12z
-              family prep
-                task jobsproc_rrfs_prep_erly
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump_erly
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 12z
-            family 13z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 13z
-            family 14z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 14z
-            family 15z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 15z
-            family 16z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 16z
-            family 17z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 17z
-          endfamily # rrfs
-        endfamily # v1.2
-      endfamily # obsproc
     endfamily # 12
     family 18 
       family rrfs
@@ -37781,7 +37758,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/18/obsproc/v1.2/rrfs/18z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/18z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/17z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/18z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/18z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/17z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -37789,7 +37766,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/18/obsproc/v1.2/rrfs/18z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/17z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/18z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/12/rrfs/v1.0/17z/enkf/forecast==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -40046,7 +40023,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /para/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/00/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/12z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -44252,7 +44229,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump==complete and /para/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/12/obsproc/v1.2/rrfs/17z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -44260,7 +44237,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/18/obsproc/v1.2/rrfs/19z/prep/jobsproc_rrfs_prep==complete and  ( /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/19z/prep/jobsproc_rrfs_prep==complete and  ( /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/12/rrfs/v1.0/16z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -44667,151 +44644,181 @@ suite para
                 task jrrfs_enkf_blend_ics_mem001
                   trigger ./jrrfs_enkf_make_ics_mem001==complete
                   edit MEMBER_NAME '001'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem002
                   edit MEMBER_NAME '002'
                 task jrrfs_enkf_blend_ics_mem002
                   trigger ./jrrfs_enkf_make_ics_mem002==complete
                   edit MEMBER_NAME '002'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem003
                   edit MEMBER_NAME '003'
                 task jrrfs_enkf_blend_ics_mem003
                   trigger ./jrrfs_enkf_make_ics_mem003==complete
                   edit MEMBER_NAME '003'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem004
                   edit MEMBER_NAME '004'
                 task jrrfs_enkf_blend_ics_mem004
                   trigger ./jrrfs_enkf_make_ics_mem004==complete
                   edit MEMBER_NAME '004'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem005
                   edit MEMBER_NAME '005'
                 task jrrfs_enkf_blend_ics_mem005
                   trigger ./jrrfs_enkf_make_ics_mem005==complete
                   edit MEMBER_NAME '005'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem006
                   edit MEMBER_NAME '006'
                 task jrrfs_enkf_blend_ics_mem006
                   trigger ./jrrfs_enkf_make_ics_mem006==complete
                   edit MEMBER_NAME '006'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem007
                   edit MEMBER_NAME '007'
                 task jrrfs_enkf_blend_ics_mem007
                   trigger ./jrrfs_enkf_make_ics_mem007==complete
                   edit MEMBER_NAME '007'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem008
                   edit MEMBER_NAME '008'
                 task jrrfs_enkf_blend_ics_mem008
                   trigger ./jrrfs_enkf_make_ics_mem008==complete
                   edit MEMBER_NAME '008'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem009
                   edit MEMBER_NAME '009'
                 task jrrfs_enkf_blend_ics_mem009
                   trigger ./jrrfs_enkf_make_ics_mem009==complete
                   edit MEMBER_NAME '009'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem010
                   edit MEMBER_NAME '010'
                 task jrrfs_enkf_blend_ics_mem010
                   trigger ./jrrfs_enkf_make_ics_mem010==complete
                   edit MEMBER_NAME '010'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem011
                   edit MEMBER_NAME '011'
                 task jrrfs_enkf_blend_ics_mem011
                   trigger ./jrrfs_enkf_make_ics_mem011==complete
                   edit MEMBER_NAME '011'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem012
                   edit MEMBER_NAME '012'
                 task jrrfs_enkf_blend_ics_mem012
                   trigger ./jrrfs_enkf_make_ics_mem012==complete
                   edit MEMBER_NAME '012'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem013
                   edit MEMBER_NAME '013'
                 task jrrfs_enkf_blend_ics_mem013
                   trigger ./jrrfs_enkf_make_ics_mem013==complete
                   edit MEMBER_NAME '013'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem014
                   edit MEMBER_NAME '014'
                 task jrrfs_enkf_blend_ics_mem014
                   trigger ./jrrfs_enkf_make_ics_mem014==complete
                   edit MEMBER_NAME '014'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem015
                   edit MEMBER_NAME '015'
                 task jrrfs_enkf_blend_ics_mem015
                   trigger ./jrrfs_enkf_make_ics_mem015==complete
                   edit MEMBER_NAME '015'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem016
                   edit MEMBER_NAME '016'
                 task jrrfs_enkf_blend_ics_mem016
                   trigger ./jrrfs_enkf_make_ics_mem016==complete
                   edit MEMBER_NAME '016'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem017
                   edit MEMBER_NAME '017'
                 task jrrfs_enkf_blend_ics_mem017
                   trigger ./jrrfs_enkf_make_ics_mem017==complete
                   edit MEMBER_NAME '017'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem018
                   edit MEMBER_NAME '018'
                 task jrrfs_enkf_blend_ics_mem018
                   trigger ./jrrfs_enkf_make_ics_mem018==complete
                   edit MEMBER_NAME '018'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem019
                   edit MEMBER_NAME '019'
                 task jrrfs_enkf_blend_ics_mem019
                   trigger ./jrrfs_enkf_make_ics_mem019==complete
                   edit MEMBER_NAME '019'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem020
                   edit MEMBER_NAME '020'
                 task jrrfs_enkf_blend_ics_mem020
                   trigger ./jrrfs_enkf_make_ics_mem020==complete
                   edit MEMBER_NAME '020'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem021
                   edit MEMBER_NAME '021'
                 task jrrfs_enkf_blend_ics_mem021
                   trigger ./jrrfs_enkf_make_ics_mem021==complete
                   edit MEMBER_NAME '021'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem022
                   edit MEMBER_NAME '022'
                 task jrrfs_enkf_blend_ics_mem022
                   trigger ./jrrfs_enkf_make_ics_mem022==complete
                   edit MEMBER_NAME '022'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem023
                   edit MEMBER_NAME '023'
                 task jrrfs_enkf_blend_ics_mem023
                   trigger ./jrrfs_enkf_make_ics_mem023==complete
                   edit MEMBER_NAME '023'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem024
                   edit MEMBER_NAME '024'
                 task jrrfs_enkf_blend_ics_mem024
                   trigger ./jrrfs_enkf_make_ics_mem024==complete
                   edit MEMBER_NAME '024'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem025
                   edit MEMBER_NAME '025'
                 task jrrfs_enkf_blend_ics_mem025
                   trigger ./jrrfs_enkf_make_ics_mem025==complete
                   edit MEMBER_NAME '025'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem026
                   edit MEMBER_NAME '026'
                 task jrrfs_enkf_blend_ics_mem026
                   trigger ./jrrfs_enkf_make_ics_mem026==complete
                   edit MEMBER_NAME '026'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem027
                   edit MEMBER_NAME '027'
                 task jrrfs_enkf_blend_ics_mem027
                   trigger ./jrrfs_enkf_make_ics_mem027==complete
                   edit MEMBER_NAME '027'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem028
                   edit MEMBER_NAME '028'
                 task jrrfs_enkf_blend_ics_mem028
                   trigger ./jrrfs_enkf_make_ics_mem028==complete
                   edit MEMBER_NAME '028'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem029
                   edit MEMBER_NAME '029'
                 task jrrfs_enkf_blend_ics_mem029
                   trigger ./jrrfs_enkf_make_ics_mem029==complete
                   edit MEMBER_NAME '029'
+                  event 1 skip_ensinit
                 task jrrfs_enkf_make_ics_mem030
                   edit MEMBER_NAME '030'
                 task jrrfs_enkf_blend_ics_mem030
                   trigger ./jrrfs_enkf_make_ics_mem030==complete
                   edit MEMBER_NAME '030'
+                  event 1 skip_ensinit
               endfamily
               family prep
                 trigger ./ics==complete
@@ -45035,7 +45042,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean_spinup
                   trigger ./jrrfs_enkf_recenter_spinup==complete
                 task jrrfs_enkf_observer_gsi_ensmean_spinup
-                  trigger ./jrrfs_enkf_calc_ensmean_spinup==complete and /para/primary/18/obsproc/v1.2/rrfs/19z/prep/jobsproc_rrfs_prep==complete and /para/primary/18/obsproc/v1.2/rrfs/19z/dump/jobsproc_rrfs_dump == complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post == complete
+                  trigger ./jrrfs_enkf_calc_ensmean_spinup==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/19z/prep/jobsproc_rrfs_prep==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/19z/dump/jobsproc_rrfs_dump == complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post == complete
                 task jrrfs_enkf_observer_gsi_spinup_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean_spinup==complete
                   edit MEMBER_NAME '001'
@@ -45258,8 +45265,10 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem001
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem001==complete
                   edit MEMBER_NAME '001'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem001
                   trigger ./jrrfs_enkf_forecast_ensinit_mem001==complete
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                   edit MEMBER_NAME '001'
                 task jrrfs_enkf_forecast_spinup_mem001
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem001==complete
@@ -45271,9 +45280,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem002
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem002==complete
                   edit MEMBER_NAME '002'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem002
                   trigger ./jrrfs_enkf_forecast_ensinit_mem002==complete
                   edit MEMBER_NAME '002'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem002
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem002==complete
                   edit MEMBER_NAME '002'
@@ -45284,9 +45295,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem003
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem003==complete
                   edit MEMBER_NAME '003'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem003
                   trigger ./jrrfs_enkf_forecast_ensinit_mem003==complete
                   edit MEMBER_NAME '003'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem003
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem003==complete
                   edit MEMBER_NAME '003'
@@ -45297,9 +45310,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem004
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem004==complete
                   edit MEMBER_NAME '004'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem004
                   trigger ./jrrfs_enkf_forecast_ensinit_mem004==complete
                   edit MEMBER_NAME '004'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem004
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem004==complete
                   edit MEMBER_NAME '004'
@@ -45310,9 +45325,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem005
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem005==complete
                   edit MEMBER_NAME '005'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem005
                   trigger ./jrrfs_enkf_forecast_ensinit_mem005==complete
                   edit MEMBER_NAME '005'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem005
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem005==complete
                   edit MEMBER_NAME '005'
@@ -45323,9 +45340,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem006
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem006==complete
                   edit MEMBER_NAME '006'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem006
                   trigger ./jrrfs_enkf_forecast_ensinit_mem006==complete
                   edit MEMBER_NAME '006'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem006
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem006==complete
                   edit MEMBER_NAME '006'
@@ -45336,9 +45355,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem007
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem007==complete
                   edit MEMBER_NAME '007'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem007
                   trigger ./jrrfs_enkf_forecast_ensinit_mem007==complete
                   edit MEMBER_NAME '007'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem007
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem007==complete
                   edit MEMBER_NAME '007'
@@ -45349,9 +45370,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem008
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem008==complete
                   edit MEMBER_NAME '008'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem008
                   trigger ./jrrfs_enkf_forecast_ensinit_mem008==complete
                   edit MEMBER_NAME '008'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem008
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem008==complete
                   edit MEMBER_NAME '008'
@@ -45362,9 +45385,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem009
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem009==complete
                   edit MEMBER_NAME '009'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem009
                   trigger ./jrrfs_enkf_forecast_ensinit_mem009==complete
                   edit MEMBER_NAME '009'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem009
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem009==complete
                   edit MEMBER_NAME '009'
@@ -45375,9 +45400,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem010
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem010==complete
                   edit MEMBER_NAME '010'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem010
                   trigger ./jrrfs_enkf_forecast_ensinit_mem010==complete
                   edit MEMBER_NAME '010'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem010
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem010==complete
                   edit MEMBER_NAME '010'
@@ -45388,9 +45415,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem011
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem011==complete
                   edit MEMBER_NAME '011'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem011
                   trigger ./jrrfs_enkf_forecast_ensinit_mem011==complete
                   edit MEMBER_NAME '011'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem011
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem011==complete
                   edit MEMBER_NAME '011'
@@ -45401,9 +45430,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem012
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem012==complete
                   edit MEMBER_NAME '012'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem012
                   trigger ./jrrfs_enkf_forecast_ensinit_mem012==complete
                   edit MEMBER_NAME '012'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem012
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem012==complete
                   edit MEMBER_NAME '012'
@@ -45414,9 +45445,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem013
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem013==complete
                   edit MEMBER_NAME '013'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem013
                   trigger ./jrrfs_enkf_forecast_ensinit_mem013==complete
                   edit MEMBER_NAME '013'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem013
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem013==complete
                   edit MEMBER_NAME '013'
@@ -45427,9 +45460,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem014
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem014==complete
                   edit MEMBER_NAME '014'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem014
                   trigger ./jrrfs_enkf_forecast_ensinit_mem014==complete
                   edit MEMBER_NAME '014'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem014
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem014==complete
                   edit MEMBER_NAME '014'
@@ -45440,9 +45475,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem015
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem015==complete
                   edit MEMBER_NAME '015'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem015
                   trigger ./jrrfs_enkf_forecast_ensinit_mem015==complete
                   edit MEMBER_NAME '015'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem015
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem015==complete
                   edit MEMBER_NAME '015'
@@ -45453,9 +45490,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem016
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem016==complete
                   edit MEMBER_NAME '016'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem016
                   trigger ./jrrfs_enkf_forecast_ensinit_mem016==complete
                   edit MEMBER_NAME '016'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem016
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem016==complete
                   edit MEMBER_NAME '016'
@@ -45466,9 +45505,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem017
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem017==complete
                   edit MEMBER_NAME '017'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem017
                   trigger ./jrrfs_enkf_forecast_ensinit_mem017==complete
                   edit MEMBER_NAME '017'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem017
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem017==complete
                   edit MEMBER_NAME '017'
@@ -45479,9 +45520,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem018
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem018==complete
                   edit MEMBER_NAME '018'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem018
                   trigger ./jrrfs_enkf_forecast_ensinit_mem018==complete
                   edit MEMBER_NAME '018'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem018
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem018==complete
                   edit MEMBER_NAME '018'
@@ -45492,9 +45535,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem019
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem019==complete
                   edit MEMBER_NAME '019'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem019
                   trigger ./jrrfs_enkf_forecast_ensinit_mem019==complete
                   edit MEMBER_NAME '019'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem019
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem019==complete
                   edit MEMBER_NAME '019'
@@ -45505,9 +45550,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem020
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem020==complete
                   edit MEMBER_NAME '020'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem020
                   trigger ./jrrfs_enkf_forecast_ensinit_mem020==complete
                   edit MEMBER_NAME '020'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem020
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem020==complete
                   edit MEMBER_NAME '020'
@@ -45518,9 +45565,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem021
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem021==complete
                   edit MEMBER_NAME '021'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem021
                   trigger ./jrrfs_enkf_forecast_ensinit_mem021==complete
                   edit MEMBER_NAME '021'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem021
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem021==complete
                   edit MEMBER_NAME '021'
@@ -45531,9 +45580,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem022
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem022==complete
                   edit MEMBER_NAME '022'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem022
                   trigger ./jrrfs_enkf_forecast_ensinit_mem022==complete
                   edit MEMBER_NAME '022'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem022
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem022==complete
                   edit MEMBER_NAME '022'
@@ -45544,9 +45595,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem023
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem023==complete
                   edit MEMBER_NAME '023'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem023
                   trigger ./jrrfs_enkf_forecast_ensinit_mem023==complete
                   edit MEMBER_NAME '023'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem023
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem023==complete
                   edit MEMBER_NAME '023'
@@ -45557,9 +45610,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem024
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem024==complete
                   edit MEMBER_NAME '024'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem024
                   trigger ./jrrfs_enkf_forecast_ensinit_mem024==complete
                   edit MEMBER_NAME '024'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem024
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem024==complete
                   edit MEMBER_NAME '024'
@@ -45570,9 +45625,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem025
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem025==complete
                   edit MEMBER_NAME '025'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem025
                   trigger ./jrrfs_enkf_forecast_ensinit_mem025==complete
                   edit MEMBER_NAME '025'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem025
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem025==complete
                   edit MEMBER_NAME '025'
@@ -45583,9 +45640,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem026
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem026==complete
                   edit MEMBER_NAME '026'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem026
                   trigger ./jrrfs_enkf_forecast_ensinit_mem026==complete
                   edit MEMBER_NAME '026'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem026
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem026==complete
                   edit MEMBER_NAME '026'
@@ -45596,9 +45655,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem027
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem027==complete
                   edit MEMBER_NAME '027'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem027
                   trigger ./jrrfs_enkf_forecast_ensinit_mem027==complete
                   edit MEMBER_NAME '027'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem027
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem027==complete
                   edit MEMBER_NAME '027'
@@ -45609,9 +45670,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem028
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem028==complete
                   edit MEMBER_NAME '028'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem028
                   trigger ./jrrfs_enkf_forecast_ensinit_mem028==complete
                   edit MEMBER_NAME '028'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem028
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem028==complete
                   edit MEMBER_NAME '028'
@@ -45622,9 +45685,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem029
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem029==complete
                   edit MEMBER_NAME '029'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem029
                   trigger ./jrrfs_enkf_forecast_ensinit_mem029==complete
                   edit MEMBER_NAME '029'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem029
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem029==complete
                   edit MEMBER_NAME '029'
@@ -45635,9 +45700,11 @@ suite para
                 task jrrfs_enkf_forecast_ensinit_mem030
                   trigger ../prep/jrrfs_enkf_prep_cyc_spinup_ensinit_mem030==complete
                   edit MEMBER_NAME '030'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_save_restart_ensinit_mem030
                   trigger ./jrrfs_enkf_forecast_ensinit_mem030==complete
                   edit MEMBER_NAME '030'
+                  complete ( ../ics/jrrfs_enkf_blend_ics_mem001:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem002:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem003:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem004:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem005:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem006:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem007:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem008:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem009:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem010:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem011:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem012:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem013:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem014:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem015:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem016:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem017:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem018:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem019:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem020:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem021:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem022:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem023:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem024:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem025:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem026:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem027:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem028:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem029:skip_ensinit or ../ics/jrrfs_enkf_blend_ics_mem030:skip_ensinit  )
                 task jrrfs_enkf_forecast_spinup_mem030
                   trigger ../analysis/jrrfs_enkf_analysis_nonvarcld_spinup_mem030==complete
                   edit MEMBER_NAME '030'
@@ -45697,7 +45764,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/18/obsproc/v1.2/rrfs/20z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/19z/enkf/forecast==complete  or /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/19z/enkf/forecast==complete  or /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -45705,7 +45772,7 @@ suite para
                 task jrrfs_det_analysis_nonvarcld
                   trigger ./jrrfs_det_update_lbc_soil==complete and ../init/jrrfs_det_process_bufr==complete
                 task jrrfs_det_analysis_gsi_spinup
-                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /para/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/19z/enkf/forecast==complete or /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc_spinup==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/19z/enkf/forecast==complete or /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                   edit CYCLE_TYPE 'spinup'
                 task jrrfs_det_update_lbc_soil_spinup
                   trigger ./jrrfs_det_analysis_gsi_spinup==complete
@@ -46204,7 +46271,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /para/primary/18/obsproc/v1.2/rrfs/20z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/20z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -47013,7 +47080,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/18/obsproc/v1.2/rrfs/21z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/21z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/20z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/21z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/21z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/20z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/18/rrfs/v1.0/18z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -47501,7 +47568,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /para/primary/18/obsproc/v1.2/rrfs/21z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/21z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/21z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/21z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -47967,7 +48034,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/18/obsproc/v1.2/rrfs/22z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/22z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/21z/enkf/forecast==complete or /para/primary/18/rrfs/v1.0/20z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/22z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/22z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/21z/enkf/forecast==complete or /para/primary/18/rrfs/v1.0/20z/enkf/forecast/jrrfs_enkf_save_restart_f2_done==complete )
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -48455,7 +48522,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /para/primary/18/obsproc/v1.2/rrfs/22z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/22z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/22z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/22z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -49264,7 +49331,7 @@ suite para
                 edit MEM_TYPE 'MEMBER'
                 edit GSI_TYPE 'ANALYSIS'
                 task jrrfs_det_analysis_gsi
-                  trigger ../prep/jrrfs_det_prep_cyc==complete and /para/primary/18/obsproc/v1.2/rrfs/23z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/23z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/22z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/18/rrfs/v1.0/20z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
+                  trigger ../prep/jrrfs_det_prep_cyc==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/23z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/23z/prep/jobsproc_rrfs_prep==complete and ( /para/primary/18/rrfs/v1.0/22z/enkf/forecast/jrrfs_enkf_save_restart_f1_done==complete or /para/primary/18/rrfs/v1.0/20z/enkf/forecast/jrrfs_enkf_save_restart_f3_done==complete)
                 task jrrfs_det_update_lbc_soil
                   trigger ./jrrfs_det_analysis_gsi==complete
                 task jrrfs_det_analysis_gsi_diag
@@ -49752,7 +49819,7 @@ suite para
                 task jrrfs_enkf_calc_ensmean
                   trigger ./jrrfs_enkf_prep_cyc_mem001==complete and ./jrrfs_enkf_prep_cyc_mem002==complete and ./jrrfs_enkf_prep_cyc_mem003==complete and ./jrrfs_enkf_prep_cyc_mem004==complete and ./jrrfs_enkf_prep_cyc_mem005==complete and ./jrrfs_enkf_prep_cyc_mem006==complete and ./jrrfs_enkf_prep_cyc_mem007==complete and ./jrrfs_enkf_prep_cyc_mem008==complete and ./jrrfs_enkf_prep_cyc_mem009==complete and ./jrrfs_enkf_prep_cyc_mem010==complete and ./jrrfs_enkf_prep_cyc_mem011==complete and ./jrrfs_enkf_prep_cyc_mem012==complete and ./jrrfs_enkf_prep_cyc_mem013==complete and ./jrrfs_enkf_prep_cyc_mem014==complete and ./jrrfs_enkf_prep_cyc_mem015==complete and ./jrrfs_enkf_prep_cyc_mem016==complete and ./jrrfs_enkf_prep_cyc_mem017==complete and ./jrrfs_enkf_prep_cyc_mem018==complete and ./jrrfs_enkf_prep_cyc_mem019==complete and ./jrrfs_enkf_prep_cyc_mem020==complete and ./jrrfs_enkf_prep_cyc_mem021==complete and ./jrrfs_enkf_prep_cyc_mem022==complete and ./jrrfs_enkf_prep_cyc_mem023==complete and ./jrrfs_enkf_prep_cyc_mem024==complete and ./jrrfs_enkf_prep_cyc_mem025==complete and ./jrrfs_enkf_prep_cyc_mem026==complete and ./jrrfs_enkf_prep_cyc_mem027==complete and ./jrrfs_enkf_prep_cyc_mem028==complete and ./jrrfs_enkf_prep_cyc_mem029==complete and ./jrrfs_enkf_prep_cyc_mem030==complete and ./jrrfs_enkf_prep_cyc_ensmean==complete
                 task jrrfs_enkf_observer_gsi_ensmean
-                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /para/primary/18/obsproc/v1.2/rrfs/23z/dump/jobsproc_rrfs_dump==complete and /para/primary/18/obsproc/v1.2/rrfs/23z/prep/jobsproc_rrfs_prep==complete
+                  trigger ./jrrfs_enkf_calc_ensmean==complete and /prod_clone/primary/12/gfs/v16.3/enkfgdas/post==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/23z/dump/jobsproc_rrfs_dump==complete and /prod_clone/primary/18/obsproc/v1.2/rrfs/23z/prep/jobsproc_rrfs_prep==complete
                 task jrrfs_enkf_observer_gsi_mem001
                   trigger ./jrrfs_enkf_observer_gsi_ensmean==complete
                   edit MEM_TYPE 'MEMBER'
@@ -50191,60 +50258,6 @@ suite para
           endfamily
         endfamily
       endfamily
-      family obsproc
-        family v1.2
-          family rrfs
-            family 18z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 18z
-            family 19z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 19z
-            family 20z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 20z
-            family 21z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 21z
-            family 22z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 22z
-            family 23z
-              family prep
-                task jobsproc_rrfs_prep
-              endfamily
-              family dump
-                task jobsproc_rrfs_dump
-              endfamily
-            endfamily # 23z
-          endfamily # rrfs
-        endfamily # v1.2
-      endfamily # obsproc
     endfamily # 18
   endfamily # primary
 endsuite    

--- a/scripts/exrrfs_blend_ics.sh
+++ b/scripts/exrrfs_blend_ics.sh
@@ -199,10 +199,7 @@ if [[ $DO_ENS_BLENDING == "TRUE" ]]; then
        else
          cycmaj=18
        fi
-       for completed_ensinit_member in $(seq 1 30); do
-         completed_ensinit_member_3d=$( printf "%03d" "${completed_ensinit_member}" )
-         ecflow_client --force=complete /rrfs_dev/primary/${cycmaj}/rrfs/v1.0/${cyc}/forecast/enkf/jrrfs_enkf_forecast_ensinit_mem${completed_ensinit_member_3d} /rrfs_dev/primary/${cycmaj}/rrfs/v1.0/${cyc}/forecast/enkf/jrrfs_enkf_save_restart_ensinit_mem${completed_ensinit_member_3d}
-       done
+       ecflow_client --event skip_ensinit
      fi
 
      # F2Py shared object files to PYTHONPATH


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- If ENKF make_ics jobs perform blending, downstream forecast ensinit jobs can be skipped. However, the existing logic is to set jobs on dev ecflow server to complete.
- In this PR, the logic has been updated to
  - If run blending, each make_ics job sets its new event, `skip_ensinit`
  - If any of the 30 make_ics jobs have `skip_ensinit` set, all forecast ensinit jobs and their save_restart jobs will be skipped.
<img width="421" height="207" alt="image" src="https://github.com/user-attachments/assets/2ddc4a57-3c01-44df-88a8-17bd9724e927" />
<img width="427" height="315" alt="image" src="https://github.com/user-attachments/assets/8fe62d2d-8790-4437-b65d-bcb764849861" />

- Also in this PR, the workflow (ecf definition file) is updated to use production obsproc. (Forgot to save a copy for a separate PR, and too lazy to revert all of the changes.... )

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested in NCO realtime parellel.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #1246


