### PR TITLE
hotfix on smart_post_groups.py after adding CYCLEDEF_PROD_EXCLUDE

### DIFF
--- a/workflow/rocoto_funcs/smart_post_groups.py
+++ b/workflow/rocoto_funcs/smart_post_groups.py
@@ -76,6 +76,8 @@ def smart_post_groups(dcCycleDef):
             dcCycles_by_postgrp[i].extend(dcCycles_by_postgrp[j])
     #
     cycledef_prod = dcCycleDef['prod']
+    if isinstance(cycledef_prod, dict):
+        cycledef_prod = cycledef_prod["cycledef"]
     for index, valid_hours in dcCycles_by_postgrp.items():
         if index == 0:  # the first post group uses the prod cycledef
             continue


### PR DESCRIPTION
Sorry that the impact on `smart_post_groups.py` was NOT considered in PR #1390.
So if one uses more than one post group, we get rocotorun errors.
This PR is a hotfix to this issue. Thank @chunhuazhou for testing.