### PR TITLE
[rrfs-nco] Cleans up alert names

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -470,9 +470,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
                   ${COMOUT}/rrfs.t${cyc}z.prslev.32km.f${fhr}.na.grib2
              $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.prslev.32km.f${fhr}.na.grib2.idx
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.32km.f${fhr}.na.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA_IDX $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.32km.f${fhr}.na.grib2.idx
       fi
       fi
@@ -563,9 +563,9 @@ EOF
                   ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2
              $DBNROOT/bin/dbn_alert MODEL RRFS_DET_FIREWX_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_FIREWX $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_FIREWX $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_FIREWX_IDX $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_FIREWX_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
   fi
 


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
-  Cleans up alert names for new NA 32 km grid, and also for firewx (adds distinct _2DFLD for the 2dfld file alerts to match what is done elsewhere)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [x] RRFS_A:  Reran a few prdgen hours in different WGFs to see that it was working as expected.
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
Cleanup suggested by @WeiWei-NCO after https://github.com/NOAA-EMC/rrfs-workflow/pull/1493 had been merged.  
