### PR TITLE
hotfix - coldstart_only experiments should not have the 'da_nocold' cycledef

### DIFF
--- a/tests/.ignore.compare_xml_outputs
+++ b/tests/.ignore.compare_xml_outputs
@@ -1,2 +1,2 @@
-1484
+1486
 # put the exact PR number in the first line without any empty spaces

--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -69,8 +69,9 @@ def smart_cycledefs():
         dcCycledef['spinup'] = {'valid_hours': f'{valid_str}', "cycledef": f'{cycledef_spinup}'}
     #
     # if we don't do DA at cold start cycles, let's exclude cold_cycs
+    do_jedi = os.getenv('DO_JEDI', 'FALSE').upper() == 'TRUE'
     nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
-    if nocoldda:
+    if do_jedi and nocoldda:
         if spinup:  # if spinup, coldda only happens at spinup cycles
             spinup_hrs2 = [item for item in spinup_hrs if item not in list(map(int, cold_cycs))]
             valid_str = " ".join(f"{i}" for i in spinup_hrs2)


### PR DESCRIPTION
Previously cycledefs `da_nocold` were generated for experiments without any DA tasks. This PR corrects this bug.