### PR TITLE
update the Graphics task to run on all supported platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ fix/ar3.5km
 fix/ea5km
 fix/global-15-3km
 fix/eu12km
+pygraf

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -117,9 +117,10 @@ export WALLTIME_UPP=${WALLTIME_UPP:-"00:50:00"}
 export NATIVE_UPP=${NATIVE_UPP:-""}
 
 # graphics
-export NODES_GRAPHICS="<nodes>1:ppn=20</nodes>"
-export WALLTIME_GRAPHICS="04:00:00"
-export NATIVE_GRAPHICS="--exclusive"
+export NODES_GRAPHICS=${NODES_GRAPHICS:-"<nodes>1:ppn=20</nodes>"}
+export WALLTIME_GRAPHICS=${WALLTIME_GRAPHICS:-"01:00:00"}
+export GRAPHICS_TILES=${GRAPHICS_TILES:-"full"}  # "full NE NC NW SE SC SW EastCO"
+export GRAPHICS_ZIP=${GRAPHICS_ZIP:-false}
 
 # clean
 export ACCOUNT_CLEAN=${ACCOUNT_CLEAN:-$ACCOUNT}
@@ -127,5 +128,3 @@ export QUEUE_CLEAN=${QUEUE_CLEAN:-$QUEUE}
 export PARTITION_CLEAN=${PARTITION_CLEAN:-$PARTITION}
 export RESERVATION_CLEAN=${RESERVATION_CLEAN:-""}
 export NODES_CLEAN="<nodes>1:ppn=1</nodes>"
-# misc
-export NODES_MISC="<nodes>1:ppn=1</nodes>"

--- a/workflow/rocoto_funcs/graphics.py
+++ b/workflow/rocoto_funcs/graphics.py
@@ -1,34 +1,21 @@
 #!/usr/bin/env python
 # this file hosts all tasks that will not be needed by NCO
 import os
+import textwrap
 from rocoto_funcs.base import xml_task, get_cascade_env
 
 # begin of graphics --------------------------------------------------------
 
 
-def graphics(xmlFile, expdir, index, dcGrpInfo, lastGrp=False):
-    task_id = f'graphics_g{index:02d}'
-    cycledefs = dcGrpInfo['cycledef']
-    group_hours = dcGrpInfo["hours"]
-    parts = group_hours.split('-')
-    if len(parts) == 1:
-        str_hours = parts[0]
-    else:
-        step = 1
-        if len(parts) == 3:
-            step = int(parts[2])
-        bgn_hr = int(parts[0])
-        end_hr = int(parts[1])
-        str_hours = " ".join(str(i) for i in range(bgn_hr, end_hr + step, step))
+def graphics(xmlFile, expdir):
+    task_id = f'graphics'
+    cycledefs = 'prod'
     #
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'FCST_LEN_HRS_CYCLES': os.getenv('FCST_LEN_HRS_CYCLES', '03 03'),
-        'GROUP_INDEX': f'{index:02d}',
-        'GROUP_HOURS': f'{str_hours}',
         'TILES': os.getenv('GRAPHICS_TILES', 'full'),
         'GRAPHICS_ZIP': os.getenv('GRAPHICS_ZIP', 'FALSE').upper(),
-        'LAST_GROUP': f'{lastGrp}'.upper(),
     }
     # dependencies
     timedep = ""
@@ -37,10 +24,15 @@ def graphics(xmlFile, expdir, index, dcGrpInfo, lastGrp=False):
         starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
         timedep = f'\n  <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
+    taskdep = ''
+    ngroup = int(os.getenv('POST_GROUP_TOT_NUM'))
+    for i in range(ngroup):
+        taskdep += f'\n<taskdep task="upp_g{i:02d}"/>'
+    taskdep = textwrap.indent(taskdep, '    ')
+    #
     dependencies = f'''
   <dependency>
-  <and>{timedep}
-    <taskdep task="upp_g{index:02d}"/>
+  <and>{timedep}{taskdep}
   </and>
   </dependency>'''
 

--- a/workflow/rocoto_funcs/graphics.py
+++ b/workflow/rocoto_funcs/graphics.py
@@ -6,38 +6,43 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of graphics --------------------------------------------------------
 
 
-def graphics(xmlFile, expdir):
-    meta_id = 'graphics'
-    cycledefs = 'prod'
-    # metatask (nested or not)
-    meta_bgn = \
-        f'''
-<metatask name="{meta_id}">
-<var name="area">full NE NC NW SE SC SW EastCO</var>'''
-    meta_end = f'\
-</metatask>\n'
-
+def graphics(xmlFile, expdir, index, dcGrpInfo):
+    task_id = f'graphics_g{index:02d}'
+    cycledefs = dcGrpInfo['cycledef']
+    group_hours = dcGrpInfo["hours"]
+    parts = group_hours.split('-')
+    if len(parts) == 1:
+        str_hours = parts[0]
+    else:
+        step = 1
+        if len(parts) == 3:
+            step = int(parts[2])
+        bgn_hr = int(parts[0])
+        end_hr = int(parts[1])
+        str_hours = " ".join(str(i) for i in range(bgn_hr, end_hr + step, step))
+    #
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'FCST_LEN_HRS_CYCLES': os.getenv('FCST_LEN_HRS_CYCLES', '03 03'),
-        'AREA': '#area#',
+        'GROUP_INDEX': f'{index:02d}',
+        'GROUP_HOURS': f'{str_hours}',
+        'TILES': os.getenv('GRAPHICS_TILES', 'full'),
     }
-    task_id = f'{meta_id}_#area#'
-
+    # dependencies
     timedep = ""
     realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
-        starttime = get_cascade_env(f"STARTTIME_{meta_id}".upper())
+        starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
         timedep = f'\n  <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
     #
     dependencies = f'''
   <dependency>
   <and>{timedep}
-  <metataskdep metatask="upp"/>
+    <taskdep task="upp_g{index:02d}"/>
   </and>
   </dependency>'''
 
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, True, meta_id, meta_bgn, meta_end)
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies)
 
 # end of graphics --------------------------------------------------------

--- a/workflow/rocoto_funcs/graphics.py
+++ b/workflow/rocoto_funcs/graphics.py
@@ -6,7 +6,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 # begin of graphics --------------------------------------------------------
 
 
-def graphics(xmlFile, expdir, index, dcGrpInfo):
+def graphics(xmlFile, expdir, index, dcGrpInfo, lastGrp=False):
     task_id = f'graphics_g{index:02d}'
     cycledefs = dcGrpInfo['cycledef']
     group_hours = dcGrpInfo["hours"]
@@ -27,6 +27,8 @@ def graphics(xmlFile, expdir, index, dcGrpInfo):
         'GROUP_INDEX': f'{index:02d}',
         'GROUP_HOURS': f'{str_hours}',
         'TILES': os.getenv('GRAPHICS_TILES', 'full'),
+        'GRAPHICS_ZIP': os.getenv('GRAPHICS_ZIP', 'FALSE').upper(),
+        'LAST_GROUP': f'{lastGrp}'.upper(),
     }
     # dependencies
     timedep = ""
@@ -43,6 +45,6 @@ def graphics(xmlFile, expdir, index, dcGrpInfo):
   </dependency>'''
 
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies)
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, command_id="GRAPHICS")
 
 # end of graphics --------------------------------------------------------

--- a/workflow/rocoto_funcs/graphics.py
+++ b/workflow/rocoto_funcs/graphics.py
@@ -8,7 +8,7 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 
 
 def graphics(xmlFile, expdir):
-    task_id = f'graphics'
+    task_id = 'graphics'
     cycledefs = 'prod'
     #
     # Task-specific EnVars beyond the task_common_vars
@@ -37,6 +37,6 @@ def graphics(xmlFile, expdir):
   </dependency>'''
 
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, command_id="GRAPHICS")
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies)
 
 # end of graphics --------------------------------------------------------

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -128,7 +128,7 @@ def setup_xml(HOMErrfs, expdir):
                     print("  *** DO_GRAPHICS=true but pygraf not cloned yet!!! ***\n  run `tools/clone_pygraf.sh` first\n")
                     sys.exit(1)
                 for index, dcGrpInfo in enumerate(listPostGrpInfo):
-                    graphics(xmlFile, expdir, index, dcGrpInfo)
+                    graphics(xmlFile, expdir, index, dcGrpInfo, index == len(listPostGrpInfo) - 1)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":
                 hofx(xmlFile, expdir)
 

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 import os
+import sys
 import stat
 from rocoto_funcs.base import header_begin, header_entities, header_end, \
     wflow_begin, wflow_log, wflow_cycledefs, wflow_end
@@ -123,6 +124,9 @@ def setup_xml(HOMErrfs, expdir):
                     mpassit(xmlFile, expdir, index, dcGrpInfo)
                     upp(xmlFile, expdir, index, dcGrpInfo)
             if os.getenv("DO_GRAPHICS", 'FALSE').upper() == "TRUE":
+                if not os.path.exists(f"{HOMErrfs}/workflow/sideload/pygraf"):
+                    print("  *** DO_GRAPHICS=true but pygraf not cloned yet!!! ***\n  run `tools/clone_pygraf.sh` first\n")
+                    sys.exit(1)
                 for index, dcGrpInfo in enumerate(listPostGrpInfo):
                     graphics(xmlFile, expdir, index, dcGrpInfo)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -122,6 +122,9 @@ def setup_xml(HOMErrfs, expdir):
                 for index, dcGrpInfo in enumerate(listPostGrpInfo):
                     mpassit(xmlFile, expdir, index, dcGrpInfo)
                     upp(xmlFile, expdir, index, dcGrpInfo)
+            if os.getenv("DO_GRAPHICS", 'FALSE').upper() == "TRUE":
+                for index, dcGrpInfo in enumerate(listPostGrpInfo):
+                    graphics(xmlFile, expdir, index, dcGrpInfo)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":
                 hofx(xmlFile, expdir)
 
@@ -179,8 +182,6 @@ def setup_xml(HOMErrfs, expdir):
             clean(xmlFile, expdir)
         if os.getenv("DO_MISC", 'FALSE').upper() == "TRUE":
             misc(xmlFile, expdir)
-        if os.getenv("DO_GRAPHICS", 'FALSE').upper() == "TRUE":
-            graphics(xmlFile, expdir)
         #
         wflow_end(xmlFile)
 # ---------------------------------------------------------------------------

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -124,11 +124,10 @@ def setup_xml(HOMErrfs, expdir):
                     mpassit(xmlFile, expdir, index, dcGrpInfo)
                     upp(xmlFile, expdir, index, dcGrpInfo)
             if os.getenv("DO_GRAPHICS", 'FALSE').upper() == "TRUE":
+                graphics(xmlFile, expdir)
                 if not os.path.exists(f"{HOMErrfs}/workflow/sideload/pygraf"):
                     print("  *** DO_GRAPHICS=true but pygraf not cloned yet!!! ***\n  run `tools/clone_pygraf.sh` first\n")
                     sys.exit(1)
-                for index, dcGrpInfo in enumerate(listPostGrpInfo):
-                    graphics(xmlFile, expdir, index, dcGrpInfo, index == len(listPostGrpInfo) - 1)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":
                 hofx(xmlFile, expdir)
 

--- a/workflow/sideload/graphics.sh
+++ b/workflow/sideload/graphics.sh
@@ -4,38 +4,42 @@ declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LI
 set -x
 date
 #
-export task_id=${task_id:-'graphics'}
-mkdir -p "${DATA}/nclprd"
-
-fhr=${FHR:-0}  # use this line or the next line
-#fhr=$((10#${FHR:-0})) # remove leading zeros
-area=${AERA:-full}
-grafdir=/lfs5/BMC/nrtrr/FIX_RRFS2/exec/pygraf
-YYJJJHH=$(date +%y%j%H -d "${CDATE:0:8} ${CDAE:8:2}")
-
-cd "${grafdir}" || exit 1
-set +x # supress messy module load information
-source pre.sh
-module use /lfs5/BMC/nrtrr/FIX_RRFS2/modulefiles
-module load prod_util/2.1.1
-set -x
-# can pygraf handle fhr in 3 digits, e.g. 000, 100?
-python create_graphics.py \
-  maps \
-  --all_leads \
-  -d "${COMINrrfs}/${RUN}.${PDY}/${cyc}/upp" \
-  -f "${fhr}" \
-  --file_type prs \
-  --file_tmpl "${YYJJJHH}0000{FCST_TIME:02d}" \
-  --images "${grafdir}/image_lists/hrrr_subset.yml hourly" \
-  -m "${NET}" \
-  -n "${SLURM_CPUS_ON_NODE:-12}" \
-  -o "${DATA}" \
-  -s "${CDATE}" \
-  --tiles "${AREA}" \
-  -z "${DATA}/nclprd"
-export err=$?; err_chk
-# link results to ${COMOUT}
-ln -snf "${DATA}" "${COMOUT}"
+pygrafdir="${HOMErrfs}/workflow/sideload/pygraf"
+image_list="${pygrafdir}/image_lists/regional_mpas_subset.yml"
+file_tmpl="rrfs.t${cyc}z.prslev.f0{FCST_TIME:02d}.conus.grib2"
+model=${NET}
+ntasks=${SLURM_CPUS_ON_NODE:-12}
+grib2_dir="${COMOUT}/upp/det"
+workdir="${COMOUT}/graphics"
+mkdir -p "${workdir}"
+cd "${pygrafdir}" || exit 1
+#
+# find forecst length for this cycle
+#
+fcst_len_hrs_cycles=${FCST_LEN_HRS_CYCLES:-"01 01"}
+fcst_len_hrs_thiscyc=$( "${USHrrfs}/find_fcst_length.sh"  "${fcst_len_hrs_cycles}"  "${cyc}" )
+echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
+read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
+fhr1=${fhr_all[0]}
+fhr2=${fhr_all[${#fhr_all[@]}-1]}
+if (( fcst_len_hrs_thiscyc <= fhr2 )); then 
+  fhr2=fcst_len_hrs_thiscyc
+fi
+#
+read -ra tiles <<< "${TILES}"
+for tile in ${tiles[@]}; do
+  tmpdir="${workdir}/tmp"
+  python create_graphics.py maps --all_leads -d ${grib2_dir} -f ${fhr1} ${fhr2} --file_type prs --file_tmpl ${file_tmpl} -m ${model} \
+      --images ${image_list} hourly -n ${ntasks} -o ${tmpdir} -s ${CDATE} --tiles ${tile}
+  export err=$?; err_chk
+  #
+  mkdir -p "${tmpdir}/${tile}"
+  dirs=(${tmpdir}/*/)
+  for i in ${dirs[@]}; do
+    mv ${i}/* "${tmpdir}/${tile}"
+  done
+done
+#
+# zip the files if requested
 
 exit 0

--- a/workflow/sideload/graphics.sh
+++ b/workflow/sideload/graphics.sh
@@ -48,7 +48,17 @@ for tile in ${tiles[@]}; do
   done
 done
 #
-# zip the files if requested and the last group
+# zip the graphics if requested and it is the last group
+if [[ "${GRAPHICS_ZIP^^}" == "TRUE" ]] && [[ "${LAST_GROUP^^}" == "TRUE"   ]]; then
+  mkdir -p "${COMOUT}/nclprd"
+  for tile in ${tiles[@]}; do
+    cd "${COMOUT}/graphics/${tile}"
+    zip files.zip *.png
+    mkdir -p "${COMOUT}/nclprd/${tile}"
+    mv files.zip "${COMOUT}/nclprd/${tile}"
+    rm -rf "${COMOUT}/graphics/${tile}"
+  done
+fi
 
 export err=$?; err_chk
 exit 0

--- a/workflow/sideload/graphics.sh
+++ b/workflow/sideload/graphics.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1090,SC1091,SC2034,SC2154,SC2153
+# shellcheck disable=all
 declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]: '
 set -x
 date
@@ -40,6 +40,6 @@ for tile in ${tiles[@]}; do
   done
 done
 #
-# zip the files if requested
+# zip the files if requested and the last group
 
 exit 0

--- a/workflow/sideload/graphics.sh
+++ b/workflow/sideload/graphics.sh
@@ -14,9 +14,9 @@ pygrafdir="${HOMErrfs}/workflow/sideload/pygraf"
 image_list="${pygrafdir}/image_lists/regional_mpas_subset.yml"
 file_tmpl="rrfs.t${cyc}z.prslev.f0{FCST_TIME:02d}.conus.grib2"
 model=${NET}
-ntasks=${SLURM_CPUS_ON_NODE:-12}
+ntasks=${NTASKS:-12}
 grib2_dir="${COMOUT}/upp/det"
-workdir="${COMOUT}/graphics/g${GROUP_INDEX}"
+workdir="${COMOUT}/graphics/tmp"
 rm -rf "${workdir}"
 mkdir -p "${workdir}"
 cd "${pygrafdir}" || exit 1
@@ -26,19 +26,16 @@ cd "${pygrafdir}" || exit 1
 fcst_len_hrs_cycles=${FCST_LEN_HRS_CYCLES:-"01 01"}
 fcst_len_hrs_thiscyc=$( "${USHrrfs}/find_fcst_length.sh"  "${fcst_len_hrs_cycles}"  "${cyc}" )
 echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
-read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
-fhr1=${fhr_all[0]}
-fhr2=${fhr_all[${#fhr_all[@]}-1]}
-if (( fcst_len_hrs_thiscyc <= fhr2 )); then 
-  fhr2=${fcst_len_hrs_thiscyc}
-fi
+fhr1=0
+fhr2=${fcst_len_hrs_thiscyc}
+wait_minutes=${WAIT_MINUTES:-1}
 #
 # generate the graphics under workdir and then move to graphics/{tile}
 #
 read -ra tiles <<< "${TILES}"
 for tile in ${tiles[@]}; do
   python create_graphics.py maps --all_leads -d ${grib2_dir} -f ${fhr1} ${fhr2} --file_type prs --file_tmpl ${file_tmpl} -m ${model} \
-      --images ${image_list} hourly -n ${ntasks} -o ${workdir} -s ${CDATE} --tiles ${tile}
+      --images ${image_list} hourly -n ${ntasks} -o ${workdir} -s ${CDATE} --tiles ${tile} -w ${wait_minutes}
   export err=$?; err_chk
   #
   mkdir -p "${COMOUT}/graphics/${tile}"
@@ -48,8 +45,8 @@ for tile in ${tiles[@]}; do
   done
 done
 #
-# zip the graphics if requested and it is the last group
-if [[ "${GRAPHICS_ZIP^^}" == "TRUE" ]] && [[ "${LAST_GROUP^^}" == "TRUE"   ]]; then
+# zip the graphics if requested
+if [[ "${GRAPHICS_ZIP^^}" == "TRUE" ]]; then
   mkdir -p "${COMOUT}/nclprd"
   for tile in ${tiles[@]}; do
     cd "${COMOUT}/graphics/${tile}"

--- a/workflow/sideload/graphics.sh
+++ b/workflow/sideload/graphics.sh
@@ -4,13 +4,20 @@ declare -rx PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LI
 set -x
 date
 #
+export HOMErrfs=${HOMErrfs} #comes from the workflow at runtime
+export EXECrrfs=${EXECrrfs:-${HOMErrfs}/exec}
+export FIXrrfs=${FIXrrfs:-${HOMErrfs}/fix}
+export PARMrrfs=${PARMrrfs:-${HOMErrfs}/parm}
+export USHrrfs=${USHrrfs:-${HOMErrfs}/ush}
+#
 pygrafdir="${HOMErrfs}/workflow/sideload/pygraf"
 image_list="${pygrafdir}/image_lists/regional_mpas_subset.yml"
 file_tmpl="rrfs.t${cyc}z.prslev.f0{FCST_TIME:02d}.conus.grib2"
 model=${NET}
 ntasks=${SLURM_CPUS_ON_NODE:-12}
 grib2_dir="${COMOUT}/upp/det"
-workdir="${COMOUT}/graphics"
+workdir="${COMOUT}/graphics/g${GROUP_INDEX}"
+rm -rf "${workdir}"
 mkdir -p "${workdir}"
 cd "${pygrafdir}" || exit 1
 #
@@ -23,23 +30,25 @@ read -ra fhr_all <<< "${GROUP_HOURS}"  # convert string to array
 fhr1=${fhr_all[0]}
 fhr2=${fhr_all[${#fhr_all[@]}-1]}
 if (( fcst_len_hrs_thiscyc <= fhr2 )); then 
-  fhr2=fcst_len_hrs_thiscyc
+  fhr2=${fcst_len_hrs_thiscyc}
 fi
+#
+# generate the graphics under workdir and then move to graphics/{tile}
 #
 read -ra tiles <<< "${TILES}"
 for tile in ${tiles[@]}; do
-  tmpdir="${workdir}/tmp"
   python create_graphics.py maps --all_leads -d ${grib2_dir} -f ${fhr1} ${fhr2} --file_type prs --file_tmpl ${file_tmpl} -m ${model} \
-      --images ${image_list} hourly -n ${ntasks} -o ${tmpdir} -s ${CDATE} --tiles ${tile}
+      --images ${image_list} hourly -n ${ntasks} -o ${workdir} -s ${CDATE} --tiles ${tile}
   export err=$?; err_chk
   #
-  mkdir -p "${tmpdir}/${tile}"
-  dirs=(${tmpdir}/*/)
+  mkdir -p "${COMOUT}/graphics/${tile}"
+  dirs=(${workdir}/*/)
   for i in ${dirs[@]}; do
-    mv ${i}/* "${tmpdir}/${tile}"
+    mv ${i}/* "${COMOUT}/graphics/${tile}"
   done
 done
 #
 # zip the files if requested and the last group
 
+export err=$?; err_chk
 exit 0

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -163,8 +163,9 @@ case ${task_id} in
     fi
     ;;
   graphics)
-    module purge
+    set +x
     source "${HOMErrfs}/workflow/tools/load_pygraf.sh"
+    set -x
     "${HOMErrfs}/workflow/sideload/${task_id}.sh"
     ;;
   *)

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -162,7 +162,9 @@ case ${task_id} in
       exit 0
     fi
     ;;
-  graphics|misc)
+  graphics)
+    module purge
+    source "${HOMErrfs}/workflow/tools/load_pygraf.sh"
     "${HOMErrfs}/workflow/sideload/${task_id}.sh"
     ;;
   *)

--- a/workflow/tools/clone_pygraf.sh
+++ b/workflow/tools/clone_pygraf.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# shellcheck disable=all
+pygraf_hash=36841088
+#
+toolsdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${toolsdir}/../sideload"
+if [[ -d pygraf ]]; then
+  echo "pygraf/ already cloned, no actions."
+else
+  which git-lfs 2>/dev/null ||  module load git-lfs
+  set -x
+  GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/NOAA-GSL/pygraf.git
+  cd pygraf
+  git checkout "${pygraf_hash}" &> /dev/null
+fi

--- a/workflow/tools/load_pygraf.sh
+++ b/workflow/tools/load_pygraf.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# shellcheck disable=all
+# Check if the script is sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Usage: source ${0}"
+  exit 1
+fi
+
+### scripts continues here...
+ushdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+if [[ -z "${MACHINE}" ]]; then
+  # shellcheck disable=SC1091
+  source "${ushdir}/detect_machine.sh"
+fi
+
+case ${MACHINE} in
+  wcoss2)
+    BASEDIR=/to/be/added
+    ;;
+  hera)
+    BASEDIR=/scratch3/BMC/wrfruc/hera/Miniforge3
+    ;;
+  ursa)
+    BASEDIR=/scratch3/BMC/wrfruc/gge/Miniforge3
+    ;;
+  derecho)
+    BASEDIR=/glade/work/geguo/Miniforge3
+    ;;
+  jet)
+    BASEDIR=/lfs6/BMC/wrfruc/gge/Miniforge3
+    ;;
+  orion)
+    BASEDIR=/work/noaa/zrtrr/gge/Miniforge3
+    ;;
+  hercules)
+    BASEDIR=/work/noaa/zrtrr/gge/hercules/Miniforge3
+    ;;
+  gaeac?)
+    if [[ -d /gpfs/f5 ]]; then
+      BASEDIR=/to/be/added
+    elif [[ -d /gpfs/f6 ]]; then
+      BASEDIR=/gpfs/f6/bil-fire10-oar/world-shared/gge/Miniforge3
+    else
+      echo "unsupported gaea cluster: ${MACHINE}"
+    fi
+    ;;
+  *)
+    BASEDIR=/unknown/location
+    echo "platform not supported: ${MACHINE}"
+    ;;
+esac
+eval "$($BASEDIR/bin/micromamba shell hook --shell bash)"
+micromamba activate ${BASEDIR}/envs/pygraf
+alias conda=micromamba


### PR DESCRIPTION
A few users have requested the Graphics capability for either retros or realtime runs other than RRFSv2X (such as fire weather, Atmospheric River). 
In rrfs-workflow, we previously hardwired the Graphics task for `jet` only.

This PR updates the Graphics task so that it can run on all supported platforms (gaea, orion/hercules, ursa/hera, derecho).


A note about the [pygraf](https://github.com/NOAA-GSL/pygraf) repository:
This repo contains a few GB git-lfs files which are NOT needed in the workflow.
To avoid checking out those not-needed git-lfs files, we decide to use the utility `tools/clone_pygraf` to do a light clone and the exp setup process will remind users to do so if `DO_GRAPHICS=true`

##### Available options for the GRAPHICS task in the exp file:
```
export GRAPHICS_TILES="full NE NC NW SE SC SW EastCO"  
          # can be any combination of these tiles, default to "full"
export GRAPHICS_ZIP=true  
         # if true, zip small graphics files into files.zip under the nclprod/ directory, default to false
```
