### PR TITLE
[rrfs-mpas-jedi]Run prep_ic parallelly for ensemble members to avoid long disk I/O time

### DIFF
--- a/jobs/JRRFS_PREP_IC
+++ b/jobs/JRRFS_PREP_IC
@@ -18,17 +18,12 @@ export USHrrfs=${USHrrfs:-${HOMErrfs}/ush}
 #-----------------------------------------------------------------------
 #
 export pid=${pid:-$$}
-if [[ -z "${ENS_INDEX}" ]]; then
-  export MEMDIR=""
-else
-  export MEMDIR="/mem${ENS_INDEX}"
-fi
 if [[ "${SPINUP_MODE:-0}" == "1" ]];  then
   prep_ic_str="prep_ic_spinup"
 else
   prep_ic_str="prep_ic"
 fi
-export UMBRELLA_PREP_IC_DATA=${UMBRELLA_PREP_IC_DATA:-${DATAROOT}/${RUN}_${prep_ic_str}_${cyc}_${rrfs_ver}/${WGF}${MEMDIR}}
+export UMBRELLA_PREP_IC_DATA=${UMBRELLA_PREP_IC_DATA:-${DATAROOT}/${RUN}_${prep_ic_str}_${cyc}_${rrfs_ver}/${WGF}}
 export jobid=${jobid:-prep_ic_${cyc}}
 export DATA=${DATA:-${UMBRELLA_PREP_IC_DATA}/${jobid}}
 

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -35,10 +35,33 @@ echo "this cycle is ${start_type} start"
 #
 timestr=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%Y-%m-%d_%H.%M.%S)
 
+# Populate the list for the ensemble members, or deterministic member
+if (( "${ENS_SIZE:-0}" > 2 )); then
+  mapfile -t mem_list < <(printf "%03d\n" $(seq 1 "$ENS_SIZE"))
+else
+  mem_list=("000") # if determinitic
+fi
+
+for index in "${mem_list[@]}"; do
+  # Determine path
+  if (( 10#${index} == 0 )); then
+    memdir=""
+    umbrella_prep_ic_mem="${UMBRELLA_PREP_IC_DATA}"
+    export CMDFILE="${DATA}/script_prep_ic_0.sh"
+  else
+    memdir="/mem${index}"
+    umbrella_prep_ic_mem="${UMBRELLA_PREP_IC_DATA}${memdir}"
+    mkdir -p "${umbrella_prep_ic_mem}"
+    pid=$((10#${index}-1))
+    export CMDFILE="${DATA}/script_prep_ic_${pid}.sh"
+  fi
+  echo $CMDFILE, $memdir
+
+
 if [[ "${start_type}" == "cold" ]]; then
-  thisfile=${COMINrrfs}/${RUN}.${PDY}/${cyc}/ic/${WGF}${MEMDIR}/init.nc
+  thisfile=${COMINrrfs}/${RUN}.${PDY}/${cyc}/ic/${WGF}${memdir}/init.nc
   if [[ -r ${thisfile} ]]; then
-    ${cpreq} "${thisfile}" "${UMBRELLA_PREP_IC_DATA}/init.nc"
+    echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/init.nc" >> "$CMDFILE"
     echo "cold start from ${thisfile}"
   else
     echo "FATAL ERROR: PREP_IC failed, cannot find cold start file: ${thisfile}"
@@ -61,13 +84,13 @@ elif [[ "${start_type}" == "warm" ]]; then
     CDATEp=$(${NDATE} -${ii} "${CDATE}" )
     PDYii=${CDATEp:0:8}
     cycii=${CDATEp:8:2}
-    thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${fcststr}/${WGF}${MEMDIR}/mpasout.${timestr}.nc
+    thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${fcststr}/${WGF}${memdir}/mpasout.${timestr}.nc
     if [[ -r ${thisfile} ]]; then
       break
     fi
   done
   if [[ -r ${thisfile} ]]; then
-    ${cpreq} "${thisfile}" "${UMBRELLA_PREP_IC_DATA}/mpasout.nc"
+    echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/mpasout.nc"  >> "$CMDFILE"
     echo "warm start from ${thisfile}"
   else
     echo "FATAL ERROR: PREP_IC failed, cannot find warm start file: ${thisfile}"
@@ -90,22 +113,22 @@ for hr in ${SFC_UPDATE_CYCS:-"99"}; do
       CDATEp=$(${NDATE} -${ii} "${CDATE}" )
       PDYii=${CDATEp:0:8}
       cycii=${CDATEp:8:2}
-      thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/fcst/${WGF}${MEMDIR}/mpasout.${timestr}.nc
+      thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/fcst/${WGF}${memdir}/mpasout.${timestr}.nc
       if [[ -r ${thisfile} ]]; then
         break
       fi
     done
     if [[ -r ${thisfile} ]]; then
-      ${cpreq} "${thisfile}" "${UMBRELLA_PREP_IC_DATA}/mpas_sfc.nc"
-      if [[ -r "${UMBRELLA_PREP_IC_DATA}/init.nc" ]]; then
-        to_file="${UMBRELLA_PREP_IC_DATA}/init.nc"
-      elif [[ -r "${UMBRELLA_PREP_IC_DATA}/mpasout.nc" ]]; then
-        to_file="${UMBRELLA_PREP_IC_DATA}/mpasout.nc"
+      echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/mpas_sfc.nc" >> "$CMDFILE"
+      if [[ -r "${umbrella_prep_ic_mem}/init.nc" ]]; then
+        to_file="${umbrella_prep_ic_mem}/init.nc"
+      elif [[ -r "${umbrella_prep_ic_mem}/mpasout.nc" ]]; then
+        to_file="${umbrella_prep_ic_mem}/mpasout.nc"
       fi
       echo "surface update from ${thisfile} to ${to_file}"
-      ncks -O -C -x -v ${var_list} "${to_file}"  tmp.nc
-      ncks -A -v ${var_list} "${UMBRELLA_PREP_IC_DATA}/mpas_sfc.nc" tmp.nc
-      mv tmp.nc "${to_file}"
+      echo ncks -O -C -x -v ${var_list} "${to_file}"  tmp.nc  >> "$CMDFILE"
+      echo ncks -A -v ${var_list} "${umbrella_prep_ic_mem}/mpas_sfc.nc" tmp.nc  >> "$CMDFILE"
+      echo mv tmp.nc "${to_file}"  >> "$CMDFILE"
     else
       echo "SFC_UPDATE failed, cannot find warm start file: ${thisfile}"
     fi
@@ -137,11 +160,28 @@ if [[ "${PREP_IC_TYPE}" == "jedivar" ]] || [[ "${PREP_IC_TYPE}" == "getkf"  ]]; 
     satbias_path=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${PREP_IC_TYPE}${spinup_str}/${WGF}
     nSatbias=$(find "${satbias_path}"/*satbias*.nc | wc -l)
     if (( nSatbias > 0 )); then
-      cp "${satbias_path}"/*satbias*.nc  "${UMBRELLA_PREP_IC_DATA}"
+      echo cp "${satbias_path}"/*satbias*.nc  "${umbrella_prep_ic_mem}" >> "$CMDFILE"
       echo "found satbias from ${satbias_path}"
       break
     fi
   done
+fi
+
+done # done for all the members
+
+#
+# parallel run the serial tasks
+#
+${cpreq} "${EXECrrfs}"/rank_run.x .
+${MPI_RUN_CMD} ./rank_run.x "${DATA}/script_prep_ic_*.sh"
+
+# Check for errors
+export err=$?
+if (( err != 0 )); then
+  echo "prep_ic failed with error code ${err}"
+  err_exit
+else
+  echo "prep_ic completed successfully"
 fi
 
 exit 0

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -55,7 +55,6 @@ for index in "${mem_list[@]}"; do # loop through all the members
     pid=$((10#${index}-1))
     export CMDFILE="${DATA}/script_prep_ic_${pid}.sh"
   fi
-  echo "$CMDFILE", "$memdir"
 
   if [[ "${start_type}" == "cold" ]]; then
     thisfile=${COMINrrfs}/${RUN}.${PDY}/${cyc}/ic/${WGF}${memdir}/init.nc

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -55,7 +55,7 @@ for index in "${mem_list[@]}"; do
     pid=$((10#${index}-1))
     export CMDFILE="${DATA}/script_prep_ic_${pid}.sh"
   fi
-  echo $CMDFILE, $memdir
+  echo "$CMDFILE", "$memdir"
 
 
 if [[ "${start_type}" == "cold" ]]; then

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -126,9 +126,9 @@ for hr in ${SFC_UPDATE_CYCS:-"99"}; do
         to_file="${umbrella_prep_ic_mem}/mpasout.nc"
       fi
       echo "surface update from ${thisfile} to ${to_file}"
-      echo ncks -O -C -x -v ${var_list} "${to_file}"  tmp.nc  >> "$CMDFILE"
-      echo ncks -A -v ${var_list} "${umbrella_prep_ic_mem}/mpas_sfc.nc" tmp.nc  >> "$CMDFILE"
-      echo mv tmp.nc "${to_file}"  >> "$CMDFILE"
+      echo " ncks -O -C -x -v ${var_list} \"${to_file}\"  tmp.nc ; \
+             ncks -A -v ${var_list} \"${umbrella_prep_ic_mem}/mpas_sfc.nc\" tmp.nc ; \
+             mv tmp.nc \"${to_file}\" " >>  "$CMDFILE"
     else
       echo "SFC_UPDATE failed, cannot find warm start file: ${thisfile}"
     fi

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -42,7 +42,7 @@ else
   mem_list=("000") # if determinitic
 fi
 
-for index in "${mem_list[@]}"; do
+for index in "${mem_list[@]}"; do # loop through all the members
   # Determine path
   if (( 10#${index} == 0 )); then
     memdir=""
@@ -57,115 +57,112 @@ for index in "${mem_list[@]}"; do
   fi
   echo "$CMDFILE", "$memdir"
 
-
-if [[ "${start_type}" == "cold" ]]; then
-  thisfile=${COMINrrfs}/${RUN}.${PDY}/${cyc}/ic/${WGF}${memdir}/init.nc
-  if [[ -r ${thisfile} ]]; then
-    echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/init.nc" >> "$CMDFILE"
-    echo "cold start from ${thisfile}"
-  else
-    echo "FATAL ERROR: PREP_IC failed, cannot find cold start file: ${thisfile}"
-    err_exit
-  fi
-elif [[ "${start_type}" == "warm" ]]; then
-  thisfile="undefined"
-  if (( spinup_mode == 1 ));  then
-    NUM=1 # only use the previous cycle mpasout.nc
-    fcststr="fcst_spinup"
-  else
-    NUM=3
-    if [[ "${prod_switch:-"no"}" == "yes" ]]; then
+  if [[ "${start_type}" == "cold" ]]; then
+    thisfile=${COMINrrfs}/${RUN}.${PDY}/${cyc}/ic/${WGF}${memdir}/init.nc
+    if [[ -r ${thisfile} ]]; then
+      echo "${cpreq} ${thisfile} ${umbrella_prep_ic_mem}/init.nc" >> "$CMDFILE"
+      echo "cold start from ${thisfile}"
+    else
+      echo "FATAL ERROR: PREP_IC failed, cannot find cold start file: ${thisfile}"
+      err_exit
+    fi
+  elif [[ "${start_type}" == "warm" ]]; then
+    thisfile="undefined"
+    if (( spinup_mode == 1 ));  then
+      NUM=1 # only use the previous cycle mpasout.nc
       fcststr="fcst_spinup"
     else
-      fcststr="fcst"
+      NUM=3
+      if [[ "${prod_switch:-"no"}" == "yes" ]]; then
+        fcststr="fcst_spinup"
+      else
+        fcststr="fcst"
+      fi
     fi
-  fi
-  for (( ii=cyc_interval; ii<=$(( NUM*cyc_interval )); ii=ii+cyc_interval )); do
-    CDATEp=$(${NDATE} -${ii} "${CDATE}" )
-    PDYii=${CDATEp:0:8}
-    cycii=${CDATEp:8:2}
-    thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${fcststr}/${WGF}${memdir}/mpasout.${timestr}.nc
-    if [[ -r ${thisfile} ]]; then
-      break
-    fi
-  done
-  if [[ -r ${thisfile} ]]; then
-    echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/mpasout.nc"  >> "$CMDFILE"
-    echo "warm start from ${thisfile}"
-  else
-    echo "FATAL ERROR: PREP_IC failed, cannot find warm start file: ${thisfile}"
-    err_exit
-  fi
-else
-  echo "FATAL ERROR: PREP_IC failed, start type is not defined"
-  err_exit
-fi
-
-#
-# do sfc cycling
-#
-for hr in ${SFC_UPDATE_CYCS:-"99"}; do
-  shr=$(printf '%02d' $((10#$hr)) )
-  var_list="smois,snow,snowh,snowc,sst,canwat,tslb,skintemp,landmask,isltyp,ivgtyp,soilt1"
-  if [ "${cyc}" == "${shr}" ]; then
-    NUM=3 # look back ${NUM} cycles to find mpasout files for surface cycling
     for (( ii=cyc_interval; ii<=$(( NUM*cyc_interval )); ii=ii+cyc_interval )); do
       CDATEp=$(${NDATE} -${ii} "${CDATE}" )
       PDYii=${CDATEp:0:8}
       cycii=${CDATEp:8:2}
-      thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/fcst/${WGF}${memdir}/mpasout.${timestr}.nc
+      thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${fcststr}/${WGF}${memdir}/mpasout.${timestr}.nc
       if [[ -r ${thisfile} ]]; then
         break
       fi
     done
     if [[ -r ${thisfile} ]]; then
-      echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/mpas_sfc.nc" >> "$CMDFILE"
-      if [[ -r "${umbrella_prep_ic_mem}/init.nc" ]]; then
-        to_file="${umbrella_prep_ic_mem}/init.nc"
-      elif [[ -r "${umbrella_prep_ic_mem}/mpasout.nc" ]]; then
-        to_file="${umbrella_prep_ic_mem}/mpasout.nc"
-      fi
-      echo "surface update from ${thisfile} to ${to_file}"
-      echo " ncks -O -C -x -v ${var_list} \"${to_file}\"  tmp.nc ; \
-             ncks -A -v ${var_list} \"${umbrella_prep_ic_mem}/mpas_sfc.nc\" tmp.nc ; \
-             mv tmp.nc \"${to_file}\" " >>  "$CMDFILE"
+      echo "${cpreq} ${thisfile} ${umbrella_prep_ic_mem}/mpasout.nc"  >> "$CMDFILE"
+      echo "warm start from ${thisfile}"
     else
-      echo "SFC_UPDATE failed, cannot find warm start file: ${thisfile}"
+      echo "FATAL ERROR: PREP_IC failed, cannot find warm start file: ${thisfile}"
+      err_exit
     fi
-  fi
-done
-
-#
-#  find the right satbias file
-#
-PREP_IC_TYPE=${PREP_IC_TYPE:-"no_da"}
-if [[ "${PREP_IC_TYPE}" == "jedivar" ]] || [[ "${PREP_IC_TYPE}" == "getkf"  ]]; then
-  if ( (( spinup_mode == 1 )) && [[ "${start_type}" == "warm" ]] ) || \
-     ( (( spinup_mode == -1 )) && [[ "${prod_switch:-"no"}" == "yes" ]] ); then
-    # warm start in the spinup session or prod_switch in the prod session
-      spinup_str="_spinup"
   else
-      spinup_str=""
+    echo "FATAL ERROR: PREP_IC failed, start type is not defined"
+    err_exit
   fi
-
-  NUM=5 # look back ${NUM} cycles to find satbias files
-  if [[ "${USE_THE_LATEST_SATBIAS:-"FALSE"}" == "TRUE" ]]; then # only use the latest satbias from the previous cycle
-    NUM=1
-  fi
-
-  for (( ii=cyc_interval; ii<=$(( NUM*cyc_interval )); ii=ii+cyc_interval )); do
-    CDATEp=$(${NDATE} -${ii} "${CDATE}" )
-    PDYii=${CDATEp:0:8}
-    cycii=${CDATEp:8:2}
-    satbias_path=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${PREP_IC_TYPE}${spinup_str}/${WGF}
-    nSatbias=$(find "${satbias_path}"/*satbias*.nc | wc -l)
-    if (( nSatbias > 0 )); then
-      echo cp "${satbias_path}"/*satbias*.nc  "${umbrella_prep_ic_mem}" >> "$CMDFILE"
-      echo "found satbias from ${satbias_path}"
-      break
+  #
+  # do sfc cycling
+  #
+  for hr in ${SFC_UPDATE_CYCS:-"99"}; do
+    shr=$(printf '%02d' $((10#$hr)) )
+    var_list="smois,snow,snowh,snowc,sst,canwat,tslb,skintemp,landmask,isltyp,ivgtyp,soilt1"
+    if [ "${cyc}" == "${shr}" ]; then
+      NUM=3 # look back ${NUM} cycles to find mpasout files for surface cycling
+      for (( ii=cyc_interval; ii<=$(( NUM*cyc_interval )); ii=ii+cyc_interval )); do
+        CDATEp=$(${NDATE} -${ii} "${CDATE}" )
+        PDYii=${CDATEp:0:8}
+        cycii=${CDATEp:8:2}
+        thisfile=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/fcst/${WGF}${memdir}/mpasout.${timestr}.nc
+        if [[ -r ${thisfile} ]]; then
+          break
+        fi
+      done
+      if [[ -r ${thisfile} ]]; then
+        echo "${cpreq}" "${thisfile}" "${umbrella_prep_ic_mem}/mpas_sfc.nc" >> "$CMDFILE"
+        if [[ -r "${umbrella_prep_ic_mem}/init.nc" ]]; then
+          to_file="${umbrella_prep_ic_mem}/init.nc"
+        elif [[ -r "${umbrella_prep_ic_mem}/mpasout.nc" ]]; then
+          to_file="${umbrella_prep_ic_mem}/mpasout.nc"
+        fi
+        echo "surface update from ${thisfile} to ${to_file}"
+        echo " ncks -O -C -x -v ${var_list} \"${to_file}\"  tmp.nc ; \
+               ncks -A -v ${var_list} \"${umbrella_prep_ic_mem}/mpas_sfc.nc\" tmp.nc ; \
+               mv tmp.nc \"${to_file}\" " >>  "$CMDFILE"
+      else
+        echo "SFC_UPDATE failed, cannot find warm start file: ${thisfile}"
+      fi
     fi
   done
-fi
+  #
+  #  find the right satbias file
+  #
+  PREP_IC_TYPE=${PREP_IC_TYPE:-"no_da"}
+  if [[ "${PREP_IC_TYPE}" == "jedivar" ]] || [[ "${PREP_IC_TYPE}" == "getkf"  ]]; then
+    if ( (( spinup_mode == 1 )) && [[ "${start_type}" == "warm" ]] ) || \
+       ( (( spinup_mode == -1 )) && [[ "${prod_switch:-"no"}" == "yes" ]] ); then
+      # warm start in the spinup session or prod_switch in the prod session
+        spinup_str="_spinup"
+    else
+        spinup_str=""
+    fi
+
+    NUM=5 # look back ${NUM} cycles to find satbias files
+    if [[ "${USE_THE_LATEST_SATBIAS:-"FALSE"}" == "TRUE" ]]; then # only use the latest satbias from the previous cycle
+      NUM=1
+    fi
+
+    for (( ii=cyc_interval; ii<=$(( NUM*cyc_interval )); ii=ii+cyc_interval )); do
+      CDATEp=$(${NDATE} -${ii} "${CDATE}" )
+      PDYii=${CDATEp:0:8}
+      cycii=${CDATEp:8:2}
+      satbias_path=${COMINrrfs}/${RUN}.${PDYii}/${cycii}/${PREP_IC_TYPE}${spinup_str}/${WGF}
+      nSatbias=$(find "${satbias_path}"/*satbias*.nc | wc -l)
+      if (( nSatbias > 0 )); then
+        echo "cp ${satbias_path}/*satbias*.nc  ${umbrella_prep_ic_mem}" >> "$CMDFILE"
+        echo "found satbias from ${satbias_path}"
+        break
+      fi
+    done
+  fi
 
 done # done for all the members
 

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -66,7 +66,7 @@ export NODES_IC=${NODES_IC:-"<nodes>1:ppn=40</nodes>"}
 export NODES_LBC=${NODES_LBC:-"<nodes>1:ppn=40</nodes>"}
 
 # prep_ic
-export NODES_PREP_IC=${NODES_PREP_IC:-"<nodes>1:ppn=1</nodes>"}
+export NODES_PREP_IC=${NODES_PREP_IC:-"<nodes>1:ppn=40</nodes>"}
 export WALLTIME_PREP_IC=${WALLTIME_PREP_IC:-"00:10:00"}
 
 # prep_lbc

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -66,7 +66,11 @@ export NODES_IC=${NODES_IC:-"<nodes>1:ppn=40</nodes>"}
 export NODES_LBC=${NODES_LBC:-"<nodes>1:ppn=40</nodes>"}
 
 # prep_ic
-export NODES_PREP_IC=${NODES_PREP_IC:-"<nodes>1:ppn=40</nodes>"}
+if ${DO_ENSEMBLE:-false}; then
+  export NODES_PREP_IC=${NODES_PREP_IC:-"<nodes>1:ppn=40</nodes>"}
+else
+  export NODES_PREP_IC=${NODES_PREP_IC:-"<nodes>1:ppn=1</nodes>"}
+fi
 export WALLTIME_PREP_IC=${WALLTIME_PREP_IC:-"00:10:00"}
 
 # prep_lbc

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -101,7 +101,7 @@ def fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
             if os.getenv("DO_ENSEMBLE", "FALSE").upper() == "TRUE":
                 recenterdep = f'\n<taskdep task="recenter"/>'
 
-    prep_ic_dep = f'<taskdep task="prep_ic{ensindexstr}"/>'
+    prep_ic_dep = f'<taskdep task="prep_ic"/>'
     if do_spinup:
         prep_ic_dep = f'<taskdep task="prep_ic_spinup"/>'
     prep_lbc_dep = f'\n    <taskdep task="prep_lbc{ensindexstr}" cycle_offset="0:00:00"/>'

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -52,7 +52,7 @@ def getkf(xmlFile, expdir, taskType):
         dependencies = f'''
   <dependency>
   <and>{timedep}
-    <metataskdep metatask="prep_ic"/>
+    <taskdep task="prep_ic"/>
     {iodadep}
     {recenterdep}
   </and>

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -32,7 +32,6 @@ def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
             task_id = f'{meta_id}'
         meta_bgn = ""
         meta_end = ""
-        ensindexstr = ""
     else:
         metatask = True
         task_id = f'{meta_id}_m#ens_index#'
@@ -46,7 +45,6 @@ def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
 <var name="ens_index">{ens_indices}</var>'''
         meta_end = f'\
 </metatask>\n'
-        ensindexstr = "_m#ens_index#"
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -66,7 +66,7 @@ def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
         else:
             jedidep = f'\n    <taskdep task="jedivar"/>'
     else:
-        prep_ic_dep = f'\n    <taskdep task="prep_ic{ensindexstr}"/>'
+        prep_ic_dep = f'\n    <taskdep task="prep_ic"/>'
         if do_spinup:
             prep_ic_dep = f'\n    <taskdep task="prep_ic_spinup"/>'
     #

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -10,7 +10,6 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     #  0 = no parallel spinup cycles in the experiment
     #  1 = a spinup cycle
     # -1 = a prod cycle parallel to spinup cycles
-    meta_id = 'prep_ic'
     if spinup_mode == 1:
         cycledefs = 'spinup'
         num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
@@ -31,13 +30,10 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     }
     if spinup_mode != 0:
         dcTaskEnv['SPINUP_MODE'] = f'{spinup_mode}'
-    metatask = False
     if spinup_mode == 1:
-        task_id = f'{meta_id}_spinup'
+        task_id = 'prep_ic_spinup'
     else:
-        task_id = f'{meta_id}'
-    meta_bgn = ""
-    meta_end = ""
+        task_id = 'prep_ic'
 
     if do_ensemble:
         ens_size = int(os.getenv('ENS_SIZE', '2'))
@@ -165,6 +161,5 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
   </and>
   </dependency>'''
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies,
-             metatask, meta_id, meta_bgn, meta_end, "PREP_IC")
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, command_id="PREP_IC")
 # end of fcst --------------------------------------------------------

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -68,16 +68,16 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         datadep_prod = ""
         for i in range(1, int(ens_size) + 1):
             memdirstr = f'/mem{i:03d}'
-            datadep_prod = datadep_prod + f'''\n        <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;{memdirstr}/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
+            datadep_prod = datadep_prod + f'''\n      <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;{memdirstr}/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
     else:
-        datadep_prod = f'''\n        <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
+        datadep_prod = f'''\n      <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
 
     datadep_spinup = f'''\n      <taskdep task="fcst_spinup" cycle_offset="-1:00:00"/>'''
     if spinup_mode == 0:  # no parallel spinup cycles
         datadep = datadep_prod
     elif spinup_mode == 1:  # a spinup cycle
         datadep = datadep_spinup
-    else:  # a prod cycle paralle to spinup cycles
+    else:  # spinup_mode == -1, i.e. a prod cycle paralle to spinup cycles
         datadep = "whatever"  # dependencies will be rewritten near the end of this file
 
     #
@@ -143,7 +143,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
             strneqs = strneqs + f"\n      <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>"
         streqs = streqs.lstrip('\n')
         strneqs = strneqs.lstrip('\n')
-        datadep_spinup = datadep_spinup.lstrip('\n')[2:]
+        datadep_spinup = datadep_spinup.lstrip('\n')
         dependencies = f'''
   <dependency>
   <and>{timedep}

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -31,31 +31,18 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     }
     if spinup_mode != 0:
         dcTaskEnv['SPINUP_MODE'] = f'{spinup_mode}'
-    if not do_ensemble:
-        metatask = False
-        if spinup_mode == 1:
-            task_id = f'{meta_id}_spinup'
-        else:
-            task_id = f'{meta_id}'
-        meta_bgn = ""
-        meta_end = ""
-        ensindexstr = ""
-        ensdirstr = ""
+    metatask = False
+    if spinup_mode == 1:
+        task_id = f'{meta_id}_spinup'
     else:
-        metatask = True
-        task_id = f'{meta_id}_m#ens_index#'
-        dcTaskEnv['ENS_INDEX'] = "#ens_index#"
-        meta_bgn = ""
-        meta_end = ""
+        task_id = f'{meta_id}'
+    meta_bgn = ""
+    meta_end = ""
+
+    if do_ensemble:
         ens_size = int(os.getenv('ENS_SIZE', '2'))
-        ens_indices = ''.join(f'{i:03d} ' for i in range(1, int(ens_size) + 1)).strip()
-        meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="ens_index">{ens_indices}</var>'''
-        meta_end = f'\
-</metatask>\n'
-        ensindexstr = "_m#ens_index#"
-        ensdirstr = "/mem#ens_index#"
+        dcTaskEnv['ENS_SIZE'] = str(ens_size)
+
     # determine prep_ic type so that we know where to find correct satbias files
     do_jedi = os.getenv("DO_JEDI", "FALSE").upper()
     if do_ensemble and do_jedi == "TRUE":
@@ -81,7 +68,14 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         strneqs = strneqs + f"\n      <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>"
     streqs = streqs.lstrip('\n')
     strneqs = strneqs.lstrip('\n')
-    datadep_prod = f'''\n      <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;{ensdirstr}/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
+    if do_ensemble:
+        datadep_prod = ""
+        for i in range(1, int(ens_size) + 1):
+            memdirstr = f'/mem{i:03d}'
+            datadep_prod = datadep_prod + f'''\n        <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;{memdirstr}/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
+    else:
+        datadep_prod = f'''\n        <datadep age="00:05:00"><cyclestr offset="-{cyc_interval}:00:00">&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/fcst/&WGF;/</cyclestr><cyclestr>mpasout.@Y-@m-@d_@H.00.00.nc</cyclestr></datadep>'''
+
     datadep_spinup = f'''\n      <taskdep task="fcst_spinup" cycle_offset="-1:00:00"/>'''
     if spinup_mode == 0:  # no parallel spinup cycles
         datadep = datadep_prod
@@ -106,7 +100,10 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
         timedep = f'\n   <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     if os.getenv('DO_IC_LBC', 'TRUE').upper() == "TRUE":
-        icdep = f'\n      <taskdep task="ic{ensindexstr}"/>'
+        if do_ensemble:
+            icdep = f'\n      <metataskdep metatask="ic"/>'
+        else:
+            icdep = f'\n      <taskdep task="ic"/>'
     else:
         icdep = ""
     #
@@ -133,7 +130,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
             dependencies = f'''
   <dependency>
   <and>{timedep}
-   <taskdep task="ic{ensindexstr}"/>
+   <taskdep task="ic"/>
   </and>
   </dependency>'''
 

--- a/workflow/rocoto_funcs/recenter.py
+++ b/workflow/rocoto_funcs/recenter.py
@@ -57,7 +57,7 @@ def recenter(xmlFile, expdir):
       <and>{strneqs}
       </and>
     </or>
-    <metataskdep metatask="prep_ic"/>
+    <taskdep task="prep_ic"/>
   </and>
   </dependency>'''
     #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Re-open the PR to parallely run prep_ic if do_ensemble. The ensemble prep_ic used to take too much time for the real-time runs on Ursa (could be as long as ~10 min per member in some cases), and even causing dead prep_ic jobs after finishing some members. This PR adds the capability to run prep_ic parallelly for ensemble members and significantly reduce the run time to less than 5 min for all the members. This has been tested in retro mode and is now in the real-time run.


