### PR TITLE
[rrfs-nco] Remove hourly max PRATE from subhourly output, fix issue with REFS f00 2DFLD file

### DIFF
--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -472,7 +472,7 @@ if [ -f PRSLEV.GrbF${post_fhr} ]; then
     if [ -e $fld2d_subh -a -e $tm15 -a -e $tm30 -a -e $tm45 ]
     then
       cat $tm45 $tm30 $tm15 $fld2d_subh > 2DFLD.GrbF${fhr}_subh
-      wgrib2 2DFLD.GrbF${fhr}_subh -set center 7 -grib $fld2d_subh_combo >> $pgmout 2>> errfile
+      wgrib2 2DFLD.GrbF${fhr}_subh -set center 7 -not max -grib $fld2d_subh_combo >> $pgmout 2>> errfile
     else
       msg="FATAL ERROR: ABORTING due to missing 15 minute UPP output $fld2d_subh $tm15 $tm30 $tm45"
       err_exit $msg

--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -489,11 +489,7 @@ if [ $WGF = "det" ] || [ $WGF = "ensf" ]; then
   if [ $WGF = "det" ]; then
     $EXECrrfs/$pgm NATLEV.GrbF${post_fhr} DPT2M.GrbF${post_fhr} >>$pgmout 2>errfile
   elif [ $WGF = "ensf" ]; then
-     if [[ $post_fhr == '00' ]]; then
-       $EXECrrfs/$pgm NATLEV.GrbF${post_fhr} DPT2M.GrbF${post_fhr} >>$pgmout 2>errfile
-     else
-       $EXECrrfs/$pgm 2DFLD.GrbF${post_fhr} DPT2M.GrbF${post_fhr} >>$pgmout 2>errfile
-     fi
+    $EXECrrfs/$pgm 2DFLD.GrbF${post_fhr} DPT2M.GrbF${post_fhr} >>$pgmout 2>errfile
   fi
   export err=$?; err_chk
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR includes two small fixes that did not make it into #1421 in time before it got merged.  Sorry for not catching these sooner - there were quite a lot of last minute product changes to keep track of!
1. The subhourly GRIB2 output files contain one extra field that doesn't need to be there - hourly max PRATE.  It is included with the on-the-hour parameters because subh_fields.txt contains PRATE:surface, which grabs both PRATE parameters.  A simple fix for this is to modify the wgrib2 command in exrrfs_post.sh to remove the PRATE hourly max field (-not max).
2. The REFS 2DFLD GRIB2 file at f00 does not contain SPFH and HGT at hybrid level 1 - I accidentally added them to the wrong section of the UPP control files.  I have updated REFS f00 files here on Cactus (fix/upp directory):
```
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_updates_20260326/fix/upp/postxconfig-NT-refs_f00.txt
/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_updates_20260326/fix/upp/refs_postcntrl_f00.xml
```
This error explains why the dew point processing step crashed at f00 with the 2DFLD file, so I reverted the recent change in exrrfs_post.sh to always use the 2DFLD file for the ensemble members.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- I tested the wgrib2 functionality on the command line and it works as expected.  The subhourly output files will contain 156 records instead of 157 with this fix.
- I generated f00 REFS output and can confirm the 2DFLD file now contains SPFH and HGT at hybrid level 1.  The associated workflow changes have not been tested but they can be tested in EMC's parallel - I don't anticipate any issues.