### PR TITLE
add a new option 'REGRID_RRFS_GRIB2' to allow regrid NA3km rotated-lat-lon to the 3km variation of grid 130 before ungrib

### DIFF
--- a/scripts/exrrfs_ungrib.sh
+++ b/scripts/exrrfs_ungrib.sh
@@ -49,7 +49,7 @@ for fhr in  ${fhr_all}; do
   GRIBFILE="${SOURCE_BASEDIR}/${TARGET_FILE}"
   if [[ "${REGRID_RRFS_GRIB2^^}" == "TRUE"  ]]; then
     if [[ -s "${GRIBFILE}" ]]; then
-      source "${USHrrfs}"/regrid_rrfs_grib2.sh # regrid NA3km rotated-lat-lon to grid 130
+      source "${USHrrfs}"/regrid_rrfs_grib2.sh # regrid NA3km rotated-lat-lon to the 3km variation of grid 130
     else
       echo "FATAL ERROR: ${GRIBFILE} missing"
       err_exit

--- a/scripts/exrrfs_ungrib.sh
+++ b/scripts/exrrfs_ungrib.sh
@@ -47,7 +47,14 @@ for fhr in  ${fhr_all}; do
   TARGET_FILE=${FILENAME_PATTERN/^HHH^/${HHH}}
   TARGET_FILE=${TARGET_FILE/^HH^/${HH}}
   GRIBFILE="${SOURCE_BASEDIR}/${TARGET_FILE}"
-  if [[ -s "${GRIBFILE}" ]]; then
+  if [[ "${REGRID_RRFS_GRIB2^^}" == "TRUE"  ]]; then
+    if [[ -s "${GRIBFILE}" ]]; then
+      source "${USHrrfs}"/regrid_rrfs_grib2.sh # regrid NA3km rotated-lat-lon to grid 130
+    else
+      echo "FATAL ERROR: ${GRIBFILE} missing"
+      err_exit
+    fi
+  elif [[ -s "${GRIBFILE}" ]]; then
     ${cpreq} "${GRIBFILE}"  "${GRIBFILE_LOCAL}"
     # if FILENAME_PATTERN_B is defined and non-empty
     if [[ -n "${FILENAME_PATTERN_B+x}" ]] && [[ -n "${FILENAME_PATTERN_B}" ]]; then

--- a/ush/regrid_rrfs_grib2.sh
+++ b/ush/regrid_rrfs_grib2.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# interplate RRFS NA3km grib2 files to the variation 130 grid at 3km
+#
+# shellcheck disable=SC2154,SC2153,SC2086
+
+budget_fields=":(WEASD|APCP|NCPCP|ACPCP|SNOD):"
+neighbor_fields=":(NCONCD|NCCICE|SPNCR|CLWMR|CICE|RWMR|SNMR|GRLE|PMTF|PMTC|REFC|CSNOW|CICEP|CFRZR|CRAIN|LAND|ICEC|TMP:surface|VEG|CCOND|SFEXC|MSLMA|PRES:tropopause|LAI|HPBL|HGT:planetary boundary layer): "
+grid_specs="lambert:266:25.000000 234.862000:2000:3000.000000 18.281000:1450:3000.000000"
+
+wgrib2 "${GRIBFILE}" -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
+       -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH"               \
+       -new_grid_interpolation bilinear \
+       -if "${budget_fields}"   -new_grid_interpolation budget -fi \
+       -if "${neighbor_fields}" -new_grid_interpolation neighbor -fi \
+       -new_grid ${grid_specs} "tmp.${GRIBFILE_LOCAL}"
+
+# store vector records together in the sam GRIB2 message as submessages
+wgrib2 "tmp.${GRIBFILE_LOCAL}" -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" -submsg_uv "${GRIBFILE_LOCAL}"

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -24,7 +24,7 @@ export EMPTY_OBS_SPACE_ACTION=${EMPTY_OBS_SPACE_ACTION:-"skip output"}
 export MPASOUT_TIMELEVELS=${MPASOUT_TIMELEVELS:-"0 1"}
 export MPASOUT_SAVE2COM_HRS=${MPASOUT_SAVE2COM_HRS:-""}  # cycling mpasout.nc is saved by the 'save_for_next' task; specify other mpasout hours if needed, e.g. "02 03", "24", "24 48"
 #export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; setting this variable will overwrite POST_GROUP_TOT_NUM
-export REGRID_RRFS_GRIB2=${REGRID_RRFS_GRIB2:-FALSE}
+export REGRID_RRFS_GRIB2=${REGRID_RRFS_GRIB2:-false}
 
 # PREP_LBC_LOOK_BACK_HRS
 if ${REALTIME:-false}; then

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -24,6 +24,7 @@ export EMPTY_OBS_SPACE_ACTION=${EMPTY_OBS_SPACE_ACTION:-"skip output"}
 export MPASOUT_TIMELEVELS=${MPASOUT_TIMELEVELS:-"0 1"}
 export MPASOUT_SAVE2COM_HRS=${MPASOUT_SAVE2COM_HRS:-""}  # cycling mpasout.nc is saved by the 'save_for_next' task; specify other mpasout hours if needed, e.g. "02 03", "24", "24 48"
 #export POST_GROUP_SPEC="0-10 11-20 21-30 31-36" # customized group specification; setting this variable will overwrite POST_GROUP_TOT_NUM
+export REGRID_RRFS_GRIB2=${REGRID_RRFS_GRIB2:-FALSE}
 
 # PREP_LBC_LOOK_BACK_HRS
 if ${REALTIME:-false}; then

--- a/workflow/rocoto_funcs/ungrib_ic.py
+++ b/workflow/rocoto_funcs/ungrib_ic.py
@@ -45,6 +45,9 @@ def ungrib_ic(xmlFile, expdir, do_ensemble=False):
         meta_end = f'</metatask>\n'
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
+    regrid_rrfs_grib2 = os.getenv('REGRID_RRFS_GRIB2', 'FALSE').upper()
+    if regrid_rrfs_grib2 == "TRUE":
+        dcTaskEnv['REGRID_RRFS_GRIB2'] = "TRUE"
     # dependencies
     if extrn_mdl_source == "GFS_NCO":
         COMINgfs = os.getenv("COMINgfs", 'COMINgfs_not_defined')

--- a/workflow/rocoto_funcs/ungrib_lbc.py
+++ b/workflow/rocoto_funcs/ungrib_lbc.py
@@ -63,6 +63,9 @@ def ungrib_lbc(xmlFile, expdir, do_ensemble=False):
     dcTaskEnv['GROUP_TOTAL_NUM'] = f'{lbc_ungrib_group_total_num}'
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
+    regrid_rrfs_grib2 = os.getenv('REGRID_RRFS_GRIB2', 'FALSE').upper()
+    if regrid_rrfs_grib2 == "TRUE":
+        dcTaskEnv['REGRID_RRFS_GRIB2'] = "TRUE"
     # dependencies
     if extrn_mdl_source == "GFS_NCO":
         COMINgfs = os.getenv("COMINgfs", 'COMINgfs_not_defined')


### PR DESCRIPTION
PR #1422 updated rrfs-workflow to be able to handle the full NA3km 9GB grib2 files directly on the rotated-lat-lon grid. This is a great step forward. 

However, currently, it takes 4+ minutes more to get each ICs/LBCs. Given the limited resources of the realtime RRFSv2X, MPAS_RRFSA runs, the previous regrid then ungrib method is still preferred. And we can continue optimizing the direct handling method.

The PR adds back the previous regrid and then ungrib method. It is now turned on/off by configuring the `REGRID_RRFS_GRIB2` option in the exp files. This way, we keep the directly reading method as well as the previous method to meet different needs.
