### PR TITLE
[rrfs-nco] add MACHINE variable to missing enkf job cards

### DIFF
--- a/ecf/scripts/analysis/enkf/jrrfs_enkf_radarref.ecf
+++ b/ecf/scripts/analysis/enkf/jrrfs_enkf_radarref.ecf
@@ -8,6 +8,7 @@
 #PBS -l debug=true
 
 model=rrfs
+export MACHINE=WCOSS2
 export cyc="%CYC%"
 %include <head.h>
 %include <envir-p1.h>

--- a/ecf/scripts/analysis/enkf/jrrfs_enkf_radarref_spinup.ecf
+++ b/ecf/scripts/analysis/enkf/jrrfs_enkf_radarref_spinup.ecf
@@ -8,6 +8,7 @@
 #PBS -l debug=true
 
 model=rrfs
+export MACHINE=WCOSS2
 export cyc="%CYC%"
 %include <head.h>
 %include <envir-p1.h>

--- a/ecf/scripts/analysis/enkf/jrrfs_enkf_updt.ecf
+++ b/ecf/scripts/analysis/enkf/jrrfs_enkf_updt.ecf
@@ -8,6 +8,7 @@
 #PBS -l debug=true
 
 model=rrfs
+export MACHINE=WCOSS2
 export cyc="%CYC%"
 %include <head.h>
 %include <envir-p1.h>

--- a/ecf/scripts/analysis/enkf/jrrfs_enkf_updt_spinup.ecf
+++ b/ecf/scripts/analysis/enkf/jrrfs_enkf_updt_spinup.ecf
@@ -8,6 +8,7 @@
 #PBS -l debug=true
 
 model=rrfs
+export MACHINE=WCOSS2
 export cyc="%CYC%"
 %include <head.h>
 %include <envir-p1.h>


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- adds missing MACHINE variable definitions to ecf job cards to:
  - enkf_updt (and spinup)
  - enkf_radarref (and spinup)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Fixed broken parallel runs yesterday; already running in NCO parallel.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

