### PR TITLE
[rrfs-mpas-jedi] Updates related to running nonvar cloud analysis in realtime

### DIFF
--- a/scripts/exrrfs_nonvar_cldana.sh
+++ b/scripts/exrrfs_nonvar_cldana.sh
@@ -31,8 +31,8 @@ HH=${CDATE:8:2}
 
 # Model background
 if [[ -r "${UMBRELLA_PREP_IC_DATA}/init.nc" ]]; then
-  echo "INFO: Skipping nonvar cloud analysis because this is a cold start"
-  echo "INFO: The 'cldfrac' field, which is required, is not available for cold starts"
+  echo "WARNING: Skipping nonvar cloud analysis because this is a cold start"
+  echo "WARNING: The 'cldfrac' field, which is required, is not available for cold starts"
   exit 0
 else
   initial_file=mpasout.nc
@@ -45,10 +45,18 @@ nlevel=$(wc -l < "${zeta_levels}")
 ln -snf "${FIXrrfs}/${MESH_NAME}/${MESH_NAME}.invariant.nc_L${nlevel}_${prefix}" ./invariant.nc
 
 # Processed observations
-${cpreq} "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud4mpas.bin" .
-${cpreq} "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.dat" .
-${cpreq} "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bin" .
-${cpreq} "${COMOUT}/nonvar_reflobs/${WGF}/RefInGSI3D.dat" .
+all_obs=( "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud4mpas.bin" 
+          "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.dat"
+          "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bin"
+          "${COMOUT}/nonvar_reflobs/${WGF}/RefInGSI3D.dat" )
+for ob in ${all_obs[@]}; do
+  if [[ -r ${ob} ]]; then
+    ${cpreq} ${ob} .
+  else
+    echo "WARNING: The following processed observations are NOT available"
+    echo ${ob}
+  fi
+done
 
 #
 #-----------------------------------------------------------------------
@@ -102,9 +110,9 @@ err_chk
 
 # Copy log files to COM directory
 if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
-  ${cpreq} stdout_cloudanalysis* "${COMOUT}/nonvar_cldana_spinup/${WGF}${MEMDIR}/"
+  cp stdout_cloudanalysis* "${COMOUT}/nonvar_cldana_spinup/${WGF}${MEMDIR}/"
 else
-  ${cpreq} stdout_cloudanalysis* "${COMOUT}/nonvar_cldana/${WGF}${MEMDIR}/"
+  cp stdout_cloudanalysis* "${COMOUT}/nonvar_cldana/${WGF}${MEMDIR}/"
 fi
 
 exit 0

--- a/scripts/exrrfs_nonvar_cldana.sh
+++ b/scripts/exrrfs_nonvar_cldana.sh
@@ -50,7 +50,7 @@ all_obs=( "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud4mpas.bin"
           "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bin"
           "${COMOUT}/nonvar_reflobs/${WGF}/RefInGSI3D.dat" )
 for ob in ${all_obs[@]}; do
-  if [[ -r ${ob} ]]; then
+  if [[ -s ${ob} ]]; then
     ${cpreq} ${ob} .
   else
     echo "WARNING: The following processed observations are NOT available"

--- a/workflow/rocoto_funcs/nonvar_bufrobs.py
+++ b/workflow/rocoto_funcs/nonvar_bufrobs.py
@@ -33,16 +33,18 @@ def nonvar_bufrobs(xmlFile, expdir):
     metar_path = f'{OBSPATH}/@Y@m@d@H.rap.t@Hz.prepbufr.tm00'
 
     timedep = ""
+    datadep = ""
     realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
         starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
+    else:
+        datadep = f'\n    <datadep age="00:02:00"><cyclestr>{lght_path}</cyclestr></datadep>'
     #
     dependencies = f'''
   <dependency>
-  <and>{timedep}
+  <and>{timedep}{datadep}
     <datadep age="00:02:00"><cyclestr>{larc_path}</cyclestr></datadep>
-    <datadep age="00:02:00"><cyclestr>{lght_path}</cyclestr></datadep>
     <datadep age="00:02:00"><cyclestr>{metar_path}</cyclestr></datadep>
   </and>
   </dependency>'''

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -8,9 +8,15 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     meta_id = 'nonvar_cldana'
     if do_spinup:
-        cycledefs = 'spinup'
+        if nocoldda:
+            cycledefs = 'da_nocold'
+        else:
+            cycledefs = 'spinup'
     else:
-        cycledefs = 'prod'
+        if spinup_mode == 0 and nocoldda:
+            cycledefs = 'da_nocold'
+        else:
+            cycledefs = 'prod'
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     dcTaskEnv = {

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -7,13 +7,14 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 
 def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     meta_id = 'nonvar_cldana'
+    nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
     if do_spinup:
         if nocoldda:
             cycledefs = 'da_nocold'
         else:
             cycledefs = 'spinup'
     else:
-        if spinup_mode == 0 and nocoldda:
+        if nocoldda:
             cycledefs = 'da_nocold'
         else:
             cycledefs = 'prod'

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -44,10 +44,13 @@ def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
     # dependencies
     timedep = ""
+    taskdep = ""
     realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
         starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
+    else:
+        taskdep = f'\n    <taskdep task="nonvar_bufrobs"/>\n    <taskdep task="nonvar_reflobs"/>'
     #
     prep_ic_dep = ""
     jedidep = ""
@@ -65,9 +68,7 @@ def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     #
     dependencies = f'''
   <dependency>
-  <and>{timedep}{prep_ic_dep}{jedidep}
-    <taskdep task="nonvar_bufrobs"/>
-    <taskdep task="nonvar_reflobs"/>
+  <and>{timedep}{prep_ic_dep}{jedidep}{taskdep}
   </and>
   </dependency>'''
     #

--- a/workflow/rocoto_funcs/nonvar_cldana.py
+++ b/workflow/rocoto_funcs/nonvar_cldana.py
@@ -5,16 +5,17 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of nonvar_cldana --------------------------------------------------------
 
 
-def nonvar_cldana(xmlFile, expdir, do_ensemble=False, do_spinup=False):
+def nonvar_cldana(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     meta_id = 'nonvar_cldana'
     nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
+    do_spinup = spinup_mode == 1
     if do_spinup:
         if nocoldda:
             cycledefs = 'da_nocold'
         else:
             cycledefs = 'spinup'
     else:
-        if nocoldda:
+        if spinup_mode == 0 and nocoldda:
             cycledefs = 'da_nocold'
         else:
             cycledefs = 'prod'

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -92,13 +92,13 @@ def setup_xml(HOMErrfs, expdir):
                 prep_ic(xmlFile, expdir, spinup_mode=1)
                 jedivar(xmlFile, expdir, spinup_mode=1)
                 if os.getenv("DO_NONVAR_CLOUD_ANA", "FALSE").upper() == "TRUE":
-                    nonvar_cldana(xmlFile, expdir, do_spinup=True)
+                    nonvar_cldana(xmlFile, expdir, spinup_mode=1)
                 fcst(xmlFile, expdir, do_spinup=True)
                 # prod line
                 prep_ic(xmlFile, expdir, spinup_mode=-1)
                 jedivar(xmlFile, expdir, spinup_mode=-1)
                 if os.getenv("DO_NONVAR_CLOUD_ANA", "FALSE").upper() == "TRUE":
-                    nonvar_cldana(xmlFile, expdir)
+                    nonvar_cldana(xmlFile, expdir, spinup_mode=-1)
                 fcst(xmlFile, expdir)
                 save_for_next(xmlFile, expdir)
             elif os.getenv("DO_FCST", "TRUE").upper() == "TRUE":


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

- Remove `nonvar_bufrobs` dependency on lightning data for realtime runs. These data are not used by the nonvariational cloud analysis at the moment.
- Remove `nonvar_cldana` dependencies on the `nonvar_bufrobs` and `nonvar_reflobs` tasks for realtime runs. This makes the workflow more resilient because the `fcst` tasks depends on `nonvar_cldana`. If `nonvar_cldana` is stuck because `nonvar_bufrobs` or `nonvar_reflobs` fails, then the entire workflow becomes stuck.
- Allow `nonvar_cldana` task to use the same `da_nocold` cycledef as the JEDI tasks. The `nonvar_cldana` task depends on the JEDI task, so this avoids issues where `nonvar_cldana` depends on a JEDI task that does not exist.
- Check whether processed observation files exist prior to copying in `exrrfs_nonvar_cldana.sh`. This avoids issues where the `nonvar_cldana` task fails because input data is missing.
- Change `cpreq` to `cp` when copying output from `nonvar_cldana`. This also avoids the potential for this task crashing in the unlikely event that output files are not created.

Tagging @chunhuazhou and @hu5970 to see if there are any other changes that they think are needed here.

## TESTS CONDUCTED: 
- Can successfully create realtime and retro workflows on Ursa using the updated code. Retro workflow looks very similar to previous code versions, with the only change being that `nonvar_cldana` now uses `cycledefs="da_nocold"`. 
- Currently testing whether a retro runs successfully on Gaea C6


