### PR TITLE
hotfix: archive nclprd/ directories correctly

### DIFF
--- a/workflow/sideload/archive_create_filelist.py
+++ b/workflow/sideload/archive_create_filelist.py
@@ -29,7 +29,7 @@ includes = []
 for pattern in items:
     if not pattern:
         continue
-    if f'/{WGF}' not in pattern:  # add WGF if missing
+    if f'/{WGF}' not in pattern and "nclprd" not in pattern:  # add WGF if missing, except nclprd
         pattern += f'/{WGF}'
     if pattern.endswith(f'/{WGF}') or pattern.endswith(f'/') or os.path.isdir(pattern):
         pattern += '/**/*'


### PR DESCRIPTION
`nclprd/` directories is special as it contains no `WGF` subdirectories at the moment. It is desirable to add `WGF` eventually.
However, this will need a coordination with the GSL web team, who maintains the RRFS (as well as RAP/HRRR) realtime web graphics and it will take a while to finally sort things out.

For now, we apply a hotfix to let the archive task to treat the `nclprd` directories differently (similar to the clean task) so that we can archive the nclprd/ results to HPSS correctly.

