### PR TITLE
Fix undefined lsm scheme in namelist.atmosphere for jedivar ang getkf

### DIFF
--- a/scripts/exrrfs_getkf.sh
+++ b/scripts/exrrfs_getkf.sh
@@ -62,6 +62,7 @@ cd "${DATA}" || exit 1
 # generate namelist, streams, and getkf.yaml on the fly
 run_duration=1:00:00
 physics_suite=${PHYSICS_SUITE:-'mesoscale_reference'}
+lsm_scheme=${LSM_SCHEME:-'sf_ruc'}
 jedi_da=true #true
 pio_num_iotasks=${NODES}
 pio_stride=${PPN}

--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -110,6 +110,7 @@ fi
 # generate namelist, streams, and jedivar.yaml on the fly
 run_duration=1:00:00
 physics_suite=${PHYSICS_SUITE:-'mesoscale_reference'}
+lsm_scheme=${LSM_SCHEME:-'sf_ruc'}
 jedi_da=true #true
 pio_num_iotasks=${NODES}
 pio_stride=${PPN}

--- a/tests/.ignore.compare_xml_outputs
+++ b/tests/.ignore.compare_xml_outputs
@@ -1,2 +1,2 @@
-1535
+1542
 # put the exact PR number in the first line without any empty spaces

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -14,7 +14,7 @@ def getkf(xmlFile, expdir, taskType):
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
-    lsm_scheme = os.getenv('LSM_SCHEME', '')
+    lsm_scheme = os.getenv('LSM_SCHEME', 'sf_ruc')
     recenter_cycs = os.getenv('RECENTER_CYCS', '99')
     analysis_variables = os.getenv('ANALYSIS_VARIABLES', '0')
     dcTaskEnv = {

--- a/workflow/rocoto_funcs/getkf.py
+++ b/workflow/rocoto_funcs/getkf.py
@@ -14,11 +14,13 @@ def getkf(xmlFile, expdir, taskType):
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
+    lsm_scheme = os.getenv('LSM_SCHEME', '')
     recenter_cycs = os.getenv('RECENTER_CYCS', '99')
     analysis_variables = os.getenv('ANALYSIS_VARIABLES', '0')
     dcTaskEnv = {
         'EXTRN_MDL_SOURCE': f'{extrn_mdl_source}',
         'PHYSICS_SUITE': f'{physics_suite}',
+        'LSM_SCHEME': f'{lsm_scheme}',
         'REFERENCE_TIME': '@Y-@m-@dT@H:00:00Z',
         'DO_RADAR_REF': os.getenv('DO_RADAR_REF', 'FALSE').upper(),
         'YAML_GEN_METHOD': os.getenv('YAML_GEN_METHOD', '1'),

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -23,7 +23,7 @@ def jedivar(xmlFile, expdir, spinup_mode=0):
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
-    lsm_scheme = os.getenv('LSM_SCHEME', '')
+    lsm_scheme = os.getenv('LSM_SCHEME', 'sf_ruc')
     ens_size = int(os.getenv('ENS_SIZE', '2'))
     ens_bec_look_back_hrs = int(os.getenv('ENS_BEC_LOOK_BACK_HRS', '3'))
     snudgetype = os.getenv('SNUDGETYPES', '')

--- a/workflow/rocoto_funcs/jedivar.py
+++ b/workflow/rocoto_funcs/jedivar.py
@@ -23,6 +23,7 @@ def jedivar(xmlFile, expdir, spinup_mode=0):
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     physics_suite = os.getenv('PHYSICS_SUITE', 'PHYSICS_SUITE_not_defined')
+    lsm_scheme = os.getenv('LSM_SCHEME', '')
     ens_size = int(os.getenv('ENS_SIZE', '2'))
     ens_bec_look_back_hrs = int(os.getenv('ENS_BEC_LOOK_BACK_HRS', '3'))
     snudgetype = os.getenv('SNUDGETYPES', '')
@@ -30,6 +31,7 @@ def jedivar(xmlFile, expdir, spinup_mode=0):
     dcTaskEnv = {
         'EXTRN_MDL_SOURCE': f'{extrn_mdl_source}',
         'PHYSICS_SUITE': f'{physics_suite}',
+        'LSM_SCHEME': f'{lsm_scheme}',
         'REFERENCE_TIME': '@Y-@m-@dT@H:00:00Z',
         'YAML_GEN_METHOD': os.getenv('YAML_GEN_METHOD', '1'),
         'COLDSTART_CYCS_DO_DA': os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper(),


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
GETKF failed due to undefined lsm scheme. This is to fix undefined lsm scheme in namelist.atmosphere for getkf and jedivar.

## TESTS CONDUCTED: 
Tested in retro.



