### PR TITLE
[rrfs-nco] Enable cleanup for 2h and 3h RESTART files

### DIFF
--- a/scripts/exrrfs_cleanup.sh
+++ b/scripts/exrrfs_cleanup.sh
@@ -45,7 +45,11 @@ if [ "${CLEAN_MODE}" == "post" ]; then
     # rrfs
     if [ "${KEEP_DET_RESTART^^}" != YES ]; then
       echo "Cleaning up det RESTART files for cyc $cyc ."
-      for Restart_cyc in $Restart_1h $Restart_2h $Restart_3h; do
+
+      # for Restart_cyc in $Restart_1h $Restart_2h $Restart_3h; do
+      # 20260508 - Keep 1h restart files
+
+      for Restart_cyc in $Restart_2h $Restart_3h; do
         date_to_remove=${Restart_cyc:0:8}
         cyc_to_remove=${Restart_cyc:8:2}
         com_to_remove=${COMIN}/rrfs.${date_to_remove}/${cyc_to_remove}/forecast/RESTART
@@ -58,7 +62,11 @@ if [ "${CLEAN_MODE}" == "post" ]; then
     # enkf
     if [ "${KEEP_ENKF_RESTART^^}" != YES ]; then
       echo "Cleaning up enkf RESTART files for cyc $cyc ."
-      for Restart_cyc in $Restart_1h $Restart_2h $Restart_3h; do
+
+      # for Restart_cyc in $Restart_1h $Restart_2h $Restart_3h; do
+      # 20260508 - Keep 1h restart files
+
+      for Restart_cyc in $Restart_2h $Restart_3h; do
         date_to_remove=${Restart_cyc:0:8}
         cyc_to_remove=${Restart_cyc:8:2}
         for imem in {01..30}; do

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -63,7 +63,7 @@ export DBNLOG=YES
 # export EMC_DEV="YES"
 # export EMC_LOG_OUTPUT="/lfs/h3/emc/lam/noscrub/ecflow/ptmp/emc.lam/ecflow_rrfs/para/output/prod/today"
 # export envir="prod"
-export KEEP_RESTART=YES
+# export KEEP_RESTART=YES
 # NCO Testing 20250819 JBP: for para testing, remove for prod
 #export PDY=20250911
 export DCOMROOT=/lfs/h1/ops/prod/dcom


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- To save some COM space, turn RESTART file cleanup back on
- Only cleanup 2h and 3h RESTART files

After CYC is completed for all components, remove

    2h det/enkf RESTART from CYCm2
    3h det/enkf RESTART from CYCm3


## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested on NCO realtime parallel




