### PR TITLE
[rrfs-nco] Some slight refinements to setup_firewx.sh based on testing.

### DIFF
--- a/ush/setup_firewx.sh
+++ b/ush/setup_firewx.sh
@@ -45,7 +45,7 @@ HOMErrfs=$currentDir/..
 . ${HOMErrfs}/versions/run.ver
 COMOUT=/lfs/h1/ops/${envir}/com/rrfs/${rrfs_ver}/firewx_input
 if [ ! -e ${COMOUT} ]; then
-       mkdir -p ${COMOUT}
+  mkdir -p ${COMOUT}
 fi
 
 TMP=/lfs/h1/nco/ptmp
@@ -153,7 +153,7 @@ do
   done
 
   if [ -s $COMOUT/rrfs_firewx_loc ]; then
-  cp -p $COMOUT/rrfs_firewx_loc $COMOUT/rrfs_firewx_loc_prev
+    cp -p $COMOUT/rrfs_firewx_loc $COMOUT/rrfs_firewx_loc_prev
   fi
   cp rrfs_firewx_loc $COMOUT/rrfs_firewx_loc
 

--- a/ush/setup_firewx.sh
+++ b/ush/setup_firewx.sh
@@ -44,6 +44,9 @@ HOMErrfs=$currentDir/..
 
 . ${HOMErrfs}/versions/run.ver
 COMOUT=/lfs/h1/ops/${envir}/com/rrfs/${rrfs_ver}/firewx_input
+if [ ! -e ${COMOUT} ]; then
+       mkdir -p ${COMOUT}
+fi
 
 TMP=/lfs/h1/nco/ptmp
 mkdir -p ${TMP}/`whoami`/firewx_setup
@@ -149,7 +152,9 @@ do
    echo "$cyc        $lt     $lg"
   done
 
+  if [ -s $COMOUT/rrfs_firewx_loc ]; then
   cp -p $COMOUT/rrfs_firewx_loc $COMOUT/rrfs_firewx_loc_prev
+  fi
   cp rrfs_firewx_loc $COMOUT/rrfs_firewx_loc
 
   fi #end prscc if statement


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Makes sure the COMOUT space for the hosting of the rrfs_firewx_loc file exists
- Makes sure the rrfs_firewx_loc file exists before copying it to rrfs_firewx_loc_prev

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others:  Off-line testing of a slightly modified version of this ush script to define the COMOUT and TMP to non-production spaces.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Discussion of running the setup_firewx.sh script within #1157   Included here as well:

Will add some details here about running the firewx setup script. The expectation is to interactively run the setup_firewx.sh script from within the ush directory of the package.

sh setup_firewx.sh

After which there will be prompts to set center latitude and longitude values for the 00/06/12/18Z cycles. Each latitude/longitude pair is checked to make sure it is valid for the RRFS domain.

Note: This may need some slight modification (or passing in a proper $envir setting) to avoid setting up an /lfs/h1/ops/prod/com/rrfs/ space.

envir=${envir:-prod}


currentDir=`pwd`
HOMErrfs=$currentDir/..

. ${HOMErrfs}/versions/run.ver
COMOUT=/lfs/h1/ops/${envir}/com/rrfs/${rrfs_ver}/firewx_input
if [ ! -e ${COMOUT} ]; then
       mkdir -p ${COMOUT}
fi

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

