### PR TITLE
[dev-sci] Bug fix for zero-padded ensemble member indices when applying analysis increments

### DIFF
--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -191,7 +191,7 @@ if [[ "${DA_SYSTEM}" = "JEDI" || "${DO_PARALLEL_DA}" = "TRUE" ]]; then
     bkdir=INPUT
   fi
 
-  if [[ ${ensmem_indx} -ge 1 ]] && [[ "${BKTYPE}" -eq 0 || "${DO_DACOLD}" = "TRUE" ]]; then
+  if [[ 10#${ensmem_indx} -ge 1 ]] && [[ "${BKTYPE}" -eq 0 || "${DO_DACOLD}" = "TRUE" ]]; then
 
     # Convert A-grid wind increments to D-grid
     cd ${run_dir}/${bkdir}


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

I recently identified a strange bug in our JEDI-based EnKF retros where increments were not correctly applied for ensemble members 18-19 and 28-29. This behavior was traced to a new conditional check in `exrrfs_forecast.sh` that determines whether a given run corresponds to an ensemble member using `if [[ ${ensmem_indx} -ge 1 ]]`. If this check passes, we apply the increments inside the forecast task so that it can be done in parallel for each member.

However, I found that bash interprets numbers with leading zeros as octal (base 8). Octal only allows digits from 0-7 and as a result, values such as `0018` or `0028` are invalid. This causes the conditional check to fail for these members. The failure does not trigger a fatal error, but it prevents the increment application step from executing, leading to forecasts being initialized from the background field instead of the analysis.

The fix explicitly forces base-10 interpretation using the `10#` prefix to ensure that zero-padded ensemble indices are handled correctly and that the conditional logic behaves as intended for all members.

## TESTS CONDUCTED: 

Tested by running a full 30-member cycle and confirming that the increments are applied for all members. 

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None
