### PR TITLE
[rrfs-nco] add warning message for EnKF observer mode and add FATAL when no obs …

### DIFF
--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -599,21 +599,22 @@ if [[ ${GSI_TYPE} == "OBSERVER" || ${anav_type} == "conv" || ${anav_type} == "co
 fi
 
 obs_number=${#obs_files_source[@]}
-obs_count=0
+obs_file_count=0
 for (( i=0; i<${obs_number}; i++ ));
 do
   obs_file=${obs_files_source[$i]}
   obs_file_t=${obs_files_target[$i]}
   if [ -r "${obs_file}" ]; then
     cpreq "${obs_file}" "${obs_file_t}"
-    ((obs_count++))  # the counter if file is available
+    ((obs_file_count++))  # the counter if file is available
   else
     print_info_msg "$VERBOSE" "WARNING: ${obs_file} does not exist! Will continue without it (is data of opportunity)"
   fi
 done
 
-if [ "$obs_count" -eq 0 ]; then
-  err_exit "FATAL: no observation files were found in this analysis"
+echo "number of obs files:" $obs_file_count
+if [ "$obs_file_count" -eq 0 ]; then
+  err_exit "FATAL ERROR: no observation files were found in this analysis."
 fi
 
 #

--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -158,7 +158,7 @@ if  [ ${OB_TYPE} != "conv" ] || [ ${BKTYPE} -eq 1 ]; then #not using GDAS
 fi
 
 if [ ${GSI_TYPE} == "OBSERVER" ]; then
-   print_info_msg "$VERBOSE" "WARNING: In this regional EnKF observer mode, GDAS is not required"
+   print_info_msg "$VERBOSE" "In this regional EnKF observer mode, GDAS is not required"
 fi
 #
 #---------------------------------------------------------------------

--- a/scripts/exrrfs_analysis_gsi.sh
+++ b/scripts/exrrfs_analysis_gsi.sh
@@ -156,6 +156,10 @@ l_both_fv3sar_gfs_ens=${l_both_fv3sar_gfs_ens:-".false."}
 if  [ ${OB_TYPE} != "conv" ] || [ ${BKTYPE} -eq 1 ]; then #not using GDAS
   l_both_fv3sar_gfs_ens=.false.
 fi
+
+if [ ${GSI_TYPE} == "OBSERVER" ]; then
+   print_info_msg "$VERBOSE" "WARNING: In this regional EnKF observer mode, GDAS is not required"
+fi
 #
 #---------------------------------------------------------------------
 #
@@ -595,16 +599,22 @@ if [[ ${GSI_TYPE} == "OBSERVER" || ${anav_type} == "conv" || ${anav_type} == "co
 fi
 
 obs_number=${#obs_files_source[@]}
+obs_count=0
 for (( i=0; i<${obs_number}; i++ ));
 do
   obs_file=${obs_files_source[$i]}
   obs_file_t=${obs_files_target[$i]}
   if [ -r "${obs_file}" ]; then
     cpreq "${obs_file}" "${obs_file_t}"
+    ((obs_count++))  # the counter if file is available
   else
-    print_info_msg "$VERBOSE" "WARNING: ${obs_file} does not exist!"
+    print_info_msg "$VERBOSE" "WARNING: ${obs_file} does not exist! Will continue without it (is data of opportunity)"
   fi
 done
+
+if [ "$obs_count" -eq 0 ]; then
+  err_exit "FATAL: no observation files were found in this analysis"
+fi
 
 #
 #-----------------------------------------------------------------------


### PR DESCRIPTION
…files

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- add WARNING message: In this regional EnKF observer mode, GDAS is not required
- add WARNING message: if missing observation file is identified, it will continue DA with data of opportunity.
- Count the total number of observation files, exit GSI analysis if the number is zero

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [X] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [X] DA engineering test
    - [X] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #1529 and #1534

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

