### PR TITLE
[rrfs-mpas-jedi] fix NaN issue on Jet,Hera and Derecho

### DIFF
--- a/sorc/_workaround_/RDASApp/gsibec/compute_qvar3d.F90
+++ b/sorc/_workaround_/RDASApp/gsibec/compute_qvar3d.F90
@@ -139,8 +139,13 @@ subroutine compute_qvar3d
         do j=1,lon2
            do i=1,lat2
               rhgues(i,j,k)=qgues(i,j,k)/qsatg(i,j,k)
-              if(regional .and. ges_tsen(i,j,k,ntguessig) < rmiss_th) then
+              !if(regional .and. ges_tsen(i,j,k,ntguessig) < rmiss_th) then
+              if(regional .and. abs(ges_tsen(i,j,k,ntguessig)) > 1.0e30) then
                 rhgues(i,j,k)=0.5
+              endif
+              if(.not.abs(rhgues(i,j,k))<1000.) then
+                write(6,*)"Error: rhgues setting", rhgues(i,j,k)
+                call stop2(540)
               endif
            end do
         end do

--- a/sorc/_workaround_/RDASApp/gsibec/control2state.F90
+++ b/sorc/_workaround_/RDASApp/gsibec/control2state.F90
@@ -61,6 +61,7 @@ use control_vectors, only: cvars3d,cvars2d
 use bias_predictors, only: predictors
 use gridmod, only: regional,lat2,lon2,nsig, nlat, nlon, twodvar_regional, mpas_regional 
 use jfunc, only: nsclen,npclen,ntclen
+use jfunc, only: qoption
 use gsi_4dvar, only: nsubwin, l4dvar, lsqrtb, ladtest_obs
 #ifdef USE_ALL_ORIGINAL
 use cwhydromod, only: cw2hydro_tl

--- a/sorc/_workaround_/RDASApp/gsibec/control2state_ad.F90
+++ b/sorc/_workaround_/RDASApp/gsibec/control2state_ad.F90
@@ -56,6 +56,7 @@ use control_vectors, only: cvars3d,cvars2d
 use bias_predictors, only: predictors
 use gridmod, only: regional,lat2,lon2,nsig,twodvar_regional,mpas_regional
 use jfunc, only: nsclen,npclen,ntclen
+use jfunc, only: qoption
 use gsi_4dvar, only: nsubwin, lsqrtb
 #ifdef USE_ALL_ORIGINAL
 use cwhydromod, only: cw2hydro_ad

--- a/sorc/_workaround_/RDASApp/gsibec/gsi_convert_cv_mod.f90
+++ b/sorc/_workaround_/RDASApp/gsibec/gsi_convert_cv_mod.f90
@@ -71,7 +71,8 @@ subroutine tv_to_t_tl_(tv,tv_tl,q,q_tl,t_tl,t)
    do j = 1, size(t_tl,2)
      do i = 1, size(t_tl,1)
  
-       if(t(i,j,k) < rmiss_th) then
+       !if(t(i,j,k) < rmiss_th) then
+       if(abs(t(i,j,k)) > 1.0e30) then
          t_tl(i,j,k) = zero
          cycle
        endif
@@ -107,7 +108,8 @@ subroutine tv_to_t_ad_(tv,tv_ad,q,q_ad,t_ad,t)
    do j = 1, size(t_ad,2)
      do i = 1, size(t_ad,1)
 
-       if(t(i,j,k) < rmiss_th) then
+       !if(t(i,j,k) < rmiss_th) then
+       if(abs(t(i,j,k)) > 1.0e30) then
          tv_ad(i,j,k) = zero
          q_ad(i,j,k) = zero
          t_ad(i,j,k) = zero

--- a/sorc/_workaround_/RDASApp/gsibec/normal_rh_to_q.f90
+++ b/sorc/_workaround_/RDASApp/gsibec/normal_rh_to_q.f90
@@ -50,7 +50,8 @@ subroutine normal_rh_to_q(rhnorm,t,p,q)
    do k=1,nsig
       do j=1,lon2
          do i=1,lat2
-            if(regional .and. ges_tsen(i,j,k,ntguessig) < rmiss_th) then
+            !if(regional .and. ges_tsen(i,j,k,ntguessig) < rmiss_th) then
+            if(regional .and. abs(ges_tsen(i,j,k,ntguessig)) > 1.0e30) then
               q(i,j,k) = zero
               cycle
             endif
@@ -124,7 +125,8 @@ subroutine normal_rh_to_q_ad(rhnorm,t,p,q)
    do k=1,nsig
       do j=1,lon2
          do i=1,lat2
-            if(regional .and. ges_tsen(i,j,k,ntguessig) < rmiss_th) then
+            !if(regional .and. ges_tsen(i,j,k,ntguessig) < rmiss_th) then
+            if(regional .and. abs(ges_tsen(i,j,k,ntguessig)) > 1.0e30) then
               rhnorm(i,j,k) = zero
               if ( qoption == 2 ) then
                 t(i,j,k  ) = zero


### PR DESCRIPTION
This PR updates a few gsibec workaround codes to prevent NaNs from appearing when rrfs-workflow is run on Jet, Hera and  Derecho.





