### PR TITLE
allow err_exit terminate an entire process group when running the workflow without any job schedulers

### DIFF
--- a/sorc/_workaround_/err_exit
+++ b/sorc/_workaround_/err_exit
@@ -69,4 +69,6 @@ elif [ ! -z $SLURM_JOB_ID ]; then
   scancel $SLURM_JOB_ID
   echo "----- waiting for $SLURM_JOB_ID to be killed -----"
   sleep 600
+elif [ ! -z $NONSCHEDULER_JOBID ]; then
+  kill -TERM -"${NONSCHEDULER_JOBID}"
 fi

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -28,7 +28,7 @@ else  # runs in an environment without a job scheduler
   export NONSCHEDULER_JOBID=$(ps -o pgid= -p $$ | tr -d ' ')  # chid processes will send SIGTERM to this JOBID
   cleanup() {
     echo "Killing the current task and all child processes..."
-    pkill -P ${NONSCHEDULER_JOBID}  # Kills all child processes of this script
+    pkill -P "${NONSCHEDULER_JOBID}"  # Kills all child processes of this script
     exit 1
   }
   trap cleanup SIGINT SIGTERM

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -24,8 +24,14 @@ elif [[ -n "${PBS_NODEFILE}" ]]; then # PBS
     export STRIDE=$((128 / PPN))
     export MPI_RUN_CMD="mpiexec -n $NTASKS -ppn $PPN --cpu-bind core --depth $STRIDE --label --line-buffer"
   fi
-else
-  echo "Info: Not slurm nor PBS"
+else  # runs in an environment without a job scheduler
+  export NONSCHEDULER_JOBID=$(ps -o pgid= -p $$ | tr -d ' ')  # chid processes will send SIGTERM to this JOBID
+  cleanup() {
+    echo "Killing the current task and all child processes..."
+    pkill -P ${NONSCHEDULER_JOBID}  # Kills all child processes of this script
+    exit 1
+  }
+  trap cleanup SIGINT SIGTERM
 fi
 #
 ulimit -s unlimited


### PR DESCRIPTION
There is an ongoing GSL project porting rrfs-workflow(mpas-jedi) to Docker containers, small clusters, personal laptops.
Lot's of these situations don't use job schedulers (i.e. no SLURM, no PBS, etc).

Currently `err_exit` can correctly terminate a workflow task and all its child processes. But it only work when using job schedulers ( either SLURM (scancel) or PBS (qdel) ).

This PR extends `err_exit` to handle the situation when non job scheduler is used. This enables porting rrfs-workflow more easily without changing exsiting j-jobs or ex-scripts.

This PR does NOT affect any current functionalities.