### PR TITLE
[rrfs-mpas-jedi]Reduce filesize of history and diag files to minimal if DO_POST=false

### DIFF
--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -43,6 +43,14 @@ mkdir -p graphinfo stream_list
 ln -snf "${FIXrrfs}/${MESH_NAME}"/graphinfo/* graphinfo/
 ${cpreq} "${FIXrrfs}/stream_list/${PHYSICS_SUITE}"/* stream_list/
 
+# If not doing post-processing (DO_POST is not TRUE), meaning history and diag files are not needed.
+# In this case, We would only output minimal information to history and diag files, to save space
+#
+if [[ "${DO_POST}" != "TRUE" ]]; then
+  sed -i -E '/initial_time|xtime|Time/!d'  stream_list/stream_list.atmosphere.diagnostics
+  sed -i -E '/initial_time|xtime|Time/!d'  stream_list/stream_list.atmosphere.output
+fi
+
 # generate the namelist on the fly
 # do_restart already defined in the above
 start_time=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +%Y-%m-%d_%H:%M:%S) 

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -36,6 +36,7 @@ def fcst(xmlFile, expdir, do_ensemble=False, dcEnsGrpInfo=None, do_spinup=False)
         'FCST_DT': os.getenv('FCST_DT', 'FCST_DT_not_defined'),
         'FCST_SUBSTEPS': os.getenv('FCST_SUBSTEPS', 'FCST_SUBSTEPS_not_defined'),
         'FCST_RADT': os.getenv('FCST_RADT', 'FCST_RADT_not_defined'),
+        'DO_POST': os.getenv("DO_POST", "TRUE").upper(),
     }
     if os.getenv('FCST_CONVECTION_SCHEME', 'FALSE').upper() == 'TRUE':
         dcTaskEnv['FCST_CONVECTION_SCHEME'] = "TRUE"


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
For GETKF cycling without ensemble forecast, we only need mpasout files for the cycling. To reduce the disk usage and simplify the GETKF cycling workflow, we can set DO_POST to false. In this case, the history and diag files are not needed. This PR reduces the entries to minimal in stream_list files for history and diagnostics, if DO_POST=false. The filesizes for conus3km can be reduced from 31G to 11K for history files, 2G to 11K fro diag files. Unless the MPAS-Model can run with history_interval being none, this is a good work-around for saving disk space, and also slightly reducing the run-time.

## TESTS CONDUCTED: 
Successfully tested in real time and retro tests.

