### PR TITLE
[rrfs-nco] more ensf forecast stabilization changes

### DIFF
--- a/parm/config/ensf/input.nml_restart_stoch_ensphy1
+++ b/parm/config/ensf/input.nml_restart_stoch_ensphy1
@@ -105,7 +105,7 @@
     layout = 40, 72
     make_nh = .false.
     mountain = .true.
-    n_split = 6
+    n_split = 5
     n_sponge = -1
     n_zs_filter = 0
     na_init = 0

--- a/parm/config/ensf/input.nml_restart_stoch_ensphy2
+++ b/parm/config/ensf/input.nml_restart_stoch_ensphy2
@@ -105,7 +105,7 @@
     layout = 40, 72
     make_nh = .false.
     mountain = .true.
-    n_split = 6
+    n_split = 5
     n_sponge = -1
     n_zs_filter = 0
     na_init = 0

--- a/parm/config/ensf/input.nml_restart_stoch_ensphy3
+++ b/parm/config/ensf/input.nml_restart_stoch_ensphy3
@@ -72,7 +72,7 @@
     d2_bg_k1 = 0.2
     d2_bg_k2 = 0.04
     d4_bg = 0.12
-    d_con = 0.5
+    d_con = 0.3
     d_ext = 0.0
     dddmp = 0.1
     delt_max = 0.004
@@ -105,7 +105,7 @@
     layout = 44, 72
     make_nh = .false.
     mountain = .true.
-    n_split = 6
+    n_split = 5
     n_sponge = -1
     n_zs_filter = 0
     na_init = 0

--- a/parm/config/ensf/input.nml_restart_stoch_ensphy4
+++ b/parm/config/ensf/input.nml_restart_stoch_ensphy4
@@ -72,7 +72,7 @@
     d2_bg_k1 = 0.2
     d2_bg_k2 = 0.04
     d4_bg = 0.12
-    d_con = 0.5
+    d_con = 0.3
     d_ext = 0.0
     dddmp = 0.1
     delt_max = 0.004
@@ -105,7 +105,7 @@
     layout = 44, 72
     make_nh = .false.
     mountain = .true.
-    n_split = 6
+    n_split = 5
     n_sponge = -1
     n_zs_filter = 0
     na_init = 0

--- a/parm/config/ensf/input.nml_restart_stoch_ensphy5
+++ b/parm/config/ensf/input.nml_restart_stoch_ensphy5
@@ -72,7 +72,7 @@
     d2_bg_k1 = 0.2
     d2_bg_k2 = 0.04
     d4_bg = 0.12
-    d_con = 0.5
+    d_con = 0.3
     d_ext = 0.0
     dddmp = 0.1
     delt_max = 0.004
@@ -105,7 +105,7 @@
     layout = 44, 72
     make_nh = .false.
     mountain = .true.
-    n_split = 6
+    n_split = 5
     n_sponge = -1
     n_zs_filter = 0
     na_init = 0


### PR DESCRIPTION


<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Changes from n_split=6 back to n_split=5 for all members
- Lowers d_con from 0.5 to 0.3 for members 3-5.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Hopefully fixes the issue(s) mentioned in #1467 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@JiliDong-NOAA didn't want to go from n_split=5 to n_split=6 previously, and now I see why.