### PR TITLE
[rrfs-nco] Cleans out unused block from forecast script

### DIFF
--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -822,20 +822,6 @@ if [ "${DO_FCST_RESTART}" = "TRUE" ] && [ $coupler_res_ct -gt 0 ] && [ $FCST_LEN
    mem_res="0"
    if [ ${WGF} = "ensf" ]; then
      mem_res=${ensmem_num}
-
-     if [ -e ${FIXLAM}/94_nodes_ensf/routehandle_fb01 ]; then
-       files=`ls ${FIXLAM}/94_nodes_ensf/routehandle_fb??`
-       echo "#! /bin/sh" > ./para_copy.sh
-       for fl in $files
-       do
-         echo "cpreq $fl ${DATA}/" >> ./para_copy.sh
-       done
-       cpprocs=`cat ./para_copy.sh | grep routehandle | wc -l`
-       mpiexec -n ${cpprocs} -ppn ${cpprocs} --cpu-bind core cfp ./para_copy.sh
-       rm ./para_copy.sh
-     fi
-
-
    fi
    $USHrrfs/update_input_nml.py \
     --path-to-defns ${FIXrrfs}/workflow/${WGF}/workflow.conf \


### PR DESCRIPTION


<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
-  Removes improperly located copying of 94 node routehandle files from forecast script.
- Efforts to properly copy 94 and 103 node configurations into run directory worked well for 94 nodes, but was creating unexplainable failures with 103 nodes (failures of the kind seen when using improper routehandle files)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

