### PR TITLE
minor fix - don't sys.exit after alerting users to clone pygraf

### DIFF
--- a/tests/.ignore.compare_xml_outputs
+++ b/tests/.ignore.compare_xml_outputs
@@ -1,2 +1,2 @@
-1535
+1540
 # put the exact PR number in the first line without any empty spaces

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 import os
-import sys
 import stat
 from rocoto_funcs.base import header_begin, header_entities, header_end, \
     wflow_begin, wflow_log, wflow_cycledefs, wflow_end
@@ -133,7 +132,6 @@ def setup_xml(HOMErrfs, expdir):
                 graphics(xmlFile, expdir)
                 if not os.path.exists(f"{HOMErrfs}/workflow/sideload/pygraf"):
                     print("  *** DO_GRAPHICS=true but pygraf not cloned yet!!! ***\n  run `tools/clone_pygraf.sh` first\n")
-                    sys.exit(1)
             if os.getenv("DO_HOFX", "FALSE").upper() == "TRUE":
                 hofx(xmlFile, expdir)
             if os.getenv("DO_ARCHIVE", "FALSE").upper() == "TRUE":


### PR DESCRIPTION
In PR #1535, it was found that the generated `rrfsv2x.xml` is not completed, missing the `archive` and `clean` tasks.
It was due to `sys.exit` after alerting users to clone pygraf.

This PR modifies this behavior so that CI tests can generate a full `rrfsv2x.xml`.