### PR TITLE
Remove 'rainnc' from the da_state

### DIFF
--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.da_state
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.da_state
@@ -59,7 +59,6 @@ tyear_accum
 refl10cm
 refl10cm_max
 rainc
-rainnc
 i_rainnc
 rainncv
 snowncv

--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.da_state
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.da_state
@@ -59,6 +59,7 @@ tyear_accum
 refl10cm
 refl10cm_max
 rainc
+rainnc
 i_rainnc
 rainncv
 snowncv

--- a/fix/stream_list/hrrrv5/stream_list.atmosphere.da_state
+++ b/fix/stream_list/hrrrv5/stream_list.atmosphere.da_state
@@ -59,7 +59,6 @@ tyear_accum
 refl10cm
 refl10cm_max
 rainc
-rainnc
 i_rainnc
 rainncv
 snowncv


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Remove rainnc from mpasout files, in order to not accumulate the field since the last cold start, but only since the beginning of the current simulation.  

## TESTS CONDUCTED: 
A CONUS 3-km retro on Gaea C6 demonstrated that the rainnc accumulation issue is corrected with this fix.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in [#1444 ]

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

