### PR TITLE
[rrfs-nco] removes 32 km product generation and alerting

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -478,13 +478,13 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
 
       if [[ ${SENDDBN} = "YES" ]] ; then
       if [ $cyc -eq 00 ] || [ $cyc -eq 06 ] || [ $cyc -eq 12 ] || [ $cyc -eq 18 ]; then
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA13 $job \
                   ${COMOUT}/rrfs.t${cyc}z.prslev.13km.f${fhr}.na.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA_IDX $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_NA13_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.prslev.13km.f${fhr}.na.grib2.idx
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA13 $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.13km.f${fhr}.na.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA_IDX $job \
+             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA13_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.13km.f${fhr}.na.grib2.idx
       fi
       fi

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -448,17 +448,14 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
 
   fi
 
-  # create prslev and 2dfld files on 13-km and 32-km North America grids
+  # create prslev and 2dfld files on 13-km North America grid
   # Deterministic cycles only for now
   if [ ${DO_ENSFCST} = "FALSE" ]; then
     prslev_na_13km=${net4}.t${cyc}z.prslev.13km.f${fhr}.na.grib2
     fld2d_na_13km=${net4}.t${cyc}z.2dfld.13km.f${fhr}.na.grib2
-    prslev_na_32km=${net4}.t${cyc}z.prslev.32km.f${fhr}.na.grib2
-    fld2d_na_32km=${net4}.t${cyc}z.2dfld.32km.f${fhr}.na.grib2
 
     if [[ $SENDCOM = 'YES' ]]; then
        export gridspecs_13="rot-ll:247.000000:-35.000000:0.000000 299.000000:1127:0.108300 -36.9303000:683:0.108300"
-       export gridspecs_32="lambert:253:50.000000 214.500000:349:32463.000000 1.000000:277:32463.000000"
 
       wgrib2 ${COMOUT}/${prslev} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.gribprslevna.uv
       wgrib2 ${COMOUT}/${fld2d} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib2dfldna.uv
@@ -478,21 +475,6 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         -new_grid ${gridspecs_13} ${COMOUT}/${fld2d_na_13km}
       wgrib2 ${COMOUT}/${fld2d_na_13km} -s > ${COMOUT}/${fld2d_na_13km}.idx
 
-# interpolate 32 km output
-
-      wgrib2 inputs.gribprslevna.uv -set_bitmap 1 -set_grib_type c3 \
-        -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
-        -new_grid_interpolation neighbor \
-        -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-        -new_grid ${gridspecs_32} ${COMOUT}/${prslev_na_32km}
-      wgrib2 ${COMOUT}/${prslev_na_32km} -s > ${COMOUT}/${prslev_na_32km}.idx
-
-      wgrib2 inputs.grib2dfldna.uv -set_bitmap 1 -set_grib_type c3 \
-        -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
-        -new_grid_interpolation neighbor \
-        -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-        -new_grid ${gridspecs_32} ${COMOUT}/${fld2d_na_32km}
-      wgrib2 ${COMOUT}/${fld2d_na_32km} -s > ${COMOUT}/${fld2d_na_32km}.idx
 
       if [[ ${SENDDBN} = "YES" ]] ; then
       if [ $cyc -eq 00 ] || [ $cyc -eq 06 ] || [ $cyc -eq 12 ] || [ $cyc -eq 18 ]; then
@@ -504,15 +486,6 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.13km.f${fhr}.na.grib2
              $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA_IDX $job \
                   ${COMOUT}/rrfs.t${cyc}z.2dfld.13km.f${fhr}.na.grib2.idx
-
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_32KMNA $job \
-                  ${COMOUT}/rrfs.t${cyc}z.prslev.32km.f${fhr}.na.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_32KMNA_IDX $job \
-                  ${COMOUT}/rrfs.t${cyc}z.prslev.32km.f${fhr}.na.grib2.idx
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_32KMNA $job \
-                  ${COMOUT}/rrfs.t${cyc}z.2dfld.32km.f${fhr}.na.grib2
-             $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_32KMNA_IDX $job \
-                  ${COMOUT}/rrfs.t${cyc}z.2dfld.32km.f${fhr}.na.grib2.idx
       fi
       fi
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Removes generation of 32 km NA grid
- Renames alerts for 13 km NA grid

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

