### PR TITLE
[rrfs-mpas-jedi]Fix the ensemble data check for jedivar

### DIFF
--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -86,7 +86,7 @@ source "${USHrrfs}/find_ensembles.sh"
 #
 # For HYB_ENS_TYPE=0, check number of ensemble files, if not enough, default to pure 3DVar
 #
-if [[ ${HYB_ENS_TYPE} == 0 ]]; then
+if (( HYB_ENS_TYPE == 0 )) ; then
   ens_size=$(( 10#${ENS_SIZE} ))
   ens_count=$(find ens -name "mem*.nc" | wc -l)
   if (( ens_count < ens_size )); then

--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -84,16 +84,18 @@ source "${USHrrfs}/copy_obs.sh" "jedivar"
 #
 source "${USHrrfs}/find_ensembles.sh"
 #
-# check number of ensemble files, if not enough, default to pure 3DVar
+# For HYB_ENS_TYPE=0, check number of ensemble files, if not enough, default to pure 3DVar
 #
-ens_size=$(( 10#${ENS_SIZE} ))
-ens_count=$(find ens -name "mem*.nc" | wc -l)
-if (( ens_count < ens_size )); then
-   echo "Number of ensemble files is ${ens_count}, less than 30, default to 3DVar"
-   export HYB_WGT_ENS=0.0
-   export HYB_WGT_STATIC=1.0
-else
-   echo "Found ${ens_count} ensemble files"
+if [[ ${HYB_ENS_TYPE} == 0 ]]; then
+  ens_size=$(( 10#${ENS_SIZE} ))
+  ens_count=$(find ens -name "mem*.nc" | wc -l)
+  if (( ens_count < ens_size )); then
+     echo "Number of ensemble files is ${ens_count}, less than 30, default to 3DVar"
+     export HYB_WGT_ENS=0.0
+     export HYB_WGT_STATIC=1.0
+  else
+     echo "Found ${ens_count} ensemble files"
+  fi
 fi
 #
 #  link background

--- a/ush/find_ensembles.sh
+++ b/ush/find_ensembles.sh
@@ -2,7 +2,6 @@
 # find ensemble forecasts based on user settings
 #
 # shellcheck disable=SC2154,SC2153
-set -x
 if [[ "${HYB_WGT_ENS}" != "0" ]] && [[ "${HYB_WGT_ENS}" != "0.0" ]]; then # using ensembles
   mpasout_file=mpasout.${timestr}.nc
   enshrs=$(( 10#${ENS_BEC_LOOK_BACK_HRS} + 1 ))
@@ -50,11 +49,11 @@ if [[ "${HYB_WGT_ENS}" != "0" ]] && [[ "${HYB_WGT_ENS}" != "0.0" ]]; then # usin
        fi
      fi
 # Break if we actually found and linked files
-     if [[ "$found_data" == "true" ]]; then break; fi
+     if [[ "${found_data}" == "true" ]]; then break; fi
   done
 
 # Check if we failed to find data after checking all enshrs
-  if [[ "$found_data" == "false" ]]; then
+  if [[ "${found_data}" == "false" ]]; then
     echo "No ensemble files found within the ${enshrs} hour look-back window."
   fi
 

--- a/ush/find_ensembles.sh
+++ b/ush/find_ensembles.sh
@@ -2,47 +2,60 @@
 # find ensemble forecasts based on user settings
 #
 # shellcheck disable=SC2154,SC2153
+set -x
 if [[ "${HYB_WGT_ENS}" != "0" ]] && [[ "${HYB_WGT_ENS}" != "0.0" ]]; then # using ensembles
-  if [[ "${HYB_ENS_TYPE}" == "1"  ]]; then # rrfsens
-    echo "use rrfs ensembles"
-    mpasout_file=mpasout.${timestr}.nc
-    enshrs=$(( 10#${ENS_BEC_LOOK_BACK_HRS} + 1 ))
-    for (( ii=0; ii<enshrs; ii=ii+1 )); do
-       CDATEp=$(${NDATE} "-${ii}" "${CDATE}" )
-       if [[ "${HYB_ENS_PATH}" == "" ]]; then
-         ensdir=${COMINrrfs}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
-       else
-         ensdir=${HYB_ENS_PATH}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
-       fi
-       ensdir_m001=${ensdir}/fcst/enkf/mem001
-       if [[ -s "${ensdir_m001}/${mpasout_file}" ]]; then
-         for (( iii=1; iii<31; iii=iii+1 )); do
+  mpasout_file=mpasout.${timestr}.nc
+  enshrs=$(( 10#${ENS_BEC_LOOK_BACK_HRS} + 1 ))
+  ens_size=$(( 10#${ENS_SIZE} ))
+  base_dir="${HYB_ENS_PATH:-$COMINrrfs}"
+
+  for (( ii=0; ii<enshrs; ii=ii+1 )); do
+     CDATEp=$(${NDATE} "-${ii}" "${CDATE}" )
+     ensdir="${base_dir}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}"
+     mpasout_m001="${ensdir}/fcst/enkf/mem001/${mpasout_file}"
+     init_m001="${ensdir}/ic/enkf/mem001/init.nc"
+
+     found_data=false # Track if we linked anything
+
+     if [[ "${HYB_ENS_TYPE}" == "1" &&  -s "${mpasout_m001}" ]]; then # rrfsens
+         echo "use rrfs ensembles"
+         for (( iii=1; iii<=ens_size; iii=iii+1 )); do
             memid=$(printf %03d "${iii}")
             ln -s "${ensdir}/fcst/enkf/mem${memid}/${mpasout_file}" "ens/mem${memid}.nc"
          done
-       fi
-    done
-  elif [[ "${HYB_ENS_TYPE}" == "2"  ]]; then # interpolated GDAS/GEFFS
-    echo "use interpolated GDAS/GEFS ensembles"
-    init_file=init.nc
-    for (( ii=0; ii<7; ii=ii+1 )); do
-       CDATEp=$(${NDATE} "-${ii}" "${CDATE}" )
-       if [[ "${HYB_ENS_PATH}" == "" ]]; then
-         ensdir=${COMINrrfs}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
-       else
-         ensdir=${HYB_ENS_PATH}/rrfs.${CDATEp:0:8}/${CDATEp:8:2}
-       fi
-       ensdir_m001=${ensdir}/ic/enkf/mem001
-       if [[ -s "${ensdir_m001}/${init_file}" ]]; then
-         for (( iii=1; iii<31; iii=iii+1 )); do
+         found_data=true
+     elif [[ "${HYB_ENS_TYPE}" == "2" &&  -s "${init_m001}"  ]]; then # interpolated GDAS/GEFFS
+         echo "use interpolated GDAS/GEFS ensembles"
+         for (( iii=1; iii<=ens_size; iii=iii+1 )); do
             memid=$(printf %03d "${iii}")
-            ln -s "${ensdir}/ic/enkf/mem${memid}/${init_file}" "ens/mem${memid}.nc"
+            ln -s "${ensdir}/ic/enkf/mem${memid}/init.nc" "ens/mem${memid}.nc"
          done
+         found_data=true
+     elif [[ "${HYB_ENS_TYPE}" == "0"  ]]; then # rrfsens->GDAS->3DVAR
+       echo "determine the ensemble type on the fly"
+       if [[ -s "${mpasout_m001}" ]]; then
+         echo "use rrfs ensembles"
+         for (( iii=1; iii<=ens_size; iii=iii+1 )); do
+            memid=$(printf %03d "${iii}")
+            ln -s "${ensdir}/fcst/enkf/mem${memid}/${mpasout_file}" "ens/mem${memid}.nc"
+         done
+         found_data=true
+       elif [[ -s "${init_m001}" ]]; then
+         echo "use interpolated GDAS/GEFS ensembles"
+         for (( iii=1; iii<=ens_size; iii=iii+1 )); do
+            memid=$(printf %03d "${iii}")
+            ln -s "${ensdir}/ic/enkf/mem${memid}/init.nc" "ens/mem${memid}.nc"
+         done
+         found_data=true
        fi
-    done
+     fi
+# Break if we actually found and linked files
+     if [[ "$found_data" == "true" ]]; then break; fi
+  done
 
-  elif [[ "${HYB_ENS_TYPE}" == "0"  ]]; then # rrfsens->GDAS->3DVAR
-    echo "determine the ensemble type on the fly"
-    echo "==== to be implemented ===="
+# Check if we failed to find data after checking all enshrs
+  if [[ "$found_data" == "false" ]]; then
+    echo "No ensemble files found within the ${enshrs} hour look-back window."
   fi
+
 fi

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -75,13 +75,9 @@ def jedivar(xmlFile, expdir, do_spinup=False):
         HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
 
     ens_dep = ""
-    need_ens_dep = False
-    if realtime.upper() == "TRUE":
-        ens_dep = ""
 
-    elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "1":  # rrfsens
+    if HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "1":  # rrfsens
         RUN = 'rrfs'
-        need_ens_dep = True
         for enshrs in range(1, int(ens_bec_look_back_hrs) + 1):
             for i in range(1, int(ens_size) + 1):
                 ensindexstr = f'mem{i:03d}'
@@ -89,7 +85,6 @@ def jedivar(xmlFile, expdir, do_spinup=False):
 
     elif HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "2":  # interpolated GDAS/GEFS
         RUN = 'rrfs'
-        need_ens_dep = True
         ens_dep = f'''
     <or>
       <datadep age="00:05:00"><cyclestr  offset="0:00:00">{HYB_ENS_PATH}/{RUN}.@Y@m@d/@H/ic/enkf/mem030/init.nc</cyclestr></datadep>
@@ -116,7 +111,7 @@ def jedivar(xmlFile, expdir, do_spinup=False):
     coldhrs = coldhrs.split(' ')
     strneqs = ""
     streqs = ""
-    if need_ens_dep and coldstart_cyc_do_da.upper() == "FALSE":  # if no DA at coldstart cycs, skip checking ensembles
+    if coldstart_cyc_do_da.upper() == "FALSE":  # if no DA at coldstart cycs, skip checking ensembles
         spaces = " " * 6
         streqs = '<or>'
         strneqs = ""

--- a/workflow/rocoto_funcs/save_for_next.py
+++ b/workflow/rocoto_funcs/save_for_next.py
@@ -38,8 +38,8 @@ def save_for_next(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     #
     dependencies = f'''
   <dependency>
-    <and>{timedep}{datadep}
-    </and>
+  <and>{timedep}{datadep}
+  </and>
   </dependency>'''
 
     #

--- a/workflow/rocoto_funcs/save_for_next.py
+++ b/workflow/rocoto_funcs/save_for_next.py
@@ -37,7 +37,9 @@ def save_for_next(xmlFile, expdir, do_ensemble=False, do_spinup=False):
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
     dependencies = f'''
-  <dependency>{timedep}{datadep}
+  <dependency>
+    <and>{timedep}{datadep}
+    </and>
   </dependency>'''
 
     #


### PR DESCRIPTION



## DESCRIPTION OF CHANGES: 
Fix the ensemble data check for jedivar. When HYB_ENS_TYPE=0, the jedivar task searches for ensemble files (RRFS, then GDAS). If an insufficient number of files are found, the system defaults to 3DVAR. This approach is ideal for real-time runs where maintaining cycle continuity is prioritized over strict ensemble dependency.
Minor fix for dependency in save_for_next.py

## TESTS CONDUCTED: 
Tested for conus12km.
