### PR TITLE
simply the cycledef_spinup setting using 'valid_hours'

### DIFF
--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -12,11 +12,6 @@ def fcst(xmlFile, expdir, do_ensemble=False, dcEnsGrpInfo=None, do_spinup=False)
     dep_xml = ""
     if do_spinup:
         cycledefs = 'spinup'
-        num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
-        if num_spinup_cycledef == '2':
-            cycledefs = 'spinup,spinup2'
-        elif num_spinup_cycledef == '3':
-            cycledefs = 'spinup,spinup2,spinup3'
     else:
         cycledefs = 'prod'
     # Task-specific EnVars beyond the task_common_vars

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -8,11 +8,6 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def jedivar(xmlFile, expdir, do_spinup=False):
     if do_spinup:
         cycledefs = 'spinup'
-        num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
-        if num_spinup_cycledef == '2':
-            cycledefs = 'spinup,spinup2'
-        elif num_spinup_cycledef == '3':
-            cycledefs = 'spinup,spinup2,spinup3'
         task_id = 'jedivar_spinup'
     else:
         cycledefs = 'prod'

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -9,11 +9,6 @@ def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     meta_id = 'nonvar_cldana'
     if do_spinup:
         cycledefs = 'spinup'
-        num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
-        if num_spinup_cycledef == '2':
-            cycledefs = 'spinup,spinup2'
-        elif num_spinup_cycledef == '3':
-            cycledefs = 'spinup,spinup2,spinup3'
     else:
         cycledefs = 'prod'
     # Task-specific EnVars beyond the task_common_vars

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -12,11 +12,6 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     # -1 = a prod cycle parallel to spinup cycles
     if spinup_mode == 1:
         cycledefs = 'spinup'
-        num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
-        if num_spinup_cycledef == '2':
-            cycledefs = 'spinup,spinup2'
-        elif num_spinup_cycledef == '3':
-            cycledefs = 'spinup,spinup2,spinup3'
     else:
         cycledefs = 'prod'
     coldhrs = os.getenv('COLDSTART_CYCS', '03 15')

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import calendar
 from datetime import datetime, timedelta
 
 
@@ -8,7 +7,9 @@ def smart_cycledefs():
     # If users set CYCLEDEF_* variables explicitly in exp.setup, then just use it
     # otherwise calculate cycledef smartly
 
-    num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '0')
+    warmda_only = os.getenv('COLDSTART_CYCS_DO_DA', 'FALSE').upper() == "FALSE"
+    cycledef_warmda = ""
+
     cycledef_ic = os.getenv('CYCLEDEF_IC', 'not_defined')
     if cycledef_ic != 'not_defined':
         cycledef_lbc = os.getenv('CYCLEDEF_LBC', 'not_defined')
@@ -17,7 +18,6 @@ def smart_cycledefs():
     else:  # compute cycledef automatically if no CYCLEDEF_* environment variables
         lbc_cycs = os.getenv('LBC_CYCS', '00 12').strip().split()
         lbc_step = str(int(24 / len(lbc_cycs)))
-        lbc_startcyc = lbc_cycs[0]
         cyc_interval = os.getenv('CYC_INTERVAL', '3')
         cold_cycs = os.getenv('COLDSTART_CYCS', '03 15').strip().split()
         ic_step = str(int(24 / len(cold_cycs)))
@@ -25,81 +25,43 @@ def smart_cycledefs():
             cyc_interval = ic_step
         prodswitch_cycs = os.getenv('PRODSWITCH_CYCS', '09 21').strip().split()
         # compute spinup_hrs (usually coldstart at 03 or 15)
-        spinup_hrs = cold_cycs[0] + "-" + f'{int(prodswitch_cycs[0])-1:02},'
+        spinup_hrs = list(range(int(cold_cycs[0]), int(prodswitch_cycs[0])))
         if len(cold_cycs) > 1:
-            half_spinup = cold_cycs[1] + "-" + f'{int(prodswitch_cycs[1])-1:02}'
-            spinup_hrs += half_spinup
+            spinup_hrs.extend(list(range(int(cold_cycs[1]), int(prodswitch_cycs[1]))))
         #
         realtime = os.getenv('REALTIME', 'false')
         spinup = os.getenv('DO_SPINUP', 'false')
         if realtime.upper() == "TRUE":
-            cycledef_ic = f'''  &Y1;&M1;&D1;{cold_cycs[0]}00 &Y2;&M2;&D2;2300 {ic_step.zfill(2)}:00:00'''
-            cycledef_lbc = f''' &Y1;&M1;&D1;{lbc_startcyc.zfill(2)}00 &Y2;&M2;&D2;2300 {lbc_step.zfill(2)}:00:00'''
-            cycledef_prod = f'''&Y1;&M1;&D1;0000 &Y2;&M2;&D2;2300 {cyc_interval.zfill(2)}:00:00'''
-            if spinup.upper() == 'TRUE':
-                cycledef_spinup = f'''00 {spinup_hrs} * &M1;,&M2; &Y1;,&Y2; *'''
-                num_spinup_cycledef = 1
-        #
+            cycledef_ic = f'  &Y1;&M1;&D1;{cold_cycs[0]}00 &Y2;&M2;&D2;2300 {ic_step.zfill(2)}:00:00'
+            cycledef_lbc = f' &Y1;&M1;&D1;{lbc_cycs[0]}00 &Y2;&M2;&D2;2300 {lbc_step.zfill(2)}:00:00'
+            cycledef_prod = f'&Y1;&M1;&D1;0000 &Y2;&M2;&D2;2300 {cyc_interval.zfill(2)}:00:00'
+            cycledef_spinup = cycledef_prod
+        # ~~~~~
         # retros write out cycledefs explicitly without referencing XML entities
-        elif spinup.upper() != "TRUE":  # no spinup cycles
+        else:
             retrodates = os.getenv('RETRO_PERIOD', '2225010100-2225010800').split("-")
-            cycledef_ic = f'''  {retrodates[0]}00 {retrodates[1]}00 {ic_step.zfill(2)}:00:00'''
-            cycledef_lbc = f''' {retrodates[0]}00 {retrodates[1]}00 {lbc_step.zfill(2)}:00:00'''
-            cycledef_prod = f'''{retrodates[0]}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'''
-        else:  # spinup cycles enabled
-            retrodates = os.getenv('RETRO_PERIOD', '2225010100-2225010800').split("-")
-            date1 = datetime.strptime(retrodates[0], "%Y%m%d%H")
-            date2 = datetime.strptime(retrodates[1], "%Y%m%d%H")
-            if date1.hour < 12:  # either start from 0z or from 12z depsite of user's start hour
-                date1.replace(hour=0)
+            hour1 = retrodates[0][8:10]
+            if spinup.upper() == "TRUE":
+                if hour1 < 12:  # determine the first prod_cyc
+                    prod_cyc1 = prodswitch_cycs[0]
+                else:
+                    prod_cyc1 = prodswitch_cycs[0]
             else:
-                date1.replace(hour=12)
+                prod_cyc1 = cold_cycs[0]  # no spin up, prod_cyc starts from the first cold start cyc
             #
-            if date1.year == date2.year and date1.month == date2.month:
-                if date1.hour == 0:
-                    prod_cyc1 = f'{int(prodswitch_cycs[0]):02}'
-                    cycledef_spinup = f'''00 {spinup_hrs} {date1.day:02}-{date2.day:02} {date1.month:02} {date1.year:04} *'''
-                    num_spinup_cycledef = 1
-                else:  # 12z
-                    prod_cyc1 = f'{int(prodswitch_cycs[1]):02}'
-                    date1b = date1 + timedelta(hours=12)
-                    cycledef_spinup = f'''00 {half_spinup} {date1.day:02} {date1.month:02} {date1.year:04} *'''
-                    cycledef_spinup2 = f'''00 {spinup_hrs} {date1b.day:02}-{date2.day:02} {date1.month:02} {date1.year:04} *'''
-                    num_spinup_cycledef = 2
-            else:  # different month, year
-                lastday = calendar.monthrange(date1.year, date1.month)[1]  # find the last day of a calendar month
-                if date1.hour == 0:
-                    prod_cyc1 = f'{int(prodswitch_cycs[0]):02}'
-                    cycledef_spinup = f'''00 {spinup_hrs} {date1.day:02}-{lastday:02} {date1.month:02} {date1.year:04} *'''
-                    cycledef_spinup2 = f'''00 {spinup_hrs} 01-{date2.day:02} {date2.month:02} {date2.year:04} *'''
-                    num_spinup_cycledef = 2
-                else:  # 12z
-                    prod_cyc1 = f'{int(prodswitch_cycs[1]):02}'
-                    date1b = date1 + timedelta(hours=12)
-                    cycledef_spinup = f'''00 {half_spinup} {date1.day:02} {date1.month:02} {date1.year:04} *'''
-                    cycledef_spinup2 = f'''00 {spinup_hrs} {date1b.day:02}-{lastday:02} {date1.month:02} {date1.year:04} *'''
-                    cycledef_spinup3 = f'''00 {spinup_hrs} 01-{date2.day:02} {date2.month:02} {date2.year:04} *'''
-                    num_spinup_cycledef = 3
-            #
-            cycledef_ic = f'''  {date1.strftime("%Y%m%d")}{cold_cycs[0]}00 {retrodates[1]}00 {ic_step.zfill(2)}:00:00'''
-            cycledef_lbc = f''' {date1.strftime("%Y%m%d%H")}00 {retrodates[1]}00 {lbc_step.zfill(2)}:00:00'''
-            cycledef_prod = f'''{date1.strftime("%Y%m%d")}{prod_cyc1}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'''
+            cycledef_ic = f'  {retrodates[0][0:8]}{cold_cycs[0]}00 {retrodates[1]}00 {ic_step.zfill(2)}:00:00'
+            cycledef_lbc = f' {retrodates[0][0:8]}{lbc_cycs[0]}00 {retrodates[1]}00 {lbc_step.zfill(2)}:00:00'
+            cycledef_prod = f'{retrodates[0][0:8]}{prod_cyc1}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
+            if spinup.upper() == "TRUE":
+                cycledef_spinup = f'{retrodates[0][0:8]}{cold_cycs[0]}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
     #
     # fill in the Cycledef dictionary
     dcCycledef = {}
     dcCycledef['ic'] = f'{cycledef_ic}'
     dcCycledef['lbc'] = f'{cycledef_lbc}'
     dcCycledef['prod'] = f'{cycledef_prod}'
-    if os.getenv('DO_SPINUP', 'false').upper() == 'TRUE':
-        dcCycledef['spinup'] = f'{cycledef_spinup}'
-        if num_spinup_cycledef == 2:
-            dcCycledef['spinup2'] = f'{cycledef_spinup2}'
-        elif num_spinup_cycledef == 3:
-            dcCycledef['spinup2'] = f'{cycledef_spinup2}'
-            dcCycledef['spinup3'] = f'{cycledef_spinup3}'
-    #
-    # set the NUM_SPINUP_CYCLEDEF environment variable
-    env_vars = {'NUM_SPINUP_CYCLEDEF': f'{num_spinup_cycledef}'}
-    os.environ.update(env_vars)
-
+    if spinup.upper() == "TRUE":
+        valid_str = " ".join(f"{i}" for i in spinup_hrs)
+        dcCycledef['spinup'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_spinup}'}
+    # ~~~~
     return dcCycledef

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -7,9 +7,6 @@ def smart_cycledefs():
     # If users set CYCLEDEF_* variables explicitly in exp.setup, then just use it
     # otherwise calculate cycledef smartly
 
-    warmda_only = os.getenv('COLDSTART_CYCS_DO_DA', 'FALSE').upper() == "FALSE"
-    cycledef_warmda = ""
-
     cycledef_ic = os.getenv('CYCLEDEF_IC', 'not_defined')
     if cycledef_ic != 'not_defined':
         cycledef_lbc = os.getenv('CYCLEDEF_LBC', 'not_defined')
@@ -40,20 +37,22 @@ def smart_cycledefs():
         # retros write out cycledefs explicitly without referencing XML entities
         else:
             retrodates = os.getenv('RETRO_PERIOD', '2225010100-2225010800').split("-")
-            hour1 = retrodates[0][8:10]
-            if spinup.upper() == "TRUE":
-                if hour1 < 12:  # determine the first prod_cyc
-                    prod_cyc1 = prodswitch_cycs[0]
-                else:
-                    prod_cyc1 = prodswitch_cycs[0]
+            hour1 = int(retrodates[0][8:10])
+            if len(cold_cycs) > 1:
+                index = 0 if hour1 < 12 else 1
             else:
-                prod_cyc1 = cold_cycs[0]  # no spin up, prod_cyc starts from the first cold start cyc
+                index = 0
+            cold_cyc1 = cold_cycs[index]
+            lbc_cyc1 = lbc_cycs[index]
+            prod_cyc1 = cold_cyc1
+            if spinup.upper() == "TRUE":  # if spinup, the first prod_cyc is from prodswitch_cycs
+                prod_cyc1 = prodswitch_cycs[index]
             #
-            cycledef_ic = f'  {retrodates[0][0:8]}{cold_cycs[0]}00 {retrodates[1]}00 {ic_step.zfill(2)}:00:00'
-            cycledef_lbc = f' {retrodates[0][0:8]}{lbc_cycs[0]}00 {retrodates[1]}00 {lbc_step.zfill(2)}:00:00'
+            cycledef_ic = f'  {retrodates[0][0:8]}{cold_cyc1}00 {retrodates[1]}00 {ic_step.zfill(2)}:00:00'
+            cycledef_lbc = f' {retrodates[0][0:8]}{lbc_cyc1}00 {retrodates[1]}00 {lbc_step.zfill(2)}:00:00'
             cycledef_prod = f'{retrodates[0][0:8]}{prod_cyc1}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
             if spinup.upper() == "TRUE":
-                cycledef_spinup = f'{retrodates[0][0:8]}{cold_cycs[0]}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
+                cycledef_spinup = f'{retrodates[0][0:8]}{cold_cyc1}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
     #
     # fill in the Cycledef dictionary
     dcCycledef = {}

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-from datetime import datetime, timedelta
 
 
 def smart_cycledefs():


### PR DESCRIPTION
PR https://github.com/NOAA-EMC/rrfs-workflow/pull/1334 introduced the `valid_hours` attribute for a cycledef. 
This PR adopts this new feature in setting cycledef for spinup cycles and greatly simplifies the process.

This only affects the spinup part and I have tested that the spinup cycledef is generated as expected:
```
<cycledef group="spinup" valid_hours="3 4 5 6 7 8 15 16 17 18 19 20">202405061500 202405070000 01:00:00</cycledef>
```