### PR TITLE
Add bufr2ioda_amsua into workflow

### DIFF
--- a/parm/iodaconv/bufr_1bamua_mapping.yaml
+++ b/parm/iodaconv/bufr_1bamua_mapping.yaml
@@ -1,0 +1,149 @@
+bufr:
+  splits:
+    satId:
+      category:
+        map:
+          _209: n18
+          _223: n19
+          _3: metop-b
+          _4: metop-a
+          _5: metop-c
+        variable: satelliteIdentifier
+
+  variables:
+    brightnessTemperature:
+      query: '*/BRITCSTC/TMBR'
+
+    fieldOfViewNumber:
+      query: '*/FOVN'
+    heightOfStation:
+      query: '*/HMSL'
+
+    latitude:
+      query: '*/CLAT'
+
+    longitude:
+      query: '*/CLON'
+
+    satelliteIdentifier:
+      query: '*/SAID'
+
+    sensorAzimuthAngle:
+      query: '*/BEARAZ'
+
+    sensorChannelNumber:
+      query: '*/BRITCSTC/CHNM'
+
+    sensorScanAngle:
+      sensorScanAngle:
+        fieldOfViewNumber: '*/FOVN'
+        scanStart: -48.333
+        scanStep: 3.333
+        sensor: amsua
+
+    sensorZenithAngle:
+      query: '*/SAZA'
+
+    solarAzimuthAngle:
+      query: '*/SOLAZI'
+
+    solarZenithAngle:
+      query: '*/SOZA'
+
+    timestamp:
+      datetime:
+        day: '*/DAYS'
+        hour: '*/HOUR'
+        minute: '*/MINU'
+        month: '*/MNTH'
+        second: '*/SECO'
+        year: '*/YEAR'
+
+encoder:
+  backend: netcdf
+
+  dimensions:
+  - name: Channel
+    path: '*/BRITCSTC'
+    source: variables/sensorChannelNumber
+
+  globals:
+  - name: platformCommonName
+    type: string
+    value: AMSUA
+
+  - name: platformLongDescription
+    type: string
+    value: MTYP 021-023 PROC AMSU-A 1B Tb
+
+  variables:
+  - name: MetaData/satelliteIdentifier
+    longName: Satellite Identifier
+    source: variables/satelliteIdentifier
+
+  - name: MetaData/sensorScanPosition
+    longName: Field Of View Number
+    source: variables/fieldOfViewNumber
+
+  - name: MetaData/heightOfStation
+    longName: Altitude of Satellite
+    source: variables/heightOfStation
+    units: m
+
+  - name: MetaData/solarZenithAngle
+    longName: Solar Zenith Angle
+    range: [0, 180]
+    source: variables/solarZenithAngle
+    units: degree
+
+  - name: MetaData/solarAzimuthAngle
+    longName: Solar Azimuth Angle
+    range: [0, 360]
+    source: variables/solarAzimuthAngle
+    units: degree
+
+  - name: MetaData/sensorZenithAngle
+    longName: Sensor Zenith Angle
+    range: [0, 90]
+    source: variables/sensorZenithAngle
+    units: degree
+
+  - name: MetaData/sensorAzimuthAngle
+    longName: Sensor Azimuth Angle
+    range: [0, 360]
+    source: variables/sensorAzimuthAngle
+    units: degree
+
+  - name: MetaData/sensorViewAngle
+    longName: Sensor View Angle
+    source: variables/sensorScanAngle
+    units: degree
+
+  - name: MetaData/sensorChannelNumber
+    longName: Sensor Channel Number
+    source: variables/sensorChannelNumber
+
+  - name: ObsValue/brightnessTemperature
+    longName: Brightness Temperature
+    chunks: [1000, 15]
+    compressionLevel: 4
+    coordinates: longitude latitude Channel
+    range: [100, 500]
+    source: variables/brightnessTemperature
+    units: K
+
+  - name: MetaData/dateTime
+    longName: Datetime
+    source: variables/timestamp
+    units: seconds since 1970-01-01T00:00:00Z
+
+  - name: MetaData/latitude
+    longName: Latitude
+    range: [-90, 90]
+    source: variables/latitude
+    units: degree_north
+
+  - name: MetaData/longitude
+    longName: Longitude
+    source: variables/longitude
+    units: degree_east

--- a/parm/iodaconv/bufr_esamua_mapping.yaml
+++ b/parm/iodaconv/bufr_esamua_mapping.yaml
@@ -1,0 +1,152 @@
+bufr:
+  splits:
+    satId:
+      category:
+        map:
+          _209: n18
+          _223: n19
+          _3: metop-b
+          _4: metop-a
+          _5: metop-c
+        variable: satelliteIdentifier
+
+  variables:
+    brightnessTemperature:
+      query: '*/ATNCHV/TMBRST'
+
+    fieldOfViewNumber:
+      query: '*/FOVN'
+
+    heightOfStation:
+      query: '*/SELV'
+
+    latitude:
+      query: '*/CLATH'
+
+    longitude:
+      query: '*/CLONH'
+
+    satelliteIdentifier:
+      query: '*/SAID'
+
+    sensorAzimuthAngle:
+      query: '*/BEARAZ'
+
+    sensorChannelNumber:
+      query: '*/ATNCHV/INCN'
+      transforms:
+        - offset: -27
+
+    sensorScanAngle:
+      sensorScanAngle:
+        fieldOfViewNumber: '*/FOVN'
+        scanStart: -48.333
+        scanStep: 3.333
+        sensor: amsua
+
+    sensorZenithAngle:
+      query: '*/SAZA'
+
+    solarAzimuthAngle:
+      query: '*/SOLAZI'
+
+    solarZenithAngle:
+      query: '*/SOZA'
+
+    timestamp:
+      datetime:
+        day: '*/DAYS'
+        hour: '*/HOUR'
+        minute: '*/MINU'
+        month: '*/MNTH'
+        second: '*/SECO'
+        year: '*/YEAR'
+
+encoder:
+  backend: netcdf
+
+  dimensions:
+  - name: Channel
+    path: '*/ATNCHV'
+    source: variables/sensorChannelNumber
+
+  globals:
+  - name: platformCommonName
+    type: string
+    value: AMSUA
+
+  - name: platformLongDescription
+    type: string
+    value: MTYP 021-033 RARS(EARS,AP,SA) AMSU-A 1C Tb DATA)
+
+  variables:
+  - name: MetaData/satelliteIdentifier
+    longName: Satellite Identifier
+    source: variables/satelliteIdentifier
+
+  - name: MetaData/sensorScanPosition
+    longName: Field Of View Number
+    source: variables/fieldOfViewNumber
+
+  - name: MetaData/heightOfStation
+    longName: Altitude of Satellite
+    source: variables/heightOfStation
+    units: m
+
+  - name: MetaData/solarZenithAngle
+    longName: Solar Zenith Angle
+    range: [0, 180]
+    source: variables/solarZenithAngle
+    units: degree
+
+  - name: MetaData/solarAzimuthAngle
+    longName: Solar Azimuth Angle
+    range: [0, 360]
+    source: variables/solarAzimuthAngle
+    units: degree
+
+  - name: MetaData/sensorZenithAngle
+    longName: Sensor Zenith Angle
+    range: [0, 90]
+    source: variables/sensorZenithAngle
+    units: degree
+
+  - name: MetaData/sensorAzimuthAngle
+    longName: Sensor Azimuth Angle
+    range: [0, 360]
+    source: variables/sensorAzimuthAngle
+    units: degree
+
+  - name: MetaData/sensorViewAngle
+    longName: Sensor View Angle
+    source: variables/sensorScanAngle
+    units: degree
+
+  - name: MetaData/sensorChannelNumber
+    longName: Sensor Channel Number
+    source: variables/sensorChannelNumber
+
+  - name: ObsValue/brightnessTemperature
+    longName: Brightness Temperature
+    chunks: [1000, 15]
+    compressionLevel: 4
+    coordinates: longitude latitude Channel
+    range: [100, 500]
+    source: variables/brightnessTemperature
+    units: K
+
+  - name: MetaData/dateTime
+    longName: Datetime
+    source: variables/timestamp
+    units: seconds since 1970-01-01T00:00:00Z
+
+  - name: MetaData/latitude
+    longName: Latitude
+    range: [-90, 90]
+    source: variables/latitude
+    units: degree_north
+
+  - name: MetaData/longitude
+    longName: Longitude
+    source: variables/longitude
+    units: degree_east

--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -227,7 +227,6 @@ shopt -s nullglob
 dirs=("$RDASAPP_DIR"/build/lib/python3.*)
 PYIODALIB=${dirs[0]}
 WXFLOWLIB=${RDASAPP_DIR}/sorc/wxflow/src
-export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYTHONPATH}"
 export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYIODALIB}/site-packages:${PYTHONPATH}"
 
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.json .

--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -228,7 +228,7 @@ dirs=("$RDASAPP_DIR"/build/lib/python3.*)
 PYIODALIB=${dirs[0]}
 WXFLOWLIB=${RDASAPP_DIR}/sorc/wxflow/src
 export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYTHONPATH}"
-export PYTHONPATH="${RDASAPP_DIR}/build/lib/python3.11/site-packages:${PYTHONPATH}"
+export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYIODALIB}/site-packages:${PYTHONPATH}"
 
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.json .
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.py .

--- a/scripts/exrrfs_ioda_bufr.sh
+++ b/scripts/exrrfs_ioda_bufr.sh
@@ -162,6 +162,8 @@ cp "${OBSPATH}/${CDATE}.rap.t${cyc}z.satwnd.tm00.bufr_d" satwndbufr
 cp "${OBSPATH}/${CDATE}.rap.t${cyc}z.gsrcsr.tm00.bufr_d" abibufr
 cp "${OBSPATH}/${CDATE}.rap.t${cyc}z.atms.tm00.bufr_d" atmsbufr
 cp "${OBSPATH}/${CDATE}.rap.t${cyc}z.crisf4.tm00.bufr_d" crisfsbufr
+cp "${OBSPATH}/${CDATE}.rap.t${cyc}z.1bamua.tm00.bufr_d" 1bamsuabufr
+cp "${OBSPATH}/${CDATE}.rap.t${cyc}z.esamua.tm00.bufr_d" esamsuabufr
 #
 #-----------------------------------------------------------------------
 #
@@ -226,6 +228,7 @@ dirs=("$RDASAPP_DIR"/build/lib/python3.*)
 PYIODALIB=${dirs[0]}
 WXFLOWLIB=${RDASAPP_DIR}/sorc/wxflow/src
 export PYTHONPATH="${WXFLOWLIB}:${PYIODALIB}:${PYTHONPATH}"
+export PYTHONPATH="${RDASAPP_DIR}/build/lib/python3.11/site-packages:${PYTHONPATH}"
 
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.json .
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.py .
@@ -235,6 +238,7 @@ cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.py .
 #cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda.json .
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_gsrcsr.json .
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_gsrcsr.py .
+cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/bufr2ioda_amsua.py .
 
 # generate a JSON w CDATE from the template and convert to IODA
 cp "${RDASAPP_DIR}"/rrfs-test/IODA/python/gen_bufr2ioda_json.py .
@@ -275,6 +279,18 @@ else
 fi
 
 #3 AMSUA
+# --------------------------------------------------
+# run  bufr2netcdf tool for atms bufr obs
+# --------------------------------------------------
+cp "${PARM_IODACONV}/bufr_1bamua_mapping.yaml" .
+cp "${PARM_IODACONV}/bufr_esamua_mapping.yaml" .
+ln -sf "${RDASAPP_DIR}/rrfs-test/IODA/python/aux" .
+yaml_1b="bufr_1bamua_mapping.yaml"
+yaml_es="bufr_esamua_mapping.yaml"
+input_1b="1bamsuabufr"
+input_es="esamsuabufr"
+output_file="ioda_amsua_{splits/satId}.nc"
+python bufr2ioda_amsua.py $input_1b $input_es $yaml_es $yaml_1b $output_file
 
 #4 CRIS
 # --------------------------------------------------
@@ -333,7 +349,7 @@ for ioda_file in ioda*.nc; do
     export err=$?; err_chk
     base_name=$(basename "$ioda_file" .nc)
     mv  "${base_name}_dc.nc" "${base_name}.nc"
-  elif [[ "${ioda_file}" == *atms* || "${ioda_file}" == *cris* ]]; then
+  elif [[ "${ioda_file}" == *atms* || "${ioda_file}" == *cris* || "${ioda_file}" == *amsua* ]]; then
     echo " ${ioda_file} ioda file detected: temporarily skipping offline domain check"
   else
     export pgm="offline_domain_check.py"


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
-Include the amsua bufr2ioda function in exrrfs_ioda_bufr.sh
-Put the bufr2ioda amsua mapping yaml file into parm/iodaconv

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Fully tested that all amsua bufr data (1bamsua and esamsua) have been sucessfully converted to ioda in retro experiment run with dev-sci workflow.
### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
 
### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
   - [ ] DA engineering test
    - [ ] Retro
    




