### PR TITLE
[rrfs-nco] Move "mkdir surface.$PDY" to after setpdy.sh

### DIFF
--- a/jobs/JRRFS_SAVE_RESTART
+++ b/jobs/JRRFS_SAVE_RESTART
@@ -68,7 +68,7 @@ export shared_forecast_output_data=${umbrella_forecast_data}/output
 export shared_forecast_restart_data=${umbrella_forecast_data}/RESTART
 
 export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA} ${SURFACE_DIR}/surface.${PDY}
+mkdir -p ${DATA}
 cd ${DATA}
 
 #-----------------------------------------------------------------------
@@ -94,6 +94,7 @@ fi
 
 export COMOUT=${COMOUT}/forecast
 mkdir -p ${COMOUT}/RESTART ${COMOUT}/INPUT
+mkdir -p ${SURFACE_DIR}/surface.${PDY}
 
 #-----------------------------------------------------------------------
 # Source the bash utility functions.


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- save_restart jobs failed because `mkdir -p ${DATA} ${SURFACE_DIR}/surface.${PDY}` was before setpdy.sh was called.
- This PR moves `mkdir -p ${SURFACE_DIR}/surface.${PDY}` to after setpdy.sh
 
## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested in NCO real-time parallel.



