### PR TITLE
hotfix on clean.py and Ursa MPI hangs

### DIFF
--- a/workflow/sideload/clean.py
+++ b/workflow/sideload/clean.py
@@ -46,6 +46,8 @@ def day_clean(srcPath, cyc1, cyc2, srcType, WGF):
         EXPDIR = os.getenv("EXPDIR", "EXPDIR_not_defined")
         STMP_KEPT_TASKS = os.getenv("STMP_KEPT_TASKS", "").strip()
         RUN = os.getenv("RUN", "")
+    else:
+        STMP_KEPT_TASKS = ""
 
     for i in range(cyc1, cyc2 + 1):
         if check_is_cyc_done:

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -31,6 +31,18 @@ fi
 ulimit -s unlimited
 ulimit -v unlimited
 ulimit -a
+if [[ ${MACHINE,,} == "ursa" ]]; then # special needs at ursa
+  export I_MPI_ADJUST_ALLTOALL=3
+  export I_MPI_ADJUST_ALLTOALLV=3
+  export I_MPI_ADJUST_ALLREDUCE=2
+  export I_MPI_ADJUST_BCAST=2
+  export I_MPI_ADJUST_REDUCE=2
+  export I_MPI_ADJUST_GATHER=2
+  export I_MPI_ADJUST_GATHERV=2
+  export I_MPI_ADJUST_SCATTER=2
+  export I_MPI_ADJUST_SCATTERV=2
+  export I_MPI_COLL_INTRANODE=pt2pt
+fi
 #
 echo "load rrfs-workflow modules by default"
 set +x # suppress messy output in the module load process


### PR DESCRIPTION
1. fix the clean task failures in realtime runs
2. fix the MPI hangs on Ursa using the MPI environmental variables recommended by the Ursa Admin.