### PR TITLE
Define da_nocold when using the nonvariational cloud analysis

### DIFF
--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -90,8 +90,9 @@ def smart_cycledefs():
     #
     # if we don't do DA at cold start cycles, let's exclude cold_cycs
     do_jedi = os.getenv('DO_JEDI', 'FALSE').upper() == 'TRUE'
+    do_nonvar_cld = os.getenv('DO_NONVAR_CLOUD_ANA', 'FALSE').upper() == 'TRUE'
     nocoldda = os.getenv('COLDSTART_CYCS_DO_DA', 'TRUE').upper() == 'FALSE'
-    if do_jedi and nocoldda:
+    if (do_jedi or do_nonvar_cld) and nocoldda:
         if spinup:  # if spinup, coldda only happens at spinup cycles
             spinup_hrs2 = [item for item in spinup_hrs if item not in list(map(int, cold_cycs))]
             valid_str = " ".join(f"{i}" for i in spinup_hrs2)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The original code only defines the `da_nocold` cycles if `DO_JEDI=true`. There is, however, an edge case when `DO_JEDI=false`, but `DO_NONVAR_CLD_ANA=true`. In this case, `da_nocold` still needs to be defined because it is used by the nonvariational cloud analysis task. This PR makes a small change that ensures that `da_nocold` is still defined if this edge case is encountered.

## TESTS CONDUCTED: 
Generated the following variants of the `exp.conus12km` workflow on Hercules:

1. `DO_JEDI=true` and `DO_NONVAR_CLOUD_ANA=true`
2. `DO_JEDI=true` and `DO_NONVAR_CLOUD_ANA=false`
3. `DO_JEDI=false` and `DO_NONVAR_CLOUD_ANA=true`
4. `DO_JEDI=false` and `DO_NONVAR_CLOUD_ANA=false`

As expected, `da_nocold` cycles are defined in workflows 1-3, but not workflow 4. With the original code, `da_nocold` cycles would not have been defined for workflow 3.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [x] Hercules

### Test cases: 
N/A

## ISSUE: 
N/A