### PR TITLE
Small changes to the pressure bounds check for GOES AMV satwinds (obt…

### DIFF
--- a/parm/getkf.yaml
+++ b/parm/getkf.yaml
@@ -15056,7 +15056,7 @@ observations:
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 400 mb
+         # Reject obs with pressure < 150 mb and > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -15065,7 +15065,7 @@ observations:
            test variables:
            - name: MetaData/pressure
            minvalue: 15000.
-           maxvalue: 40000.
+           maxvalue: 30000.
            where:
            - variable: ObsType/windEastward
              is_in: 246
@@ -15429,7 +15429,7 @@ observations:
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 400 mb
+         # Reject obs with pressure < 150 mb and > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -15438,7 +15438,7 @@ observations:
            test variables:
            - name: MetaData/pressure
            minvalue: 15000.
-           maxvalue: 40000.
+           maxvalue: 30000.
            where:
            - variable: ObsType/windEastward
              is_in: 246

--- a/parm/jedivar.yaml
+++ b/parm/jedivar.yaml
@@ -15126,7 +15126,7 @@ cost function:
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 400 mb
+         # Reject obs with pressure < 150 mb and > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -15135,7 +15135,7 @@ cost function:
            test variables:
            - name: MetaData/pressure
            minvalue: 15000.
-           maxvalue: 40000.
+           maxvalue: 30000.
            where:
            - variable: ObsType/windEastward
              is_in: 246
@@ -15499,7 +15499,7 @@ cost function:
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 400 mb
+         # Reject obs with pressure < 150 mb and > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -15508,7 +15508,7 @@ cost function:
            test variables:
            - name: MetaData/pressure
            minvalue: 15000.
-           maxvalue: 40000.
+           maxvalue: 30000.
            where:
            - variable: ObsType/windEastward
              is_in: 246


### PR DESCRIPTION
This PR changes the bounds_check_pressure filter for GOES deep-layer water vapor satwinds (obtype 246) lower limit from 400 hPa to 300 hPa in order to be consistent with GSI. Changes are made for both the GOES-16 and GOES-18 (satID: 270 and 272) satellites. Thank you to @delippi for catching this and making this change as a part of this prior [PR](https://github.com/NOAA-EMC/RDASApp/pull/571#event-25400189452)
