### PR TITLE
Add T2m and Q2m to streamlist for getkf observer access from ensemble…

### DIFF
--- a/fix/stream_list/convection_permitting/stream_list.atmosphere.background
+++ b/fix/stream_list/convection_permitting/stream_list.atmosphere.background
@@ -23,3 +23,5 @@ vegfra
 w
 xice
 refl10cm
+t2m
+q2

--- a/fix/stream_list/hrrrv5/stream_list.atmosphere.background
+++ b/fix/stream_list/hrrrv5/stream_list.atmosphere.background
@@ -23,3 +23,5 @@ vegfra
 w
 xice
 refl10cm
+t2m
+q2

--- a/fix/stream_list/mesoscale_reference/stream_list.atmosphere.background
+++ b/fix/stream_list/mesoscale_reference/stream_list.atmosphere.background
@@ -22,3 +22,5 @@ v10
 vegfra
 w
 xice
+t2m
+q2


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
This PR updates the streamlist configuration to include 2-meter temperature (T2m) and 2-meter specific humidity (Q2m). These additions are required to allow the GETKF observer to correctly read and process these surface fields from individual ensemble members during the HofX calculation.

Previously, these fields were not explicitly listed in the streamlist, preventing the observer from accessing the necessary member-level background information for surface observations.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
Diagnostic histograms of $H(x)$ for air temperature and specific humidity (Member 1) confirm that the surface operator now successfully retrieves ensemble member fields following the inclusion of T2m and Q2m in the streamlist. 
<table>
  <tr>
    <td align="center"><b>Before (Sfc Operator / Missing)</b></td>
    <td align="center"><b>After (Sfc Operator / Success)</b></td>
  </tr>
  <tr>
    <td><img width="587" alt="Before" src="https://github.com/user-attachments/assets/1ebc0423-e5cd-41a6-911d-c31ab70abbd0"></td>
    <td><img width="571" alt="After" src="https://github.com/user-attachments/assets/c47b42ba-15e4-4e26-b353-97cc6668aaae"></td>
  </tr>
</table>

<table>
  <tr>
    <td align="center"><b>Before (Sfc Operator / Wrong)</b></td>
    <td align="center"><b>After (Sfc Operator / Success)</b></td>
  </tr>
  <tr>
    <td><img width="587" alt="Before" src="https://github.com/user-attachments/assets/0ad21952-ab27-4c2d-b26f-ac17e716f7ad"></td>
    <td><img width="571" alt="After" src="https://github.com/user-attachments/assets/25752f91-5919-4c9d-9c52-223cbe66e9ba"></td>
  </tr>
</table>