### PR TITLE
use ip_d instead of ip_4 for snow trim in rrfs_util and update GSI wi…

### DIFF
--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -32,7 +32,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/GSI
 # Specify either a branch name or a hash but not both.
 #branch = release/rrfs.v1.0.0
-hash = b857ade
+hash = db90edf
 local_path = gsi
 required = True
 externals = None
@@ -42,7 +42,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 0a4d1cf
+hash = 0cd8036
 local_path = rrfs_utl
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- use ip_d instead of ip_4 for snow trim in rrfs_util
- update GSI with bug fix in the forward operator in windborne observations. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested in the real time parallel, gsi.x, gsi_enkf.x and rrfs_util_process_imssnow_fv3lam.exe run as expected.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [X] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [X] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

