### PR TITLE
Add `CYCLEDEF_PROD_EXCLUDE` to allow excluding some cycles from cycledef_prod

### DIFF
--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -57,7 +57,7 @@ def smart_cycledefs():
     dcCycledef = {}
     dcCycledef['ic'] = f'{cycledef_ic}'
     dcCycledef['lbc'] = f'{cycledef_lbc}'
-    exclude_str = os.getenv('CYCLEDEF_PROD_EXClUDE', '')
+    exclude_str = os.getenv('CYCLEDEF_PROD_EXCLUDE', '')
     if exclude_str:
         dcCycledef['prod'] = {'exclude_hours': f'{exclude_str}', "cycledef": f'{cycledef_prod}'}
     else:

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -57,7 +57,12 @@ def smart_cycledefs():
     dcCycledef = {}
     dcCycledef['ic'] = f'{cycledef_ic}'
     dcCycledef['lbc'] = f'{cycledef_lbc}'
-    dcCycledef['prod'] = f'{cycledef_prod}'
+    exclude_str = os.getenv('CYCLEDEF_PROD_EXClUDE', '')
+    if exclude_str:
+        dcCycledef['prod'] = {'exclude_hours': f'{exclude_str}', "cycledef": f'{cycledef_prod}'}
+    else:
+        dcCycledef['prod'] = f'{cycledef_prod}'
+    #
     if spinup.upper() == "TRUE":
         valid_str = " ".join(f"{i}" for i in spinup_hrs)
         dcCycledef['spinup'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_spinup}'}


### PR DESCRIPTION
The PR addresses the urgent RRFSv2X need to exclude `1 2 13 14` from the `cycledef_prod` so that we can drop four cycles to save computing resources and hence make sure the realtime runs complete successfully in time.