### PR TITLE
Update UPP hash and fix files to resolve issues with surface SW radiation fields, missing DPT field

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs_v1
-hash = 084024b
+hash = 8393f42
 local_path = UPP
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- This PR contains 2 small product-related updates to fix a couple of issues that were discovered by downstream users of the RRFS: 
1. The hash of the UPP code is updated to the latest version in the release/rrfs_v1 branch.  A member of the NWM team discovered that there are issues with 3 parameters in the newly added 2DFLD GRIB2 files: CSDSF, instantaneous surface USWRF, and instantaneous surface DSWRF.  The issue is related to an incorrect calculation of the solar zenith angle.  So the UPP code will need to be recompiled with this PR.
2. Dew point at hybrid level 1 is missing from the REFS testbed GRIB2 files.  This field is needed/requested by SPC.  The following UPP fix files are updated to add DPT:1 hybrid level to the REFS 2DFLD and testbed files in order to fix this issue, since the NATLEV output is turned off for the ensemble members (except f00).
On Cactus/Dogwood:
`/lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/post_updates_20260421/fix/upp`
postxconfig-NT-refs_f00.txt     
postxconfig-NT-refs_f01.txt    
postxconfig-NT-refs.txt         
refs_postcntrl_f00.xml 
refs_postcntrl_f01.xml       
refs_postcntrl.xml
testbed_fields_2dfld.txt

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
The updated UPP hash was successfully tested as part of [UPP PR 1503](https://github.com/NOAA-EMC/UPP/pull/1503).
The modifications for the testbed files were successfully tested in a standalone script outside of the workflow.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Continues to address #1313 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@WenMeng-NOAA 
