### PR TITLE
run graphics using metatasks based on tiles, allow cleaning nclprd/

### DIFF
--- a/tests/.ignore.compare_xml_outputs
+++ b/tests/.ignore.compare_xml_outputs
@@ -1,2 +1,2 @@
-1466
+1480
 # put the exact PR number in the first line without any empty spaces

--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -118,8 +118,8 @@ export NATIVE_UPP=${NATIVE_UPP:-""}
 
 # graphics
 export NODES_GRAPHICS=${NODES_GRAPHICS:-"<nodes>1:ppn=20</nodes>"}
-export WALLTIME_GRAPHICS=${WALLTIME_GRAPHICS:-"01:00:00"}
-export GRAPHICS_TILES=${GRAPHICS_TILES:-"full"}  # "full NE NC NW SE SC SW EastCO"
+export WALLTIME_GRAPHICS=${WALLTIME_GRAPHICS:-"02:00:00"}
+export GRAPHICS_TILES=${GRAPHICS_TILES:-"full NE NC NW SE SC SW EastCO"}  # "full NE NC NW SE SC SW EastCO"
 export GRAPHICS_ZIP=${GRAPHICS_ZIP:-false}
 
 # clean

--- a/workflow/exp/rt_ursa/exp.rrfsv2x
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x
@@ -97,7 +97,7 @@ export NODES_IODA_MRMS_REFL="<nodes>1:ppn=40</nodes>"
 export KEEPDATA=YES
 export MAXTRIES=3
 export STMP_RETENTION_CYCS=26
-export COM_RETENTION_CYCS='{"default": 84, "lbc,fcst": 48, "upp": 840}'  # use " inside and ' outside
+export COM_RETENTION_CYCS='{"default": 84, "lbc,fcst": 48, "upp,nclprd": 840}'  # use " inside and ' outside
 export CYCLETHROTTLE=3600
 export CYCLELIFESPAN=2
 #

--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -74,8 +74,6 @@ def fcst(xmlFile, expdir, do_ensemble=False, dcEnsGrpInfo=None, do_spinup=False)
         metatask = True
         task_id = f'{meta_id}_m#ens_index#'
         dcTaskEnv['ENS_INDEX'] = "#ens_index#"
-        meta_bgn = ""
-        meta_end = ""
         meta_bgn = f'''
 <metatask name="{group_name}">
 <var name="ens_index">{ens_indices}</var>'''

--- a/workflow/rocoto_funcs/graphics.py
+++ b/workflow/rocoto_funcs/graphics.py
@@ -8,13 +8,19 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 
 
 def graphics(xmlFile, expdir):
-    task_id = 'graphics'
+    meta_id = 'graphics'
+    task_id = f'{meta_id}_#tile#'
+    tiles = os.getenv('GRAPHICS_TILES', 'full')
+    meta_bgn = f'''
+<metatask name="{meta_id}">
+<var name="tile">{tiles}</var>'''
+    meta_end = f'</metatask>\n'
     cycledefs = 'prod'
     #
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'FCST_LEN_HRS_CYCLES': os.getenv('FCST_LEN_HRS_CYCLES', '03 03'),
-        'TILES': os.getenv('GRAPHICS_TILES', 'full'),
+        'TILE': '#tile#',
         'GRAPHICS_ZIP': os.getenv('GRAPHICS_ZIP', 'FALSE').upper(),
     }
     # dependencies
@@ -37,6 +43,6 @@ def graphics(xmlFile, expdir):
   </dependency>'''
 
     #
-    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies)
+    xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, True, meta_id, meta_bgn, meta_end, "GRAPHICS")
 
 # end of graphics --------------------------------------------------------

--- a/workflow/sideload/clean.py
+++ b/workflow/sideload/clean.py
@@ -66,6 +66,8 @@ def day_clean(srcPath, cyc1, cyc2, srcType, WGF, com_nondefault=""):
             task = srcType.strip().split('_', 1)[1]
             if task == "default":
                 pattern = f'{i:02}/*/{WGF}'
+            elif task == "nclprd":
+                pattern = f'{i:02}/nclprd'
             else:
                 pattern = f'{i:02}/{task}/{WGF}'
 

--- a/workflow/sideload/graphics.sh
+++ b/workflow/sideload/graphics.sh
@@ -16,7 +16,8 @@ file_tmpl="rrfs.t${cyc}z.prslev.f0{FCST_TIME:02d}.conus.grib2"
 model=${NET}
 ntasks=${NTASKS:-12}
 grib2_dir="${COMOUT}/upp/det"
-workdir="${COMOUT}/graphics/tmp"
+workdir="${COMOUT}/graphics/${WGF}"
+zipdir="${COMOUT}/nclprd"
 rm -rf "${workdir}"
 mkdir -p "${workdir}"
 cd "${pygrafdir}" || exit 1
@@ -28,34 +29,18 @@ fcst_len_hrs_thiscyc=$( "${USHrrfs}/find_fcst_length.sh"  "${fcst_len_hrs_cycles
 echo "forecast length for this cycle is ${fcst_len_hrs_thiscyc}"
 fhr1=0
 fhr2=${fcst_len_hrs_thiscyc}
-wait_minutes=${WAIT_MINUTES:-1}
+wait_minutes=${WAIT_MINUTES:-180}
+tile=${TILE:-'full'}
 #
-# generate the graphics under workdir and then move to graphics/{tile}
+# generate the graphics
 #
-read -ra tiles <<< "${TILES}"
-for tile in ${tiles[@]}; do
+if [[ "${GRAPHICS_ZIP^^}" == "TRUE" ]]; then
+  mkdir -p "${zipdir}"
+  python create_graphics.py maps --all_leads -d ${grib2_dir} -f ${fhr1} ${fhr2} --file_type prs --file_tmpl ${file_tmpl} -m ${model} \
+      --images ${image_list} hourly -n ${ntasks} -o ${workdir} -s ${CDATE} --tiles ${tile} -z ${zipdir} -w ${wait_minutes}
+else
   python create_graphics.py maps --all_leads -d ${grib2_dir} -f ${fhr1} ${fhr2} --file_type prs --file_tmpl ${file_tmpl} -m ${model} \
       --images ${image_list} hourly -n ${ntasks} -o ${workdir} -s ${CDATE} --tiles ${tile} -w ${wait_minutes}
-  export err=$?; err_chk
-  #
-  mkdir -p "${COMOUT}/graphics/${tile}"
-  dirs=(${workdir}/*/)
-  for i in ${dirs[@]}; do
-    mv ${i}/* "${COMOUT}/graphics/${tile}"
-  done
-done
-#
-# zip the graphics if requested
-if [[ "${GRAPHICS_ZIP^^}" == "TRUE" ]]; then
-  mkdir -p "${COMOUT}/nclprd"
-  for tile in ${tiles[@]}; do
-    cd "${COMOUT}/graphics/${tile}"
-    zip files.zip *.png
-    mkdir -p "${COMOUT}/nclprd/${tile}"
-    mv files.zip "${COMOUT}/nclprd/${tile}"
-    rm -rf "${COMOUT}/graphics/${tile}"
-  done
 fi
-
 export err=$?; err_chk
 exit 0


### PR DESCRIPTION
This PR enable running graphics using metatasks based on tiles and hence the behavior is consistent between realtime and retro runs. It also adds `nclprd/` to the clean schedule for realtime runs.