### PR TITLE
[dev-sci] Modify clean task to work with retros using Rocoto

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -399,7 +399,7 @@ define resources used for each tasks
 ]>
 
 {%- if do_retro %}
-<workflow realtime="F" scheduler="&SCHED;" cyclethrottle="12">
+<workflow realtime="F" scheduler="&SCHED;" cyclethrottle="{{ cycle_throttle }}">
 {% else %}
 <workflow realtime="T" scheduler="&SCHED;" cyclethrottle="26" cyclelifespan="01:00:00:00">
 {%- endif %}
@@ -418,6 +418,7 @@ define resources used for each tasks
 {%- endif %}
   <cycledef group="recentercyc"> {{ recenter_cycledef }} </cycledef>
   <cycledef group="archive">  {{ archive_cycledef }} </cycledef> 
+  <cycledef group="clean">  {{ clean_cycledef }} </cycledef> 
 
   <log>
     <cyclestr>&LOGDIR;/FV3LAM_wflow_&TAG;.log</cyclestr>
@@ -4094,7 +4095,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&CLEAN_TN;" cycledefs="archive" maxtries="{{ maxtries_run_post }}">
+  <task name="&CLEAN_TN;" cycledefs="clean" maxtries="{{ maxtries_run_post }}">
 
     &RSRV_POST;
 
@@ -4107,6 +4108,7 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
     <envar><name>LOGDIR</name><value>&LOGDIR;</value></envar>
     <envar><name>CDATE</name><value><cyclestr offset="-4:00:00">@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLEDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
     <envar><name>NWGES_BASEDIR</name><value><cyclestr>&NWGES_BASEDIR;</cyclestr></value></envar>
 {%- if do_ensemble %}
     <envar><name>nens</name><value><cyclestr>{{ num_ens_members }}</cyclestr></value></envar>
@@ -4115,6 +4117,7 @@ MODULES_RUN_TASK_FP script.
 {%- endif %}
 
     <dependency>
+{%- if not do_retro %}
        <or>
           <and>
             <or>
@@ -4135,6 +4138,21 @@ MODULES_RUN_TASK_FP script.
             <taskdep task="&RUN_PRDGEN_TN;_f012" cycle_offset="-6:00:00"/>
           </and>
        </or>
+{%- else %}
+       <or>
+{%- if do_dacycle %}
+         <and>
+           <taskdep task="&RUN_ANALYSIS_TN;"/>
+           <taskdep task="&RUN_ANALYSIS_JEDI_TN;"/>
+         </and>
+{%- elif do_ensemble %}
+         <and>
+           <taskdep task="&RUN_ENKFUPDT_TN;"/>
+           <taskdep task="&RUN_ENKFUPDT_JEDI_TN;"/>
+         </and>
+{%- endif %}
+       </or>
+{%- endif %}
     </dependency>
 
   </task>

--- a/parm/rdas-atmosphere-templates-fv3_c13_getkf_solver.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_getkf_solver.yaml
@@ -46,7 +46,7 @@ inflation_mult: 1.0
 # Horizontal localization for GETKF
 obs_distribution_localizations:
   obs_distribution:
-    name: RoundRobin
+    name: Halo
     halo size: 500e3
   obs_localizations:
   - localization method: Horizontal Gaspari-Cohn
@@ -55,7 +55,7 @@ override_obs_distribution_localizations:
   override: true
   mrms_refl:
     obs_distribution:
-      name: RoundRobin
+      name: Halo
       halo size: 100e3
     obs_localizations:
     - localization method: Horizontal Gaspari-Cohn

--- a/scripts/exrrfs_clean.ksh
+++ b/scripts/exrrfs_clean.ksh
@@ -19,7 +19,11 @@
 # set up currentime from CDATE 
 #-----------------------------------------------------------------------
 #
-currentime=$(echo "${CDATE}" | sed 's/\([[:digit:]]\{2\}\)$/ \1/')
+if [ "${DO_RETRO}" = "TRUE" ]; then
+  currentime="${CYCLEDATE:0:8} ${CYCLEDATE:8:2}"
+else
+  currentime=$(echo "${CDATE}" | sed 's/\([[:digit:]]\{2\}\)$/ \1/')
+fi
 
 listens=$(seq 1 $nens)
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -589,6 +589,10 @@ WFLOW_LAUNCH_LOG_FN="log.launch_FV3LAM_wflow"
 # An array containing the hours of the day at which the GSI hybrid using 
 # FV3LAM ensemeble.
 #
+# CYCLE_THROTTLE:
+# Number of cycles ahead of the current cycle that can run
+# Only used for retro experiments
+#
 #-----------------------------------------------------------------------
 #
 DATE_FIRST_CYCL="YYYYMMDD"
@@ -622,6 +626,7 @@ DA_CYCLE_INTERV="1"
 RESTART_INTERVAL="1 2"
 RESTART_INTERVAL_LONG="1 2"
 CYCL_HRS_HYB_FV3LAM_ENS=( "99" )
+CYCLE_THROTTLE=12
 #-----------------------------------------------------------------------
 #
 # Set cycle definition for each group.  The cycle definition sets the cycle
@@ -677,6 +682,10 @@ CYCL_HRS_HYB_FV3LAM_ENS=( "99" )
 # cycle definition for "archive" group
 # This group runs: run_archive
 #
+# CLEAN_CYCLEDEF:
+# cycle definition for "clean" group
+# This group runs: clean
+#
 #-----------------------------------------------------------------------
 #
 CYCLEDAY="*"
@@ -690,6 +699,7 @@ PROD_CYCLEDEF="00 01 01 01 2100 *"
 RECENTER_CYCLEDEF="00 01 01 01 2100 *"
 PRODLONG_CYCLEDEF="00 01 01 01 2100 *"
 ARCHIVE_CYCLEDEF="00 01 01 01 2100 *"
+CLEAN_CYCLEDEF="00 01 01 01 2100 *"
 SAVEDA_CYCLEDEF="00 01 01 01 2100 *"
 #
 #-----------------------------------------------------------------------

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -510,7 +510,9 @@ settings="\
   'saveda_cycledef': ${SAVEDA_CYCLEDEF}
   'recenter_cycledef': ${RECENTER_CYCLEDEF}
   'archive_cycledef': ${ARCHIVE_CYCLEDEF}
+  'clean_cycledef': ${CLEAN_CYCLEDEF}
   'dt_atmos': ${DT_ATMOS}
+  'cycle_throttle': ${CYCLE_THROTTLE}
 #
 # boundary, forecast, and post process length.
 #


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

As we begin running retros on conus3km, we have observed that storing both the GSI and JEDI analyses during cycling can take up a lot of space. For example, a single cycling directory on stmp takes up nearly 7 TB for a EnKF retro. Therefore, we need to clean up these directories as we go. 

There is currently a `CLEAN` task and associated `exrrfs_clean.ksh` script. However, this script and task are designed for realtime applications and do not work with retros. Here, we update this task and script to work for retros. Changes include: 

* Clean task now defines the `currentime` variable based on the cycle time for retros. It previously defaulted to the actual current time with `CDATE` 
* For retros, the clean task now checks for either the deterministic or ensemble analysis tasks to be completed before running such that it can run for every cycle. This means it always runs whether performing a EnKF/Var retro or if product generation is disabled
* The clean task is now controlled by its own cycledef (`clean_cycledefs`) rather than relying on the archive task cycle definition (which is not always enabled for retros)
* The `cyclethrottle` value can now be configured through `config.sh`. Previously it was hardcoded to 12 cycles. This required the cleaning window to exceed 12 cycles to avoid deleting directories that might still be in use

For reference, here are my current clean settings for my conus3km EnKF retros as defined in `config.sh`: 

```
CYCLE_THROTTLE=6
CLEAN_CYCLEDEF="00 00-23 ${CYCLEDAY} ${CYCLEMONTH} ${STARTYEAR} *"
CLEAN_OLDPROD_HRS=999
CLEAN_OLDLOG_HRS=999
CLEAN_NWGES_HRS=999
CLEAN_OLDRUN_HRS=12
CLEAN_OLDFCST_HRS=12
CLEAN_OLDSTMPPOST_HRS=12
```

With this configuration, the stmp directories older than 12 hours relative to the current cycle time are removed. The prod and log directories are fully retained for validation, and the nwges directories are also preserved in order to retain ensemble backgrounds needed for JEDIVAR retros.

One more note: this PR also contains a bug fix for the JCB config files for GETKF. The solver needs to use the Halo obs distribution but was incorrectly set to RoundRobin before. 

## TESTS CONDUCTED: 

This was tested with a small, 3-member EnKF retro on conus12km to confirm that all works as expected.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None