### PR TITLE
[rrfs-nco] Creates a fatal error with missing NOSOFS data

### DIFF
--- a/ush/fvcom_prep.sh
+++ b/ush/fvcom_prep.sh
@@ -142,11 +142,8 @@ elif [[ -e "$erie2" && -e "$mh2" && -e "$sup2" && -e "$ont2" ]]; then
   output_sup=$sup2
   output_ont=$ont2
 else
-  message_txt="WARNING: No FVCOM data is available."
-  print_info_msg "${message_txt}"
-  if [ ! -z "${MAILTO}" ] && [ "${MACHINE}" = "WCOSS2" ]; then
-    echo "${message_txt}" | mail.py ${MAILTO}
-  fi
+  message_txt="FATAL ERROR: Missing required FVCOM data from ${FVCOM_DIR}"
+  err_exit "${message_txt}"
 fi
 
 # names of missing input files to the Python script


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Provides a more descriptive message about missing FVCOM (NOSOFS) data, and makes it an err_exit rather than an e-mailed WARNING.  

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #1573 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

