### PR TITLE
[rrfs-nco] Remove NBMFLD GRIB2 files

### DIFF
--- a/scripts/exrrfs_post.sh
+++ b/scripts/exrrfs_post.sh
@@ -417,12 +417,10 @@ if [ ${DO_ENSFCST} = "TRUE" ]; then
   prslev=${DATA}/${net4}.t${cyc}z.${mem_num}.prslev.${gridspacing}.f${fhr}.${gridname}.grib2
   natlev=${DATA}/${net4}.t${cyc}z.${mem_num}.natlev.${gridspacing}.f${fhr}.${gridname}.grib2
   fld2d=${DATA}/${net4}.t${cyc}z.${mem_num}.2dfld.${gridspacing}.f${fhr}.${gridname}.grib2
-  nbmfld=${DATA}/${net4}.t${cyc}z.${mem_num}.nbmfld.${gridspacing}.f${fhr}.${gridname}.grib2
 else
   prslev=${DATA}/${net4}.t${cyc}z.prslev.${gridspacing}.f${fhr}.${gridname}.grib2
   natlev=${DATA}/${net4}.t${cyc}z.natlev.${gridspacing}.f${fhr}.${gridname}.grib2
   fld2d=${DATA}/${net4}.t${cyc}z.2dfld.${gridspacing}.f${fhr}.${gridname}.grib2
-  nbmfld=${DATA}/${net4}.t${cyc}z.nbmfld.${gridspacing}.f${fhr}.${gridname}.grib2
 fi
 
 if [ -f PRSLEV.GrbF${post_fhr} ]; then
@@ -480,32 +478,12 @@ if [ -f PRSLEV.GrbF${post_fhr} ]; then
   fi # SUB_GEN=1 test
 fi # PRSLEV test
 
-# post process 2m dew point for NBM - this is needed for RRFS (det) and REFS (ensf)
-if [ $WGF = "det" ] || [ $WGF = "ensf" ]; then
-  export pgm="rrfs_util_dpt2m_post.exe"
-  . prep_step
-
-# Use the NATLEV file for deterministic RRFS, and the 2DFLD file for ensemble members
-  if [ $WGF = "det" ]; then
-    $EXECrrfs/$pgm NATLEV.GrbF${post_fhr} DPT2M.GrbF${post_fhr} >>$pgmout 2>errfile
-  elif [ $WGF = "ensf" ]; then
-    $EXECrrfs/$pgm 2DFLD.GrbF${post_fhr} DPT2M.GrbF${post_fhr} >>$pgmout 2>errfile
-  fi
-  export err=$?; err_chk
-
-  cat NBMFLD.GrbF${post_fhr} DPT2M.GrbF${post_fhr} > NBMFLD_new.GrbF${post_fhr}
-fi
-
 if [ -f NATLEV.GrbF${post_fhr} ]; then
   wgrib2 NATLEV.GrbF${post_fhr} -set center 7 -grib ${natlev} >>$pgmout 2>>errfile
 fi
 
 if [ -f PRSLEV.GrbF${post_fhr} ]; then
   wgrib2 PRSLEV.GrbF${post_fhr} -set center 7 -not "UGRD:30 m above ground" -grib ${prslev} >>$pgmout 2>>errfile
-fi
-
-if [ -f NBMFLD_new.GrbF${post_fhr} ]; then
-  wgrib2 NBMFLD_new.GrbF${post_fhr} -set center 7 -grib ${nbmfld} >>$pgmout 2>>errfile
 fi
 #
 #-----------------------------------------------------------------------
@@ -520,15 +498,6 @@ cpreq -p ${fld2d} ${COMOUT}
 # Native level output is disabled for ensemble forecasts after f00
 if [[ -f ${natlev} ]]; then
   cpreq -p ${natlev} ${COMOUT}
-fi
-# NBMFLD file is only generated for RRFS and REFS
-if [[ -f ${nbmfld} ]]; then
-  cpreq -p ${nbmfld} ${COMOUT}
-  if [ ${DO_ENSFCST} = "TRUE" ]; then
-    wgrib2 ${nbmfld} -s > ${COMOUT}/${net4}.t${cyc}z.${mem_num}.nbmfld.${gridspacing}.f${fhr}.${gridname}.grib2.idx
-  else
-    wgrib2 ${nbmfld} -s > ${COMOUT}/${net4}.t${cyc}z.nbmfld.${gridspacing}.f${fhr}.${gridname}.grib2.idx
-  fi
 fi
 
 # Only one latlons_corners file per cycle is needed in COMOUT - make this change later

--- a/sorc/app_build.sh
+++ b/sorc/app_build.sh
@@ -580,7 +580,7 @@ else
 	      ./check_imssnow_fv3lam.exe ./fv3lam_pre_blending_tq.exe \
 	      ./fv3lam_pre_blending_uv.exe ./gen_annual_maxmin_GVF.exe \
 	      ./gen_cs.exe ./gen_ensmean_recenter.exe ./lakesurgery.exe \
-	      ./rrfs_bucket.exe"
+	      ./rrfs_bucket.exe ./dpt2m_post.exe"
 
       rm -f ${remove_list}
 
@@ -599,7 +599,6 @@ AQM_UTIL_PREFIX=aqm_util
 
 [ -f ${EXEC_DIR}/adjust_soiltq.exe ] && mv ${EXEC_DIR}/adjust_soiltq.exe ${EXEC_DIR}/${RRFS_UTIL_PREFIX}_adjust_soiltq.exe
 [ -f ${EXEC_DIR}/chgres_cube ] && mv ${EXEC_DIR}/chgres_cube ${EXEC_DIR}/${UFS_UTIL_PREFIX}_chgres_cube
-[ -f ${EXEC_DIR}/dpt2m_post.exe ] && mv ${EXEC_DIR}/dpt2m_post.exe ${EXEC_DIR}/${RRFS_UTIL_PREFIX}_dpt2m_post.exe
 [ -f ${EXEC_DIR}/enkf.x ] && mv ${EXEC_DIR}/enkf.x ${EXEC_DIR}/${GSI_PREFIX}_enkf.x
 [ -f ${EXEC_DIR}/ens_mean_recenter_P2DIO.exe ] && mv ${EXEC_DIR}/ens_mean_recenter_P2DIO.exe ${EXEC_DIR}/${RRFS_UTIL_PREFIX}_ens_mean_recenter_P2DIO.exe
 [ -f ${EXEC_DIR}/filter_topo ] && mv ${EXEC_DIR}/filter_topo ${EXEC_DIR}/${UFS_UTIL_PREFIX}_filter_topo


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- In this PR, the NBMFLD GRIB2 files are removed.  They no longer have any downstream users and are not needed. The Blend will calculate VVEL directly and deliver a code update to support that prior to the RRFS implementation.
- In addition to the exrrfs_post.sh script changes, the following fix files in fix/upp will need to be updated in the NCO real-time parallel:
      - postxconfig-NT-refs.txt
      - postxconfig-NT-refs_f00.txt
      - postxconfig-NT-refs_f01.txt
      - postxconfig-NT-rrfs.txt
      - postxconfig-NT-rrfs_f00.txt
      - postxconfig-NT-rrfs_f01.txt
      - refs_postcntrl.xml
      - refs_postcntrl_f00.xml
      - refs_postcntrl_f01.xml
      - rrfs_postcntrl.xml
      - rrfs_postcntrl_f00.xml
      - rrfs_postcntrl_f01.xml
- @MatthewPyle-NOAA I have these fix files here on Dogwood:
`      /lfs/h2/emc/vpppg/noscrub/Benjamin.Blake/UPP-nbmfld/parm/rrfs`

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
The RRFS regression test from the UPP repository completed successfully with the new fix files - the NBMFLD files were no longer generated.  These script changes have not been tested in the workflow but the NBMFLD files do not affect any other files and I don't anticipate any issues.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #1531 