### PR TITLE
add a utility to trim and harden the fix/ directory for a target MPAS mesh

### DIFF
--- a/workflow/tools/harden_fix_files/exclude.txt
+++ b/workflow/tools/harden_fix_files/exclude.txt
@@ -1,0 +1,65 @@
+# a list of files/subdirectories to be excluded from the final target version of the fix/ directory
+# 
+# - use empty lines to sepearate different sections
+# - each section corresponds to a subdirectory (including the top level fix directory, ie. "./")
+# - the first line of each section is a header and it specifies a given directory followed by a colon
+# - other lines of each section continues without empty lines in between and list files/directories to be excluded
+# - if a section contains only one line (i.e, a header), it means to remove the whole directory
+# - one may use "./:" as the header to exclude files/directories under the top fix directory
+# 
+#  The comment lines below are to illustrate how to make a conus12km only fix/ directory
+#    one needs to uncomment if the target is not conus12km, not L60, etc.
+#
+
+./:
+INIT_DONE
+ar3.5km
+ea5km
+global12km
+global-15-3km
+global15km
+south3.5km
+eu12km
+sf1km
+
+chemistry/dust:
+fengsha_dust_inputs.conus12km.nc
+fengsha_dust_inputs.conus3km.nc
+
+chemistry/RAVE:
+RAVE.dummy.conus12km.nc
+RAVE.dummy.conus3km.nc
+
+conus12km:
+conus12km.invariant.nc_L65*
+static_bec
+bumploc/conus12km_L65_80_401km11levels
+
+conus3km:
+
+na12km:
+
+physics:
+convection_permitting
+mesoscale_reference
+mpas_global
+
+#gsi_bec:
+#mpas_pave_L60.txt
+
+mpas_blend/conus3km:
+
+stream_list:
+convection_permitting
+mesoscale_reference
+mpas_global
+
+ungrib:
+Vtable.HRRR
+Vtable.RAP
+
+vert_levels:
+L112.txt
+L125.txt
+#L60.txt
+L62.txt

--- a/workflow/tools/harden_fix_files/harden.sh
+++ b/workflow/tools/harden_fix_files/harden.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# shellcheck disable=SC1091
+run_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+fix_dir="${run_dir}/../../../fix"
+#cmd="echo rm -rf"  # for dry run
+cmd="rm -rf"  # remove excluded files/directories
+
+"${run_dir}"/../init.sh
+
+echo "First, remove the fix files/directories not needed by the target (i.e. those listed in harden_fix_files/exclude.txt) ......"
+section_start=false
+knt=0
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  # strip leading/trailing whitespace
+  line="${line#"${line%%[![:space:]]*}"}"   # leading
+  line="${line%"${line##*[![:space:]]}"}"   # trailing
+
+  if [[ -z "${line}" ]]; then  # empty line, section ends
+    section_start=false
+    if (( knt == 1 )); then  # only one line in this section, so remove the whole directory
+      ${cmd}  "${fix_dir}/${header}"
+    fi
+    knt=0
+  elif [[ ${line} == *: ]]; then # 4. line ends with ":", section starts
+    header="${line%:}"
+    section_start=true
+    knt=1
+  elif [[ ${line} != \#* ]]; then  # if not comments
+    if ${section_start}; then
+      ${cmd}  "${fix_dir}/${header}/${line}"
+    fi
+    ((knt++))
+  fi
+done < "${run_dir}/exclude.txt"
+
+echo "Second, harden all links under the fix/ directory ......"
+cd "${fix_dir}/.." || exit 1
+set -x
+pwd
+rm -rf fix_harden
+rsync -aL --exclude ".agent" fix/ fix_harden/
+set +x
+
+echo "Done!"
+echo "The fix_harden/ directory contains no links, and only regular files needed by the target."
+echo -e "For a delivery to NCO, one may run\n    mv fix fix_old\n    mv fix_harden fix\nto prepare the final fix/ directory"


### PR DESCRIPTION
This PR adds a utility to trim and harden the fix/ directory for a target MPAS mesh (such as conus12km) so that we can share a small fix tarball file for community users to run rrfsv2 experiments.

This utility may also be used in the future to prepare a final version of the fix/ directory (only a na3km domain is needed) for a delivery to NCO.