### PR TITLE
add a new option 'chemrrfs' to build.all

### DIFF
--- a/sorc/build.all
+++ b/sorc/build.all
@@ -26,10 +26,6 @@ if [[ "${1,,}" == chem* ]] || [[ "${2,,}" == chem* ]]; then
   cd "${HOMErrfs}/sorc/MPAS-Model" || exit 1
   git checkout "${branch_commit}"
   git submodule update --init --recursive
-  if [[ "${branch_commit}" != "chemrrfs" ]]; then
-    # allow smoke_coarse in histlist_3d_smoke
-    cp "${HOMErrfs}/fix/chemistry/mpassit/histlist_3d_smoke.coarse" "${HOMErrfs}/fix/chemistry/mpassit/histlist_3d_smoke"
-  fi
 fi
 cd "${HOMErrfs}/sorc" || exit 1
 

--- a/sorc/build.all
+++ b/sorc/build.all
@@ -11,18 +11,25 @@ cleanup() {
 }
 trap cleanup SIGINT SIGTERM
 
-if [[ "${1,,}" == "chem" ]] || [[ "${2,,}" == "chem" ]]; then
+if [[ "${1,,}" == chem* ]] || [[ "${2,,}" == chem* ]]; then
   cd "${HOMErrfs}/sorc" || exit 1
   echo "Option 'chem' found in the command line, downloading chem-specific MPAS-Model ......"
-  remote_url="https://github.com/cheMPAS-Fire/MPAS-Model"
-  branch_commit="chem/develop"  # a branch name or a commit hash
+  if [[ "${1,,}" == chemrrfs ]] || [[ "${2,,}" == chemrrfs ]]; then
+    remote_url="https://github.com/RRFSx/MPAS-Model"
+    branch_commit="chemrrfs"
+  else
+    remote_url="https://github.com/cheMPAS-Fire/MPAS-Model"
+    branch_commit="chem/develop"  # a branch name or a commit hash
+  fi
   mv MPAS-Model "MPAS-Model.$(date +%s)" # save a copy of current MPAS-Model
   git clone "${remote_url}" MPAS-Model
   cd "${HOMErrfs}/sorc/MPAS-Model" || exit 1
   git checkout "${branch_commit}"
   git submodule update --init --recursive
-  # allow smoke_coarse in histlist_3d_smoke
-  cp "${HOMErrfs}/fix/chemistry/mpassit/histlist_3d_smoke.coarse" "${HOMErrfs}/fix/chemistry/mpassit/histlist_3d_smoke"
+  if [[ "${branch_commit}" != "chemrrfs" ]]; then
+    # allow smoke_coarse in histlist_3d_smoke
+    cp "${HOMErrfs}/fix/chemistry/mpassit/histlist_3d_smoke.coarse" "${HOMErrfs}/fix/chemistry/mpassit/histlist_3d_smoke"
+  fi
 fi
 cd "${HOMErrfs}/sorc" || exit 1
 


### PR DESCRIPTION
`build.all chem` will clone cheMPAS-Fire/MPAS-Model which contains more experimental chem changes
`build.all chemrrfs` will clone the `chemrrfs` branch of RRFS/MPAS-Model which contains stable chem changes after more tests. This branch is usually a few commits ahead of the default MPAS-Model in rrfs-workflow.