### PR TITLE
several updates for RRFSv2X

### DIFF
--- a/parm/hrrrv5/namelist.atmosphere
+++ b/parm/hrrrv5/namelist.atmosphere
@@ -61,7 +61,7 @@
     config_mynn_mixscalars = 0
     config_mynn_mixaerosols = 1
     config_mynn_mixnumcon = 0
-    config_mynn_sfcflux_land = 0
+    !config_mynn_sfcflux_land = 0
 /
 &physics_mp_tempo
     config_tempo_aerosolaware = .true.

--- a/parm/mpas_global/namelist.atmosphere
+++ b/parm/mpas_global/namelist.atmosphere
@@ -64,7 +64,7 @@
     config_mynn_mixscalars = 0
     config_mynn_mixaerosols = 1
     config_mynn_mixnumcon = 0
-    config_mynn_sfcflux_land = 0
+    !config_mynn_sfcflux_land = 0
 /
 &physics_mp_tempo
     config_tempo_aerosolaware = .true.

--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -72,9 +72,14 @@ mpasout_interval=${MPASOUT_INTERVAL:-1}
 [[ ${history_interval} =~ ^[0-9]+$ ]] && history_interval="${history_interval}:00:00"
 [[ ${diag_interval} =~ ^[0-9]+$ ]] && diag_interval="${diag_interval}:00:00"
 [[ ${mpasout_interval} =~ ^[0-9]+$ ]] && mpasout_interval="${mpasout_interval}:00:00"
+if [[ "${MPASOUT_TIMELEVELS}" != "" ]]; then # prioritize MPASOUT_TIMELEVELS
+  mpasout_replacement="s|output_interval=\"@mpasout_interval@\"|output_timelevels=\"${MPASOUT_TIMELEVELS}\"|"
+else
+  mpasout_replacement="s/@mpasout_interval@/${mpasout_interval}/"
+fi
 sed -e "s/@restart_interval@/${restart_interval}/" -e "s/@history_interval@/${history_interval}/" \
     -e "s/@diag_interval@/${diag_interval}/" -e "s/@lbc_interval@/${lbc_interval}/" \
-    -e "s/@mpasout_interval@/${mpasout_interval}/" "${PARMrrfs}"/streams.atmosphere  > streams.atmosphere
+    -e "${mpasout_replacement}"  "${PARMrrfs}"/streams.atmosphere  > streams.atmosphere
 #
 if [[ "${mpasout_interval,,}" == "none" ]]; then  # remove the da_state stream for coldstart only forecasts
   sed -i '/<stream name="da_state"/,/<\/stream>/d' streams.atmosphere
@@ -92,22 +97,24 @@ if [[ "${history_interval,,}" != "none" ]]; then
     CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
     timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
     if [[ "${DO_SPINUP:-FALSE}" != "TRUE" ]];  then
-      ln -snf "${UMBRELLA_FCST_DATA}/history.${timestr}.nc" "${DATA}"
-      ln -snf "${UMBRELLA_FCST_DATA}/diag.${timestr}.nc" "${DATA}"
+      ln -snf "${UMBRELLA_FCST_DATA}/history.${timestr}.nc" "${DATA}/"
+      ln -snf "${UMBRELLA_FCST_DATA}/diag.${timestr}.nc" "${DATA}/"
     fi
   done
 fi
 # prelink the mpasout files to umbrella
-if [[ "${mpasout_interval,,}" != "none" ]]; then
-  mpasout_all=$(seq 0 $((10#${mpasout_interval%%:*})) $((10#${fcst_len_hrs_thiscyc} )) )
-  for fhr in ${mpasout_all}; do
-    CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
-    timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
-    if [[ "${DO_SPINUP:-FALSE}" != "TRUE" ]];  then
-      ln -snf "${UMBRELLA_FCST_DATA}/mpasout.${timestr}.nc" "${DATA}"
-    fi
-  done
+if [[ "${MPASOUT_TIMELEVELS}" != "" ]]; then # prioritize MPASOUT_TIMELEVELS
+  read -ra mpasout_all <<< "${MPASOUT_TIMELEVELS}"
+elif [[ "${mpasout_interval,,}" != "none" ]]; then
+ read -ra mpasout_all <<< $(seq 0 $((10#${mpasout_interval%%:*})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ')
 fi
+for fhr in ${mpasout_all[@]}; do
+  CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
+  timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)
+  if [[ "${DO_SPINUP:-FALSE}" != "TRUE" ]];  then
+    ln -snf "${UMBRELLA_FCST_DATA}/mpasout.${timestr}.nc" "${DATA}/"
+  fi
+done
 
 # run the MPAS model
 source prep_step

--- a/scripts/exrrfs_fcst.sh
+++ b/scripts/exrrfs_fcst.sh
@@ -106,8 +106,9 @@ fi
 if [[ "${MPASOUT_TIMELEVELS}" != "" ]]; then # prioritize MPASOUT_TIMELEVELS
   read -ra mpasout_all <<< "${MPASOUT_TIMELEVELS}"
 elif [[ "${mpasout_interval,,}" != "none" ]]; then
- read -ra mpasout_all <<< $(seq 0 $((10#${mpasout_interval%%:*})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ')
+ read -ra mpasout_all <<< "$(seq 0 $((10#${mpasout_interval%%:*})) $((10#${fcst_len_hrs_thiscyc} )) | paste -sd ' ')"
 fi
+# shellcheck disable=SC2068
 for fhr in ${mpasout_all[@]}; do
   CDATEp=$( ${NDATE} "${fhr}" "${CDATE}" )
   timestr=$(date -d "${CDATEp:0:8} ${CDATEp:8:2}" +%Y-%m-%d_%H.%M.%S)

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -30,6 +30,7 @@ def fcst(xmlFile, expdir, do_ensemble=False, dcEnsGrpInfo=None, do_spinup=False)
         'HISTORY_INTERVAL': f'{history_interval}',
         'RESTART_INTERVAL': f'{restart_interval}',
         'MPASOUT_INTERVAL': os.getenv('MPASOUT_INTERVAL', '1'),
+        'MPASOUT_TIMELEVELS': os.getenv('MPASOUT_TIMELEVELS', ''),
         'PHYSICS_SUITE': f'{physics_suite}',
         'FCST_LEN_HRS_CYCLES': f'{fcst_len_hrs_cycles}',
         'FCST_DT': os.getenv('FCST_DT', 'FCST_DT_not_defined'),

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -14,7 +14,6 @@ def getkf(xmlFile, expdir, taskType):
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
-    coldstart_cyc_do_da = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE')
     recenter_cycs = os.getenv('RECENTER_CYCS', '99')
     dcTaskEnv = {
         'EXTRN_MDL_SOURCE': f'{extrn_mdl_source}',
@@ -52,6 +51,7 @@ def getkf(xmlFile, expdir, taskType):
             dcTaskEnv['IODA_BUFR_WGF'] = 'det'
 
         final_recenterdep = ""
+        spaces = " " * 4
         if os.getenv("DO_RECENTER", "FALSE").upper() == "TRUE":
             recenterhrs = recenter_cycs.split(' ')
             recenterdep = f'<taskdep task="recenter"/>'

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -6,11 +6,14 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 
 
 def getkf(xmlFile, expdir, taskType):
-    cycledefs = 'prod'
+    nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
+    if nocoldda:
+        cycledefs = 'da_nocold'
+    else:
+        cycledefs = 'prod'
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
-    coldhrs = os.getenv('COLDSTART_CYCS', '03 15')
     coldstart_cyc_do_da = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE')
     recenter_cycs = os.getenv('RECENTER_CYCS', '99')
     dcTaskEnv = {
@@ -35,14 +38,6 @@ def getkf(xmlFile, expdir, taskType):
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
-    coldhrs = coldhrs.split(' ')
-    strneqs = ""
-    spaces = " " * 4
-    if coldstart_cyc_do_da.upper() == "FALSE":
-        for hr in coldhrs:
-            hr = f"{int(hr):02d}"
-            strneqs += '\n' + spaces + f'<strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>'
-
     timedep = ""
     realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
@@ -79,7 +74,7 @@ def getkf(xmlFile, expdir, taskType):
 
         dependencies = f'''
   <dependency>
-  <and>{timedep}{strneqs}
+  <and>{timedep}
     <taskdep task="prep_ic"/>
     {iodadep}{final_recenterdep}
   </and>

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -5,15 +5,21 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of jedivar --------------------------------------------------------
 
 
-def jedivar(xmlFile, expdir, do_spinup=False):
+def jedivar(xmlFile, expdir, spinup_mode=0):
+    nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
+    do_spinup = spinup_mode == 1
     if do_spinup:
-        cycledefs = 'spinup'
+        if nocoldda:
+            cycledefs = 'da_nocold'
+        else:
+            cycledefs = 'spinup'
         task_id = 'jedivar_spinup'
     else:
-        cycledefs = 'prod'
+        if spinup_mode == 0 and nocoldda:
+            cycledefs = 'da_nocold'
+        else:
+            cycledefs = 'prod'
         task_id = 'jedivar'
-    coldhrs = os.getenv('COLDSTART_CYCS', '03 15')
-    coldstart_cyc_do_da = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE')
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
@@ -69,7 +75,6 @@ def jedivar(xmlFile, expdir, do_spinup=False):
         HYB_ENS_PATH = f'&COMROOT;/{NET}/{VERSION}'
 
     ens_dep = ""
-
     if HYB_WGT_ENS != "0" and HYB_WGT_ENS != "0.0" and HYB_ENS_TYPE == "1":  # rrfsens
         RUN = 'rrfs'
         ens_dep = "\n    <or>"
@@ -104,22 +109,12 @@ def jedivar(xmlFile, expdir, do_spinup=False):
         iodadep = '<taskdep task="ioda_bufr"/>'
     else:
         iodadep = f'<datadep age="00:01:00"><cyclestr>&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/ioda_bufr/det/ioda_aircar.nc</cyclestr></datadep>'
-
-    final_ens_dep = ens_dep
-    #
-    coldhrs = coldhrs.split(' ')
-    strneqs = ""
-    if coldstart_cyc_do_da.upper() == "FALSE":  # if no DA at coldstart cycs, skip this task
-        for hr in coldhrs:
-            hr = f"{int(hr):02d}"
-            strneqs += f'\n    <strneq><left><cyclestr>@H</cyclestr></left><right>{hr}</right></strneq>'
-
     #
     dependencies = f'''
   <dependency>
-  <and>{timedep}{strneqs}
+  <and>{timedep}
     {prep_ic_dep}
-    {iodadep}{final_ens_dep}
+    {iodadep}{ens_dep}
   </and>
   </dependency>'''
     #

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -90,13 +90,13 @@ def setup_xml(HOMErrfs, expdir):
                 prep_lbc(xmlFile, expdir)
                 # spin up line
                 prep_ic(xmlFile, expdir, spinup_mode=1)
-                jedivar(xmlFile, expdir, do_spinup=True)
+                jedivar(xmlFile, expdir, spinup_mode=1)
                 if os.getenv("DO_NONVAR_CLOUD_ANA", "FALSE").upper() == "TRUE":
                     nonvar_cldana(xmlFile, expdir, do_spinup=True)
                 fcst(xmlFile, expdir, do_spinup=True)
                 # prod line
                 prep_ic(xmlFile, expdir, spinup_mode=-1)
-                jedivar(xmlFile, expdir)
+                jedivar(xmlFile, expdir, spinup_mode=-1)
                 if os.getenv("DO_NONVAR_CLOUD_ANA", "FALSE").upper() == "TRUE":
                     nonvar_cldana(xmlFile, expdir)
                 fcst(xmlFile, expdir)

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -69,7 +69,7 @@ def smart_cycledefs():
         dcCycledef['spinup'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_spinup}'}
     #
     # if we don't do DA at cold start cycles, let's exclude cold_cycs
-    nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'FALSE').upper() == 'FALSE'
+    nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
     if nocoldda:
         if spinup:  # if spinup, coldda only happens at spinup cycles
             spinup_hrs2 = [item for item in spinup_hrs if item not in list(map(int, cold_cycs))]

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -25,9 +25,9 @@ def smart_cycledefs():
         if len(cold_cycs) > 1:
             spinup_hrs.extend(list(range(int(cold_cycs[1]), int(prodswitch_cycs[1]))))
         #
-        realtime = os.getenv('REALTIME', 'false')
-        spinup = os.getenv('DO_SPINUP', 'false')
-        if realtime.upper() == "TRUE":
+        realtime = os.getenv('REALTIME', 'FALSE').upper() == "TRUE"
+        spinup = os.getenv('DO_SPINUP', 'FALSE').upper() == "TRUE"
+        if realtime:
             cycledef_ic = f'  &Y1;&M1;&D1;{cold_cycs[0]}00 &Y2;&M2;&D2;2300 {ic_step.zfill(2)}:00:00'
             cycledef_lbc = f' &Y1;&M1;&D1;{lbc_cycs[0]}00 &Y2;&M2;&D2;2300 {lbc_step.zfill(2)}:00:00'
             cycledef_prod = f'&Y1;&M1;&D1;0000 &Y2;&M2;&D2;2300 {cyc_interval.zfill(2)}:00:00'
@@ -44,27 +44,42 @@ def smart_cycledefs():
             cold_cyc1 = cold_cycs[index]
             lbc_cyc1 = lbc_cycs[index]
             prod_cyc1 = cold_cyc1
-            if spinup.upper() == "TRUE":  # if spinup, the first prod_cyc is from prodswitch_cycs
+            if spinup:  # if spinup, the first prod_cyc is from prodswitch_cycs
                 prod_cyc1 = prodswitch_cycs[index]
             #
             cycledef_ic = f'  {retrodates[0][0:8]}{cold_cyc1}00 {retrodates[1]}00 {ic_step.zfill(2)}:00:00'
             cycledef_lbc = f' {retrodates[0][0:8]}{lbc_cyc1}00 {retrodates[1]}00 {lbc_step.zfill(2)}:00:00'
             cycledef_prod = f'{retrodates[0][0:8]}{prod_cyc1}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
-            if spinup.upper() == "TRUE":
+            if spinup:
                 cycledef_spinup = f'{retrodates[0][0:8]}{cold_cyc1}00 {retrodates[1]}00 {cyc_interval.zfill(2)}:00:00'
     #
     # fill in the Cycledef dictionary
     dcCycledef = {}
     dcCycledef['ic'] = f'{cycledef_ic}'
     dcCycledef['lbc'] = f'{cycledef_lbc}'
+    #
     exclude_str = os.getenv('CYCLEDEF_PROD_EXCLUDE', '')
     if exclude_str:
         dcCycledef['prod'] = {'exclude_hours': f'{exclude_str}', "cycledef": f'{cycledef_prod}'}
     else:
         dcCycledef['prod'] = f'{cycledef_prod}'
     #
-    if spinup.upper() == "TRUE":
+    if spinup:
         valid_str = " ".join(f"{i}" for i in spinup_hrs)
         dcCycledef['spinup'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_spinup}'}
+    #
+    # if we don't do DA at cold start cycles, let's exclude cold_cycs
+    nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'FALSE').upper() == 'FALSE'
+    if nocoldda:
+        if spinup:  # if spinup, coldda only happens at spinup cycles
+            spinup_hrs2 = [item for item in spinup_hrs if item not in list(map(int, cold_cycs))]
+            valid_str = " ".join(f"{i}" for i in spinup_hrs2)
+            dcCycledef['da_nocold'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_spinup}'}
+        else:
+            exclude_cycs = list(map(int, os.getenv('CYCLEDEF_PROD_EXCLUDE', '').strip().split()))
+            exclude_cycs.extend(list(map(int, cold_cycs)))
+            exclude_cycs = sorted(set(exclude_cycs))  # uniq and sort
+            exclude_str = " ".join(f"{i}" for i in exclude_cycs)
+            dcCycledef['da_nocold'] = {'exclude_hours': f'{exclude_str}', "cycledef": f'{cycledef_prod}'}
     # ~~~~
     return dcCycledef


### PR DESCRIPTION
1. if no DA at cold start cycles, remove the `jedivar` or `getkf` tasks from those cycles. This is achieved by introducing a new `da_nocold` cycledef with an `exclude_hours` attribute.
2. update MPAS-Model to include a cmake hotfix and the capability to output at flexible time levels.
3. introduce `export MPASOUT_TIMELEVELS='0 1'` so that we only output mpasout files at 0h and 1h forecast hours.