### PR TITLE
[rrfs-nco] ensemble forecast script fix

### DIFF
--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -671,7 +671,34 @@ else
       LAYOUT_X="${LAYOUT_X_ENSF}" 
       if [ $ensmem_num = "3" ] || [ $ensmem_num = "4" ] || [ $ensmem_num = "5" ]; then
         LAYOUT_X="${LAYOUT_X_ENSF_LARGER}"
-      fi
+
+        if [ -e ${FIXLAM}/103_nodes_ensf/routehandle_fb01 ]; then
+         files=`ls ${FIXLAM}/103_nodes_ensf/routehandle_fb??`
+         echo "#! /bin/sh" > ./para_copy.sh
+         for fl in $files
+         do
+           echo "cpreq $fl ${DATA}/" >> ./para_copy.sh
+         done
+         cpprocs=`cat ./para_copy.sh | grep routehandle | wc -l`
+         mpiexec -n ${cpprocs} -ppn ${cpprocs} --cpu-bind core cfp ./para_copy.sh
+         rm ./para_copy.sh
+        fi
+
+      else #  mem 1 or 2
+
+        if [ -e ${FIXLAM}/94_nodes_ensf/routehandle_fb01 ]; then
+         files=`ls ${FIXLAM}/94_nodes_ensf/routehandle_fb??`
+         echo "#! /bin/sh" > ./para_copy.sh
+         for fl in $files
+         do
+           echo "cpreq $fl ${DATA}/" >> ./para_copy.sh
+         done
+         cpprocs=`cat ./para_copy.sh | grep routehandle | wc -l`
+         mpiexec -n ${cpprocs} -ppn ${cpprocs} --cpu-bind core cfp ./para_copy.sh
+         rm ./para_copy.sh
+
+      fi #ensmem_num
+
       LAYOUT_Y="${LAYOUT_Y_ENSF}" 
       WRITE_GRP="${WRTCMP_write_groups_ENSF}"
       WRITE_TSK="${WRTCMP_write_tasks_per_group_ENSF}"

--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -849,20 +849,6 @@ if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN
    mem_res="0"
    if [ ${WGF} = "ensf" ]; then
      mem_res=${ensmem_num}
-
-     if [ -e ${FIXLAM}/94_nodes_ensf/routehandle_fb01 ]; then
-       files=`ls ${FIXLAM}/94_nodes_ensf/routehandle_fb??`
-       echo "#! /bin/sh" > ./para_copy.sh
-       for fl in $files
-       do
-         echo "cpreq $fl ${DATA}/" >> ./para_copy.sh
-       done
-       cpprocs=`cat ./para_copy.sh | grep routehandle | wc -l`
-       mpiexec -n ${cpprocs} -ppn ${cpprocs} --cpu-bind core cfp ./para_copy.sh
-       rm ./para_copy.sh
-     fi
-
-
    fi
    $USHrrfs/update_input_nml.py \
     --path-to-defns ${FIXrrfs}/workflow/${WGF}/workflow.conf \


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- While monitoring the node changes for the RRFS ensemble forecast, noticed/realized that the routehandle files were not being copied into the run directory with the ensemble. 
- This moves the block doing the copying to an area that will get executed, and adds separate blocks for mem 1 and mem2 (94 nodes) and mem 3 to mem 5 (103 nodes). 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

NOTE:  Not yet tested - why this is a draft.  


### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

