### PR TITLE
allow setting history_interval to none

### DIFF
--- a/parm/streams.atmosphere
+++ b/parm/streams.atmosphere
@@ -37,7 +37,7 @@
         filename_template="history.$Y-$M-$D_$h.$m.$s.nc"
         io_type="pnetcdf,cdf5"
         clobber_mode="replace_files"
-        output_interval="@history_interval@:00:00" >
+        output_interval="@history_interval@" >
         <file name="stream_list/stream_list.atmosphere.output"/>
 </stream>
 
@@ -46,7 +46,7 @@
         filename_template="diag.$Y-$M-$D_$h.$m.$s.nc"
         io_type="pnetcdf,cdf5"
         clobber_mode="replace_files"
-        output_interval="@diag_interval@:00:00" >
+        output_interval="@diag_interval@" >
         <file name="stream_list/stream_list.atmosphere.diagnostics"/>
 </stream>
 

--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -69,6 +69,8 @@ history_interval=${HISTORY_INTERVAL:-1}
 diag_interval=${HISTORY_INTERVAL:-1}
 mpasout_interval=${MPASOUT_INTERVAL:-1}
 [[ ${restart_interval} =~ ^[0-9]+$ ]] && restart_interval="${restart_interval}:00:00"
+[[ ${history_interval} =~ ^[0-9]+$ ]] && history_interval="${history_interval}:00:00"
+[[ ${diag_interval} =~ ^[0-9]+$ ]] && diag_interval="${diag_interval}:00:00"
 [[ ${mpasout_interval} =~ ^[0-9]+$ ]] && mpasout_interval="${mpasout_interval}:00:00"
 sed -e "s/@restart_interval@/${restart_interval}/" -e "s/@history_interval@/${history_interval}/" \
     -e "s/@diag_interval@/${diag_interval}/" -e "s/@lbc_interval@/${lbc_interval}/" \
@@ -83,19 +85,29 @@ if [[ "${DO_CHEMISTRY^^}" == "TRUE" ]]; then
   source "${USHrrfs}"/chem_fcst.sh
 fi
 #
-# prelink the forecast output files to umbrella
-history_all=$(seq 0 $((10#${history_interval})) $((10#${fcst_len_hrs_thiscyc} )) )
-for fhr in ${history_all}; do
-  CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
-  timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
-  if [[ "${DO_SPINUP:-FALSE}" != "TRUE" ]];  then
-    ln -snf "${UMBRELLA_FCST_DATA}/history.${timestr}.nc" "${DATA}"
-    ln -snf "${UMBRELLA_FCST_DATA}/diag.${timestr}.nc" "${DATA}"
-    if [[ "${mpasout_interval,,}" != "none" ]]; then
+# prelink the history/diag files to umbrella
+if [[ "${history_interval,,}" != "none" ]]; then
+  history_all=$(seq 0 $((10#${history_interval})) $((10#${fcst_len_hrs_thiscyc} )) )
+  for fhr in ${history_all}; do
+    CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
+    timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
+    if [[ "${DO_SPINUP:-FALSE}" != "TRUE" ]];  then
+      ln -snf "${UMBRELLA_FCST_DATA}/history.${timestr}.nc" "${DATA}"
+      ln -snf "${UMBRELLA_FCST_DATA}/diag.${timestr}.nc" "${DATA}"
+    fi
+  done
+fi
+# prelink the mpasout files to umbrella
+if [[ "${mpasout_interval,,}" != "none" ]]; then
+  mpasout_all=$(seq 0 $((10#${mpasout_interval})) $((10#${fcst_len_hrs_thiscyc} )) )
+  for fhr in ${mpasout_all}; do
+    CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
+    timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
+    if [[ "${DO_SPINUP:-FALSE}" != "TRUE" ]];  then
       ln -snf "${UMBRELLA_FCST_DATA}/mpasout.${timestr}.nc" "${DATA}"
     fi
-  fi
-done
+  done
+fi
 
 # run the MPAS model
 source prep_step

--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -87,7 +87,7 @@ fi
 #
 # prelink the history/diag files to umbrella
 if [[ "${history_interval,,}" != "none" ]]; then
-  history_all=$(seq 0 $((10#${history_interval})) $((10#${fcst_len_hrs_thiscyc} )) )
+  history_all=$(seq 0 $((10#${history_interval%%:*})) $((10#${fcst_len_hrs_thiscyc} )) )
   for fhr in ${history_all}; do
     CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
@@ -99,7 +99,7 @@ if [[ "${history_interval,,}" != "none" ]]; then
 fi
 # prelink the mpasout files to umbrella
 if [[ "${mpasout_interval,,}" != "none" ]]; then
-  mpasout_all=$(seq 0 $((10#${mpasout_interval})) $((10#${fcst_len_hrs_thiscyc} )) )
+  mpasout_all=$(seq 0 $((10#${mpasout_interval%%:*})) $((10#${fcst_len_hrs_thiscyc} )) )
   for fhr in ${mpasout_all}; do
     CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -33,6 +33,11 @@ else
   export PREP_LBC_LOOK_BACK_HRS=${PREP_LBC_LOOK_BACK_HRS:-${lbc_step_hrs}}
 fi
 
+# if HISTORY_INTERVAL=none, set DO_POST=false
+if [[ "${history_interval,,}" != "none" ]]; then
+  DO_POST=false
+fi
+
 # DO_CLEAN
 if ${DO_CLEAN:-false} && ! ${REALTIME:-false}; then
   export STMP_RETENTION_CYCS=${STMP_RETENTION_CYCS:-2}

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -34,7 +34,7 @@ else
 fi
 
 # if HISTORY_INTERVAL=none, set DO_POST=false
-if [[ "${history_interval,,}" != "none" ]]; then
+if [[ "${HISTORY_INTERVAL,,}" != "none" ]]; then
   DO_POST=false
 fi
 

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -34,8 +34,8 @@ else
 fi
 
 # if HISTORY_INTERVAL=none, set DO_POST=false
-if [[ "${HISTORY_INTERVAL,,}" != "none" ]]; then
-  DO_POST=false
+if [[ "${HISTORY_INTERVAL,,}" == "none" ]]; then
+  export DO_POST=false
 fi
 
 # DO_CLEAN


### PR DESCRIPTION
This PR addresses the need to only output mpasout files and NO history NOR diag outputs.

Because the post job depends on history files. So setting `HISTORY_INTERVAL=none` will automatically disable all post tasks.