### PR TITLE
[rrfs-mpas-jedi]Add ensemble forecast grouping

### DIFF
--- a/workflow/rocoto_funcs/ensmean.py
+++ b/workflow/rocoto_funcs/ensmean.py
@@ -5,7 +5,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of ensmean --------------------------------------------------------
 
 
-def ensmean(xmlFile, expdir):
+def ensmean(xmlFile, fcst_dep, expdir):
     meta_id = 'ensmean'
     cycledefs = 'prod'
     #
@@ -42,8 +42,7 @@ def ensmean(xmlFile, expdir):
     #
     dependencies = f'''
   <dependency>
-  <and>{timedep}
-    <metataskdep metatask="fcst"/>
+  <and>{timedep}{fcst_dep}
   </and>
   </dependency>'''
     #

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -7,7 +7,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 
 def fcst(xmlFile, expdir, dcGrpInfo=None, do_ensemble=False, do_spinup=False):
     meta_id = 'fcst'
-    dep_xml=""
+    dep_xml = ""
     if do_spinup:
         cycledefs = 'spinup'
         num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
@@ -68,7 +68,6 @@ def fcst(xmlFile, expdir, dcGrpInfo=None, do_ensemble=False, do_spinup=False):
         dcTaskEnv['ENS_INDEX'] = "#ens_index#"
         meta_bgn = ""
         meta_end = ""
-        ens_size = int(os.getenv('ENS_SIZE', '2'))
         meta_bgn = f'''
 <metatask name="{batch_name}">
 <var name="ens_index">{members}</var>'''

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -5,7 +5,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of fcst --------------------------------------------------------
 
 
-def fcst(xmlFile, expdir, dcGrpInfo=None, do_ensemble=False, do_spinup=False):
+def fcst(xmlFile, expdir, dcEnsGrpInfo=None, do_ensemble=False, do_spinup=False):
     meta_id = 'fcst'
     dep_xml = ""
     if do_spinup:
@@ -60,17 +60,20 @@ def fcst(xmlFile, expdir, dcGrpInfo=None, do_ensemble=False, do_spinup=False):
         meta_end = ""
         ensindexstr = ""
     else:
-        members = dcGrpInfo["members"]
-        dep_xml = dcGrpInfo["dependency_xml"]
-        batch_name = dcGrpInfo["batch_name"]
+        if dcEnsGrpInfo is None:
+            print('dcEnsGrpInfo not set up or incorrect!')
+            sys.exit(1)
+        ens_indices = dcEnsGrpInfo["ens_indices"]
+        dep_xml = dcEnsGrpInfo["dep_xml"]
+        group_name = dcEnsGrpInfo["group_name"]
         metatask = True
         task_id = f'{meta_id}_m#ens_index#'
         dcTaskEnv['ENS_INDEX'] = "#ens_index#"
         meta_bgn = ""
         meta_end = ""
         meta_bgn = f'''
-<metatask name="{batch_name}">
-<var name="ens_index">{members}</var>'''
+<metatask name="{group_name}">
+<var name="ens_index">{ens_indices}</var>'''
         meta_end = f'\
 </metatask>\n'
         ensindexstr = "_m#ens_index#"

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import sys
 from rocoto_funcs.base import xml_task, get_cascade_env
 
 # begin of fcst --------------------------------------------------------

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -5,8 +5,9 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of fcst --------------------------------------------------------
 
 
-def fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
+def fcst(xmlFile, expdir, dcGrpInfo=None, do_ensemble=False, do_spinup=False):
     meta_id = 'fcst'
+    dep_xml=""
     if do_spinup:
         cycledefs = 'spinup'
         num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
@@ -59,16 +60,18 @@ def fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
         meta_end = ""
         ensindexstr = ""
     else:
+        members = dcGrpInfo["members"]
+        dep_xml = dcGrpInfo["dependency_xml"]
+        batch_name = dcGrpInfo["batch_name"]
         metatask = True
         task_id = f'{meta_id}_m#ens_index#'
         dcTaskEnv['ENS_INDEX'] = "#ens_index#"
         meta_bgn = ""
         meta_end = ""
         ens_size = int(os.getenv('ENS_SIZE', '2'))
-        ens_indices = ''.join(f'{i:03d} ' for i in range(1, int(ens_size) + 1)).strip()
         meta_bgn = f'''
-<metatask name="{meta_id}">
-<var name="ens_index">{ens_indices}</var>'''
+<metatask name="{batch_name}">
+<var name="ens_index">{members}</var>'''
         meta_end = f'\
 </metatask>\n'
         ensindexstr = "_m#ens_index#"
@@ -111,7 +114,7 @@ def fcst(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     dependencies = f'''
   <dependency>
   <and>{timedep}{prep_lbc_dep}
-    {prep_ic_dep}{jedidep}{chemdep}{cloudana_dep}{recenterdep}
+    {prep_ic_dep}{jedidep}{chemdep}{cloudana_dep}{recenterdep}{dep_xml}
   </and>
   </dependency>'''
 

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -6,7 +6,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of fcst --------------------------------------------------------
 
 
-def fcst(xmlFile, expdir, dcEnsGrpInfo=None, do_ensemble=False, do_spinup=False):
+def fcst(xmlFile, expdir, do_ensemble=False, dcEnsGrpInfo=None, do_spinup=False):
     meta_id = 'fcst'
     dep_xml = ""
     if do_spinup:

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -155,9 +155,9 @@ def setup_xml(HOMErrfs, expdir):
                     getkf(xmlFile, expdir, 'POST')
             if os.getenv("DO_NONVAR_CLOUD_ANA", "FALSE").upper() == "TRUE":
                 nonvar_cldana(xmlFile, expdir, do_ensemble=True)
-            listGrpInfo = smart_ens_groups('fcst')
-            for dcGrpInfo in listGrpInfo["group_list"]:
-                fcst(xmlFile, expdir, dcGrpInfo, do_ensemble=True)
+            listEnsGrpInfo = smart_ens_groups('fcst')
+            for dcEnsGrpInfo in listEnsGrpInfo["group_list"]:
+                fcst(xmlFile, expdir, dcEnsGrpInfo, do_ensemble=True)
             if os.getenv('DO_CYC', 'FALSE').upper() == "TRUE":
                 save_for_next(xmlFile, expdir, do_ensemble=True)
             if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
@@ -165,7 +165,7 @@ def setup_xml(HOMErrfs, expdir):
                     mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True)
                     upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True)
             if do_ensmean_post == "TRUE":
-                fcst_dep = listGrpInfo["combined_dependency_xml"]
+                fcst_dep = listEnsGrpInfo["combined_dep_xml"]
                 ensmean(xmlFile, fcst_dep, expdir)
                 for index, dcGrpInfo in enumerate(listPostGrpInfo):
                     mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True, do_ensmean_post=True)

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -14,6 +14,7 @@ from rocoto_funcs.prep_ic import prep_ic
 from rocoto_funcs.prep_lbc import prep_lbc
 from rocoto_funcs.jedivar import jedivar
 from rocoto_funcs.fcst import fcst
+from rocoto_funcs.smart_ens_groups import smart_ens_groups
 from rocoto_funcs.save_for_next import save_for_next
 from rocoto_funcs.getkf import getkf
 from rocoto_funcs.recenter import recenter
@@ -63,7 +64,10 @@ def setup_xml(HOMErrfs, expdir):
 
 # ---------------------------------------------------------------------------
 # assemble tasks for a deterministic experiment
-        if do_deterministic == "TRUE":
+        if do_deterministic == "TRUE" and os.getenv("IC_ONLY", "FALSE").upper() == "TRUE":
+            ungrib_ic(xmlFile, expdir)
+            ic(xmlFile, expdir)
+        elif do_deterministic == "TRUE":
             if os.getenv("DO_IODA", "FALSE").upper() == "TRUE":
                 if do_chemistry == "TRUE":
                     ioda_airnow(xmlFile, expdir)
@@ -147,10 +151,13 @@ def setup_xml(HOMErrfs, expdir):
             if os.getenv("DO_JEDI", "FALSE").upper() == "TRUE":
                 getkf(xmlFile, expdir, 'OBSERVER')
                 getkf(xmlFile, expdir, 'SOLVER')
-                getkf(xmlFile, expdir, 'POST')
+                if os.getenv("DO_GETKF_POST", "TRUE").upper() == "TRUE":
+                    getkf(xmlFile, expdir, 'POST')
             if os.getenv("DO_NONVAR_CLOUD_ANA", "FALSE").upper() == "TRUE":
                 nonvar_cldana(xmlFile, expdir, do_ensemble=True)
-            fcst(xmlFile, expdir, do_ensemble=True)
+            listGrpInfo = smart_ens_groups('fcst')
+            for dcGrpInfo in listGrpInfo["group_list"]:
+                fcst(xmlFile, expdir, dcGrpInfo, do_ensemble=True)
             if os.getenv('DO_CYC', 'FALSE').upper() == "TRUE":
                 save_for_next(xmlFile, expdir, do_ensemble=True)
             if os.getenv("DO_POST", "TRUE").upper() == "TRUE":
@@ -158,7 +165,8 @@ def setup_xml(HOMErrfs, expdir):
                     mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True)
                     upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True)
             if do_ensmean_post == "TRUE":
-                ensmean(xmlFile, expdir)
+                fcst_dep = listGrpInfo["combined_dependency_xml"]
+                ensmean(xmlFile, fcst_dep, expdir)
                 for index, dcGrpInfo in enumerate(listPostGrpInfo):
                     mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True, do_ensmean_post=True)
                     upp(xmlFile, expdir, index, dcGrpInfo, do_ensemble=True, do_ensmean_post=True)

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -157,7 +157,7 @@ def setup_xml(HOMErrfs, expdir):
                 nonvar_cldana(xmlFile, expdir, do_ensemble=True)
             listEnsGrpInfo = smart_ens_groups('fcst')
             for dcEnsGrpInfo in listEnsGrpInfo["group_list"]:
-                fcst(xmlFile, expdir, dcEnsGrpInfo, do_ensemble=True)
+                fcst(xmlFile, expdir, do_ensemble=True, dcEnsGrpInfo=dcEnsGrpInfo)
             if os.getenv('DO_CYC', 'FALSE').upper() == "TRUE":
                 save_for_next(xmlFile, expdir, do_ensemble=True)
             if os.getenv("DO_POST", "TRUE").upper() == "TRUE":

--- a/workflow/rocoto_funcs/smart_ens_groups.py
+++ b/workflow/rocoto_funcs/smart_ens_groups.py
@@ -6,6 +6,7 @@ def smart_ens_groups(meta_id):
     list_group_info = []
     ens_size = int(os.getenv('ENS_SIZE', '30'))
     num_groups = int(os.getenv('NUM_ENS_GROUPS', '1'))
+    ens_threshold = os.getenv('ENS_FINISH_THRESHOLD', '1.0')
 
     # 1. Generate padded IDs (001, 002...)
     all_indices = [f'{i:03d}' for i in range(1, ens_size + 1)]
@@ -30,7 +31,7 @@ def smart_ens_groups(meta_id):
             # Dependency points to the previous range label
             prev_range = f"{groups[i-1][0]}-{groups[i-1][-1]}"
             current_group_name = f"{meta_id}_{groups[i][0]}-{groups[i][-1]}"
-            dependency_xml = f'\n    <metataskdep metatask="{meta_id}_{prev_range}"/>'
+            dependency_xml = f'\n    <metataskdep metatask="{meta_id}_{prev_range}"   threshold="{ens_threshold}"/>'
 
         list_group_info.append({
             "members": ' '.join(group_indices),

--- a/workflow/rocoto_funcs/smart_ens_groups.py
+++ b/workflow/rocoto_funcs/smart_ens_groups.py
@@ -48,4 +48,3 @@ def smart_ens_groups(meta_id):
         "group_list": list_group_info,
         "combined_dep_xml": xml_grp
     }
-

--- a/workflow/rocoto_funcs/smart_ens_groups.py
+++ b/workflow/rocoto_funcs/smart_ens_groups.py
@@ -6,10 +6,7 @@ def smart_ens_groups(meta_id):
     list_group_info = []
     ens_size = int(os.getenv('ENS_SIZE', '30'))
     num_groups = int(os.getenv('ENS_GROUP_TOT_NUM', '1'))
-    try:
-        ens_threshold = float(os.getenv('ENS_FINISH_THRESHOLD', '1.0'))
-    except ValueError:
-        ens_threshold = 1.0  # Fallback if the input is "abc"
+    ens_metadep_frac_threshold = float(os.getenv('ENS_METADEP_FRAC_THRESHOLD', '1.0'))
 
     # 1. Generate padded IDs (001, 002...)
     all_indices = [f'{i:03d}' for i in range(1, ens_size + 1)]
@@ -31,7 +28,7 @@ def smart_ens_groups(meta_id):
         if i > 0:
             # Dependency points to the previous range label
             prev_group = f"{meta_id}_g{i-1:02d}"
-            dep_xml = f'\n    <metataskdep metatask="{prev_group}"   threshold="{ens_threshold:.1f}"/>'
+            dep_xml = f'\n    <metataskdep metatask="{prev_group}" threshold="{ens_metadep_frac_threshold:.1f}"/>'
 
         list_group_info.append({
             "ens_indices": ' '.join(group_indices),

--- a/workflow/rocoto_funcs/smart_ens_groups.py
+++ b/workflow/rocoto_funcs/smart_ens_groups.py
@@ -15,7 +15,7 @@ def smart_ens_groups(meta_id):
     groups = [all_indices[i * k + min(i, m): (i + 1) * k + min(i + 1, m)] for i in range(num_groups)]
 
     # 3. Build group info and XML dependencies
-    xml_grp = "" # Define dependency for all the groups, prepare for subsequent tasks
+    xml_grp = ""   # Define dependency for all the groups, prepare for subsequent tasks
 
     for i, group_indices in enumerate(groups):
         # Create the range string: "001-015"

--- a/workflow/rocoto_funcs/smart_ens_groups.py
+++ b/workflow/rocoto_funcs/smart_ens_groups.py
@@ -5,8 +5,11 @@ import os
 def smart_ens_groups(meta_id):
     list_group_info = []
     ens_size = int(os.getenv('ENS_SIZE', '30'))
-    num_groups = int(os.getenv('NUM_ENS_GROUPS', '1'))
-    ens_threshold = os.getenv('ENS_FINISH_THRESHOLD', '1.0')
+    num_groups = int(os.getenv('ENS_GROUP_TOT_NUM', '1'))
+    try:
+        ens_threshold = float(os.getenv('ENS_FINISH_THRESHOLD', '1.0'))
+    except ValueError:
+        ens_threshold = 1.0  # Fallback if the input is "abc"
 
     # 1. Generate padded IDs (001, 002...)
     all_indices = [f'{i:03d}' for i in range(1, ens_size + 1)]
@@ -19,25 +22,21 @@ def smart_ens_groups(meta_id):
     xml_grp = ""   # Define dependency for all the groups, prepare for subsequent tasks
 
     for i, group_indices in enumerate(groups):
-        # Create the range string: "001-015"
-        range_label = f"{group_indices[0]}-{group_indices[-1]}"
-        current_group_name = f"{meta_id}_{range_label}"
+        current_group = f"{meta_id}_g{i:02d}"
 
-        xml_grp = xml_grp + f'\n    <metataskdep metatask="{current_group_name}"/>'
+        xml_grp = xml_grp + f'\n    <metataskdep metatask="{current_group}"/>'
 
         # Define dependency: Batch 2 depends on Batch 1, etc.
-        dependency_xml = ""
+        dep_xml = ""
         if i > 0:
             # Dependency points to the previous range label
-            prev_range = f"{groups[i-1][0]}-{groups[i-1][-1]}"
-            current_group_name = f"{meta_id}_{groups[i][0]}-{groups[i][-1]}"
-            dependency_xml = f'\n    <metataskdep metatask="{meta_id}_{prev_range}"   threshold="{ens_threshold}"/>'
+            prev_group = f"{meta_id}_g{i-1:02d}"
+            dep_xml = f'\n    <metataskdep metatask="{prev_group}"   threshold="{ens_threshold:.1f}"/>'
 
         list_group_info.append({
-            "members": ' '.join(group_indices),
-            "batch_name": current_group_name,
-            "dependency_xml": dependency_xml,
-            "range": range_label  # Optional: keep the range string as a separate key
+            "ens_indices": ' '.join(group_indices),
+            "group_name": current_group,
+            "dep_xml": dep_xml,
         })
 
     # Generate a summary string of all ranges
@@ -47,9 +46,6 @@ def smart_ens_groups(meta_id):
     # Return a dictionary containing BOTH the list and the combined XML
     return {
         "group_list": list_group_info,
-        "combined_dependency_xml": xml_grp
+        "combined_dep_xml": xml_grp
     }
 
-
-# Example usage:
-# groups = smart_ens_groups("my_experiment")

--- a/workflow/rocoto_funcs/smart_ens_groups.py
+++ b/workflow/rocoto_funcs/smart_ens_groups.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import os
+
+
+def smart_ens_groups(meta_id):
+    list_group_info = []
+    ens_size = int(os.getenv('ENS_SIZE', '30'))
+    num_groups = int(os.getenv('NUM_ENS_GROUPS', '1'))
+
+    # 1. Generate padded IDs (001, 002...)
+    all_indices = [f'{i:03d}' for i in range(1, ens_size + 1)]
+
+    # 2. Split indices into N groups
+    k, m = divmod(len(all_indices), num_groups)
+    groups = [all_indices[i * k + min(i, m): (i + 1) * k + min(i + 1, m)] for i in range(num_groups)]
+
+    # 3. Build group info and XML dependencies
+    xml_grp = "" # Define dependency for all the groups, prepare for subsequent tasks
+
+    for i, group_indices in enumerate(groups):
+        # Create the range string: "001-015"
+        range_label = f"{group_indices[0]}-{group_indices[-1]}"
+        current_group_name = f"{meta_id}_{range_label}"
+
+        xml_grp = xml_grp + f'\n    <metataskdep metatask="{current_group_name}"/>'
+
+        # Define dependency: Batch 2 depends on Batch 1, etc.
+        dependency_xml = ""
+        if i > 0:
+            # Dependency points to the previous range label
+            prev_range = f"{groups[i-1][0]}-{groups[i-1][-1]}"
+            current_group_name = f"{meta_id}_{groups[i][0]}-{groups[i][-1]}"
+            dependency_xml = f'\n    <metataskdep metatask="{meta_id}_{prev_range}"/>'
+
+        list_group_info.append({
+            "members": ' '.join(group_indices),
+            "batch_name": current_group_name,
+            "dependency_xml": dependency_xml,
+            "range": range_label  # Optional: keep the range string as a separate key
+        })
+
+    # Generate a summary string of all ranges
+    ranges_summary = ", ".join([f"{g[0]}-{g[-1]}" for g in groups])
+    print(f"Ensemble member {meta_id} in groups: {ranges_summary}")
+
+    # Return a dictionary containing BOTH the list and the combined XML
+    return {
+        "group_list": list_group_info,
+        "combined_dependency_xml": xml_grp
+    }
+
+
+# Example usage:
+# groups = smart_ens_groups("my_experiment")


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
In real-tims runs on Ursa, to make best usage of the reservations and avoid competing resources with the other runs using the same reservations, it might help to divide the ensemble members forecast into several batches by setting `ENS_GROUP_TOT_NUM` in the exp file (default=1, not to divide into >1 groups). This PR follows the similar logic as in https://github.com/NOAA-EMC/rrfs-workflow/pull/1334 and adds the ensemble grouping for the members forecast. In some cases, we might need to wait until the previous batch of ensemble forecast tasks to be fully completed (`ENS_FINISH_THRESHOLD=1.0`, default) or half of the members finished (by setting `ENS_FINISH_THRESHOLD=0.5`) or not to wait for the completion of previous batch of tasks at all (by setting `ENS_FINISH_THRESHOLD=0.0`).
This ensemble grouping can be extended to other ensemble member tasks if needed.  

## TESTS CONDUCTED: 
Tested in retro. 



