### PR TITLE
add `tools/qrocoto/bkg_rrun_and_notify`, mostly for monitoring realtime runs on Gaea

### DIFF
--- a/workflow/tools/qrocoto/bkg_rrun_and_notify
+++ b/workflow/tools/qrocoto/bkg_rrun_and_notify
@@ -1,0 +1,34 @@
+#!/bin/bash
+# shellcheck disable=all
+# Usage: bkg_rrun [sleeptime] [email=freq_in_seconds] [email_address] [email_tag]
+
+sleeptime=60  # seconds
+email_freq=-1
+if (( $# > 0 )); then
+  sleeptime=$1
+  if ! [[ "${sleeptime}" =~ ^[0-9]+$ ]]; then  # if not a non-negative number
+    sleeptime=60
+  fi
+  if [[ "$2" == *email* ]]; then
+    email_freq=${2//[^0-9]/}  # get the seconds
+    email_addr=$3
+    email_tag=$4
+  fi
+fi
+
+knt=0
+while true; do
+ rrun
+ if (( 10#${email_freq} > 0 )); then
+   if (( knt * sleeptime >= 10#${email_freq} )); then
+     subject="session is alive: ${email_tag}"
+     recipents="${email_addr} ${email_addr}"  # add additional email addresses if needed
+     echo "-" | mail -s "${subject}" ${recipents}
+     knt=1
+   else
+     (( knt += 1 ))
+   fi
+ fi
+
+ sleep ${sleeptime}
+done

--- a/workflow/tools/qrocoto/bkg_rrun_and_notify
+++ b/workflow/tools/qrocoto/bkg_rrun_and_notify
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=all
-# Usage: bkg_rrun [sleeptime] [email=freq_in_seconds] [email_address] [email_tag]
+# Usage: bkg_rrun_and_notify [sleeptime] [email=freq_in_seconds] [email_address] [email_tag]
 
 sleeptime=60  # seconds
 email_freq=-1


### PR DESCRIPTION
As we know, Gaea does not have `crontab`.

We either use `scrontab` or the `bkg_rrun` command inside a `tmux` or `screen` session to repeatedly execute `rocotorun`.

However, scrontab has known OOM (out of memory) or "launch failed requeued held" issues which happen randomly.
A `tmux` or `screen` session can be killed automatically when front nodes restart due to OOM or other crashes.

So we don't have a stable method at the moment to continuously run our workflow for more than 1 or 2 days.
This brings big challenges in maintaining or monitoring RRFS experiments on Gaea, especially for realtime ones.

This PR adds a new utility `bkg_rrun_and_notify` by expanding bkg_rrun.   
It can send users "session is alive" emails at a given time interval (suggest setting to 30 minutes (1800s)). If we don't receive such kind of emails for more than 30 minutes, it usually means the involved front node has issues and needs manual intervention. 

The usage is as follows:
`bkg_rrun_and_notify [sleeptime] [email=freq_in_seconds] [email_address] [email_tag]`    
    
where `sleeptime` is the frequency (in seconds) to run the `bkg_rrun_and_notify` command;  
`email=freq_in_seconds` is the frequency (in seconds) to send out emails;  
`email_address` is the user's email address;  
`email_tag` is to add a tag to the end of the email subject to distinguish different experiments.

Here is an example:
```
bkg_rrun_and_notify 300 email=1800 Guoqing.Ge@noaa.gov rt_GAEA
```
It runs the command every 5 minutes and send emails to "Guoqing.Ge@noaa.gov" every 30 minutes using the email subject  `session is alive: rt_GAEA` 