### PR TITLE
[rrfs-nco] Increases granularity of dbn alerts

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -352,9 +352,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fi
       if [[ ${SENDDBN} = "YES" ]] ; then
         if (( 10#$cyc % 3 == 0 )); then
-            $DBNROOT/bin/dbn_alert MODEL RRFS_2DFLD_DET_${DBNDOM} $job \
+            $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_${DBNDOM} $job \
                 ${COMOUT}/rrfs.t${cyc}z.2dfld.${outspacing}.f${fhr}.${domain}.grib2
-            $DBNROOT/bin/dbn_alert MODEL RRFS_2DFLD_DET_${DBNDOM}_IDX $job \
+            $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_${DBNDOM}_IDX $job \
                 ${COMOUT}/rrfs.t${cyc}z.2dfld.${outspacing}.f${fhr}.${domain}.grib2.idx
         fi
       fi  #SENDDBN

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -304,6 +304,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
   domains=(hi pr)
   for domain in ${domains[@]}
   do
+    DBNDOM="${domain^^}"
     outspacing="2p5km"
     if [ ${DO_ENSFCST} = "TRUE" ]; then
       if [[ $SENDCOM = 'YES' ]]; then
@@ -317,9 +318,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fi
       if [[ ${SENDDBN} = "YES" ]] ; then
         if (( 10#$cyc % 3 == 0 )); then
-            $DBNROOT/bin/dbn_alert MODEL RRFS_DET $job \
+            $DBNROOT/bin/dbn_alert MODEL RRFS_DET_${DBNDOM} $job \
                 ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2
-            $DBNROOT/bin/dbn_alert MODEL RRFS_DET_IDX $job \
+            $DBNROOT/bin/dbn_alert MODEL RRFS_DET_${DBNDOM}_IDX $job \
                 ${COMOUT}/rrfs.t${cyc}z.prslev.${outspacing}.f${fhr}.${domain}.grib2.idx
         fi
       fi  #SENDDBN
@@ -330,6 +331,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
   domains=(conus ak hi pr)
   for domain in ${domains[@]}
   do
+    DBNDOM="${domain^^}"
     if [[ $domain = "conus" || $domain = "ak" ]]; then
       outspacing="3km"
       task="4"
@@ -350,9 +352,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fi
       if [[ ${SENDDBN} = "YES" ]] ; then
         if (( 10#$cyc % 3 == 0 )); then
-            $DBNROOT/bin/dbn_alert MODEL RRFS_2DFLD_DET $job \
+            $DBNROOT/bin/dbn_alert MODEL RRFS_2DFLD_DET_${DBNDOM} $job \
                 ${COMOUT}/rrfs.t${cyc}z.2dfld.${outspacing}.f${fhr}.${domain}.grib2
-            $DBNROOT/bin/dbn_alert MODEL RRFS_2DFLD_DET_IDX $job \
+            $DBNROOT/bin/dbn_alert MODEL RRFS_2DFLD_DET_${DBNDOM}_IDX $job \
                 ${COMOUT}/rrfs.t${cyc}z.2dfld.${outspacing}.f${fhr}.${domain}.grib2.idx
         fi
       fi  #SENDDBN
@@ -396,9 +398,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         wgrib2 ${COMOUT}/${fld2d_subh_dom} -s > ${COMOUT}/${fld2d_subh_dom}.idx
 
 	if [[ $SENDDBN = 'YES' ]]; then
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_SUBH $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_SUBH_${DBNDOM} $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.${outspacing}.subh.f${fhr}.${domain}.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_SUBH_IDX $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_SUBH_${DBNDOM}_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.${outspacing}.subh.f${fhr}.${domain}.grib2.idx
 	fi
       fi

--- a/ush/prdgen/rrfs_smokedust_combine.sh
+++ b/ush/prdgen/rrfs_smokedust_combine.sh
@@ -52,8 +52,8 @@ do
         fi
 
         if [ "$SENDDBN" == "YES" ]; then
-            ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET $job $COMOUT/${OUTPUTfile}
-            ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET_IDX $job $COMOUT/${OUTPUTfile}.idx
+            ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET_SMOKE $job $COMOUT/${OUTPUTfile}
+            ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET_SMOKE_IDX $job $COMOUT/${OUTPUTfile}.idx
         fi
     done
 done
@@ -100,8 +100,8 @@ do
     fi
 
     if [ "$SENDDBN" == "YES" ]; then
-        ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET $job $COMOUT/${OUTPUTfile}
-        ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET_IDX $job $COMOUT/${OUTPUTfile}.idx
+        ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET_DUST $job $COMOUT/${OUTPUTfile}
+        ${DBNROOT}/bin/dbn_alert MODEL RRFS_DET_DUST_IDX $job $COMOUT/${OUTPUTfile}.idx
     fi
     cd ../
 done


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- adds DBNDOM for PR/HI and subh products, makes smoke and dust alerts distinct from RRFS_DET as well.  


## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:  Ran a 12Z deterministic cycle with the changes.   All looked to work as expected.  Log files (on cactus) under /lfs/h3/emc/lam/noscrub/ecflow/ptmp/emc.lam/ecflow_rrfs/para/output/prod/today/2026050512/*prdgen*
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Addresses an NCO DF concern.

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

