### PR TITLE
Fix satbias initialization for cold starts in RRFS retrospective cycling runs

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -2941,6 +2941,9 @@ MODULES_RUN_TASK_FP script.
        <and>
       <and>
         <taskdep task="&IODA_BUFR_TN;_prod"/>
+        {%- if do_radda %}
+        <taskdep task="&ANALYSIS_JEDI_TN;_prod{{ uscore_ensmem_name }}" cycle_offset="-1:00:00"/>
+        {%- endif  %} 
       </and>
          <timedep><cyclestr offset="&START_TIME_CONVENTIONAL;">@Y@m@d@H@M00</cyclestr></timedep>
          <or>
@@ -3033,6 +3036,9 @@ MODULES_RUN_TASK_FP script.
            <datadep age="02:00"><cyclestr>&OBSPATH;/{{obstype_source}}.@Y@m@d/{{obstype_source}}.t@Hz.prepbufr.tm00</cyclestr></datadep>
          </or>
          <taskdep task="&PREP_CYC_TN;_prod{{ uscore_ensmem_name }}"/>
+         {%- if do_radda %}
+         <taskdep task="&ANALYSIS_GSI_TN;_prod{{ uscore_ensmem_name }}" cycle_offset="-1:00:00"/>
+         {%- endif  %}
          {%- if use_rrfse_ens %}
          {%- if do_envar_radar_ref and do_envar_radar_ref_once %}
          <taskdep task="&PROCESS_RADAR_REF_TN;_prod"/>

--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -454,10 +454,7 @@ mkdir -p data/satbias_in  data/satbias_out
 
 cp "${FIX_JEDI}/"satbias_init/*.tlapse.txt data/satbias_in/.
 
-if [ ${BKTYPE} -eq 1 ]; then  # cold start uses the fixed initialize bias
-   cp "${FIX_JEDI}/satbias_init/*.nc" data/satbias_in/.
-
-else # copy bias from previous cycle
+if [[ ${DO_RADDA} == "TRUE" ]]; then # copy bias from previous cycle
   satcounter=1
   maxcounter=240
   echo 'COMOUT =', ${COMOUT}
@@ -501,7 +498,9 @@ else # copy bias from previous cycle
     satcounter=$((satcounter + 1))
 
   done
+# If not find satbias from previous 10 days, copy it from satbias_init
   if [ $satcounter -eq $maxcounter ]; then
+    echo "Not found satbias from previous 10 days, copy it from satbias_init"
     cp "${FIX_JEDI}/"satbias_init/*.nc data/satbias_in/.
   fi
 fi


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
In cycling runs, satellite radiance data assimilation requires the satellite bias coefficients (satbias) to be copied from the previous cycle. The only exception is the initial cold start, which should use the coefficients from satbias_init. However, the current exrrfs_analysis_jedi.sh script incorrectly implements this logic, causing all cold starts in retrospective runs to copy the bias coefficients from satbias_init rather than from the previous cycle. This PR fixes the issue by ensuring that the satbias coefficients are copied from the correct cycle.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@delippi 

