### PR TITLE
Turn off deterministic WMO products for all cycles except 00/06/12/18Z

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -424,14 +424,17 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
   fi
 
   #-- Generate AWIPS/wmo products for RRFS
-  #-- AWIPS/wmo products are not generated for ensemble forecasts
+  #-- 00/06/12/18Z deterministic cycles only
+  #-- AWIPS/wmo products are not generated for ensemble member forecasts
   if [ ${DO_ENSFCST} = "FALSE" ]; then
-    ${USHrrfs}/prdgen/rrfs_mkawp.sh ${fhr}
+    if [ $cyc -eq 00 ] || [ $cyc -eq 06 ] || [ $cyc -eq 12 ] || [ $cyc -eq 18 ]; then
+      ${USHrrfs}/prdgen/rrfs_mkawp.sh ${fhr}
+    fi
   fi
 
   #-- Generate RAP smoke and HYSPLIT dust products for RRFS
   #-- 06Z and 12Z deterministic cycles only
-  #-- Smoke/dust products are not generated for ensemble forecasts
+  #-- Smoke/dust products are not generated for ensemble member forecasts
   if [ ${DO_ENSFCST} = "FALSE" ]; then
     if [ $cyc -eq 06 ] || [ $cyc -eq 12 ]; then
       if (( 10#$fhr <= 72 )); then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- It was discovered in an email thread with NCO dataflow that we are creating deterministic RRFS WMO products for every cycle.  We can only generate these for the 00/06/12/18Z cycles due to SBN bandwidth limitations.  This PR adds an if condition to the product generation task which will turn off these products for all other cycles. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
No tests conducted, but it is a simple one line change so I don't anticipate any issues.