### PR TITLE
hotfix - make clean.py more robust

### DIFF
--- a/workflow/sideload/clean.py
+++ b/workflow/sideload/clean.py
@@ -97,20 +97,20 @@ def day_clean(srcPath, cyc1, cyc2, srcType, WGF, com_nondefault=""):
         #
         pathlist = list(Path(srcPath).glob(pattern.rstrip(f'/{WGF}')))
         for mypath in pathlist:
-            if os.path.exists(mypath) and is_directory_empty(mypath):
+            if os.path.isdir(mypath) and is_directory_empty(mypath):
                 os.rmdir(mypath)
                 print(f'remove empty directory: {mypath}')
         # ~~~~~~~~~~~~
         # remove RUN.PDY/cyc if it is empty under com/
         #
         cycPath = srcPath.rstrip('/') + f"/{i:02}"
-        if os.path.exists(cycPath) and srcType.startswith("com") and is_directory_empty(cycPath):
+        if os.path.isdir(cycPath) and srcType.startswith("com") and is_directory_empty(cycPath):
             os.rmdir(cycPath)
             print(f'remove empty directory: {cycPath}')
         # ~~~~~~~~~~~~
         # remove srcPath if it is empty
         #
-        if os.path.exists(srcPath) and is_directory_empty(srcPath):
+        if os.path.isdir(srcPath) and is_directory_empty(srcPath):
             os.rmdir(srcPath)
             print(f'remove empty directory: {srcPath}')
 #


### PR DESCRIPTION
**clean.py** has assumed only different task directories exist under `RUN.PDY/cyc`.

However, users may manually create regular files there to do some temporary processing.
This crashed the clean task in the realtime RRFSv2X when `tar_plots.ksh` was manually added into `rrfs.20260428/17/`

This PR adds a sanity check to make sure it is path before checking `is_directory_empty`