### PR TITLE
[rrfs-nco] Adds ${CYCLE} as a fresh argument passed to stnmlist executable.

### DIFF
--- a/scripts/exrrfs_bufrsnd.sh
+++ b/scripts/exrrfs_bufrsnd.sh
@@ -124,9 +124,6 @@ MM=`echo $PDY | cut -c5-6`
 DD=`echo $PDY | cut -c7-8`
 CYCLE=$PDY$cyc
 
-startd=$YYYY$MM$DD
-startdate=$CYCLE
-
 STARTDATE=${YYYY}-${MM}-${DD}_${cyc}:00:00
 endtime=$($NDATE ${FHRLIM} ${YYYY}${MM}${DD}${cyc})
 
@@ -327,6 +324,7 @@ cat <<EOF > stnmlist_input
 1
 $DATA/class1.bufr
 ${COMOUT}/bufr.${cyc}/bufr
+${CYCLE}
 EOF
 
 mkdir -p ${COMOUT}/bufr.${cyc}

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -42,7 +42,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl
 # Specify either a branch name or a hash but not both.
 #branch = production/RRFS.v1
-hash = 0cd8036
+hash = 45c1cda
 local_path = rrfs_utl
 required = True
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Updates the exrrfs_bufrsnd.sh script, removing a couple of items defined but never used, and adding a fourth argument in the namelist used for the stnmlist executable. 
- Has a corresponding change to the rrfs_utl repository (https://github.com/NOAA-GSL/rrfs_utl/pull/96)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others: 

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Partially fixes the issue(s) mentioned in #1452 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

