### PR TITLE
enforce UTC for all Python datetime objects

### DIFF
--- a/ush/yaml_finalize
+++ b/ush/yaml_finalize
@@ -3,7 +3,7 @@ import os
 import sys
 import hifiyaml4rrfs as hy
 import yamltools4rrfs as yj
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 args = sys.argv
 nargs = len(args) - 1
@@ -44,12 +44,19 @@ ANALYSIS_VARIABLES = os.getenv("ANALYSIS_VARIABLES", "0")  # 5, 12 or a list of 
 # determine the temporal grid for Gaussian Thinning
 time_mesh = 3
 THINNING_TIME_MESH = f"PT{time_mesh:02d}H"
-analysis_time = datetime.strptime(ANALYSIS_DATE, "%Y-%m-%dT%H:%M:%SZ")
+analysis_time = datetime.strptime(ANALYSIS_DATE, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
 delta = timedelta(hours=time_mesh / 2)
 time_min = analysis_time - delta
 time_max = analysis_time + delta
 THINNING_TIME_MIN = time_min.strftime("%Y-%m-%dT%H:%M:%SZ")
 THINNING_TIME_MAX = time_max.strftime("%Y-%m-%dT%H:%M:%SZ")
+#
+# set the obs time window for satellite radiance obs, default to 60 minutes
+delta = timedelta(minutes=60)
+time_min = analysis_time - delta
+time_max = analysis_time + delta
+SATRAD_TWINDOW_MIN = int(time_min.timestamp())  # seconds since epoch (i.e. 1970-01-01T00:00:00Z)
+SATRAD_TWINDOW_MAX = int(time_max.timestamp())  # seconds since epoch (i.e. 1970-01-01T00:00:00Z)
 
 # replacements for the @VAR@ patterns
 replacements = {
@@ -72,6 +79,8 @@ replacements = {
     "THINNING_TIME_MESH": f"{THINNING_TIME_MESH}",
     "THINNING_TIME_MIN": f"{THINNING_TIME_MIN}",
     "THINNING_TIME_MAX": f"{THINNING_TIME_MAX}",
+    "SATRAD_TWINDOW_MIN": f"{SATRAD_TWINDOW_MIN}",
+    "SATRAD_TWINDOW_MAX": f"{SATRAD_TWINDOW_MAX}",
 }
 
 # ------------------------------------------------------------------------------------

--- a/workflow/tools/herbie_get_GEFS_from_aws
+++ b/workflow/tools/herbie_get_GEFS_from_aws
@@ -13,7 +13,7 @@ if nargs < 2:
 
 print(f'each cycle data will be downloaded to ./tmp/ temporarily and then moved to ./downloads/')
 from herbie import Herbie
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import shutil
 import time
@@ -27,8 +27,8 @@ fhr_interval = 3
 cyc_interval = 6
 
 two_dates = date_range.split("-")
-date1 = datetime.strptime(two_dates[0], "%Y%m%d%H")
-date2 = datetime.strptime(two_dates[1], "%Y%m%d%H")
+date1 = datetime.strptime(two_dates[0], "%Y%m%d%H").replace(tzinfo=timezone.utc)
+date2 = datetime.strptime(two_dates[1], "%Y%m%d%H").replace(tzinfo=timezone.utc)
 cur_date = date1
 fhrs = fhr_range.split("-")
 dcProduct = {"atmos.5": "pgrb2ap5", "atmos.5b": "pgrb2bp5"}

--- a/workflow/tools/herbie_get_GFS_from_aws
+++ b/workflow/tools/herbie_get_GFS_from_aws
@@ -14,7 +14,7 @@ if nargs < 2:
 
 print(f'each cycle data will be downloaded to ./tmp/ temporarily and then moved to ./downloads/')
 from herbie import Herbie
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import shutil
 import time
@@ -30,8 +30,8 @@ if nargs > 2:
 cyc_interval = 6
 
 two_dates = date_range.split("-")
-date1 = datetime.strptime(two_dates[0], "%Y%m%d%H")
-date2 = datetime.strptime(two_dates[1], "%Y%m%d%H")
+date1 = datetime.strptime(two_dates[0], "%Y%m%d%H").replace(tzinfo=timezone.utc)
+date2 = datetime.strptime(two_dates[1], "%Y%m%d%H").replace(tzinfo=timezone.utc)
 cur_date = date1
 fhrs = fhr_range.split("-")
 

--- a/workflow/tools/herbie_get_RAP_from_aws
+++ b/workflow/tools/herbie_get_RAP_from_aws
@@ -13,7 +13,7 @@ if nargs < 2:
 
 print(f'each cycle data will be downloaded to ./tmp/ temporarily and then moved to ./downloads/')
 from herbie import Herbie
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import shutil
 import time
@@ -27,8 +27,8 @@ fhr_interval = 1
 cyc_interval = 1
 
 two_dates = date_range.split("-")
-date1 = datetime.strptime(two_dates[0], "%Y%m%d%H")
-date2 = datetime.strptime(two_dates[1], "%Y%m%d%H")
+date1 = datetime.strptime(two_dates[0], "%Y%m%d%H").replace(tzinfo=timezone.utc)
+date2 = datetime.strptime(two_dates[1], "%Y%m%d%H").replace(tzinfo=timezone.utc)
 cur_date = date1
 fhrs = fhr_range.split("-")
 fhr_at_cyc = {}


### PR DESCRIPTION
All Python datetime objects in the workflow should be in UTC.
This PR enforces this explicitly to be robust.