### PR TITLE
mpassit updates: use invariant.nc for grid_file_input_grid and read zs/dzs from hist_file_input_grid

### DIFF
--- a/parm/namelist.mpassit
+++ b/parm/namelist.mpassit
@@ -1,5 +1,5 @@
 &config
-    grid_file_input_grid = "history.@timestr@.nc"
+    grid_file_input_grid = "invariant.nc"
     hist_file_input_grid = "history.@timestr@.nc"
     diag_file_input_grid = "diag.@timestr@.nc"
     output_file          = "mpassit.@timestr@.nc"

--- a/scripts/exrrfs_mpassit.sh
+++ b/scripts/exrrfs_mpassit.sh
@@ -4,6 +4,7 @@ declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LI
 set -x
 
 cpreq=${cpreq:-cpreq}
+prefix=${EXTRN_MDL_SOURCE%_NCO} # remove the trailing '_NCO' if any
 cd "${DATA}"  || exit 1
 #
 #  copy excutable and fix files for this mesh
@@ -25,6 +26,9 @@ dx=${MPASSIT_DX:-12000.0}
 ref_lat=${MPASSIT_REF_LAT:-"39.0"}
 ref_lon=${MPASSIT_REF_LON:-"-97.5"}
 #
+zeta_levels=${EXPDIR}/config/ZETA_LEVELS.txt
+nlevel=$(wc -l < "${zeta_levels}")
+ln -snf "${FIXrrfs}/${MESH_NAME}/${MESH_NAME}.invariant.nc_L${nlevel}_${prefix}" ./invariant.nc
 #
 # find forecst length for this cycle
 #

--- a/workflow/rocoto_funcs/clean.py
+++ b/workflow/rocoto_funcs/clean.py
@@ -37,7 +37,12 @@ def clean(xmlFile, expdir):
   </and>
   </dependency>'''
     if clean_mode == 1:
-        dependencies = ""
+        dependencies = f'''
+  <dependency>
+  <and>
+    <taskdep task="prep_ic"/>
+  </and>
+  </dependency>'''
     #
     xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies)
 # end of clean --------------------------------------------------------

--- a/workflow/rocoto_funcs/mpassit.py
+++ b/workflow/rocoto_funcs/mpassit.py
@@ -22,6 +22,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         str_hours = " ".join(str(i) for i in range(bgn_hr, end_hr + step, step))
     #
     # Task-specific EnVars beyond the task_common_vars
+    extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     dcTaskEnv = {
         'FCST_LEN_HRS_CYCLES': os.getenv('FCST_LEN_HRS_CYCLES', '03 03'),
         'GROUP_INDEX': f'{index:02d}',
@@ -31,6 +32,7 @@ def mpassit(xmlFile, expdir, index, dcGrpInfo, do_ensemble=False, do_ensmean_pos
         'MPASSIT_DX': os.getenv('MPASSIT_DX', 'MPASSIT_DX_not_defined'),
         'MPASSIT_REF_LAT': os.getenv('MPASSIT_REF_LAT', 'MPASSIT_REF_LAT_not_defined'),
         'MPASSIT_REF_LON': os.getenv('MPASSIT_REF_LON', 'MPASSIT_REF_LON_not_defined'),
+        'EXTRN_MDL_SOURCE': f'{extrn_mdl_source}',
     }
 
     if os.getenv('DO_CHEMISTRY', 'FALSE').upper() == "TRUE":


### PR DESCRIPTION
This PR addresses the zero `ter` (terrain) field issue reported by @daviddowellNOAA in https://github.com/ufs-community/MPAS-Model/issues/159

It requires this MPASSIT PR https://github.com/NOAA-GSL/MPASSIT/pull/22.