### PR TITLE
updates to allow spinup cycles work correctly

### DIFF
--- a/workflow/rocoto_funcs/fcst.py
+++ b/workflow/rocoto_funcs/fcst.py
@@ -17,6 +17,8 @@ def fcst(xmlFile, expdir, do_ensemble=False, dcEnsGrpInfo=None, do_spinup=False)
     # Task-specific EnVars beyond the task_common_vars
     extrn_mdl_source = os.getenv('IC_EXTRN_MDL_NAME', 'IC_PREFIX_not_defined')
     fcst_len_hrs_cycles = os.getenv('FCST_LEN_HRS_CYCLES', '03 03')
+    if do_spinup:
+        fcst_len_hrs_cycles = ('01 ' * 24).strip()  # spinup cycles only need 1h forecasts
     lbc_interval = os.getenv('LBC_INTERVAL', '3')
     history_interval = os.getenv('HISTORY_INTERVAL', '1')
     diag_interval = os.getenv('DIAG_INTERVAL', '1')

--- a/workflow/rocoto_funcs/ioda_airnow.py
+++ b/workflow/rocoto_funcs/ioda_airnow.py
@@ -8,13 +8,8 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def ioda_airnow(xmlFile, expdir):
     task_id = 'ioda_airnow'
     cycledefs = 'prod'
-    num_spinup_cycledef = int(os.getenv('NUM_SPINUP_CYCLEDEF', '0'))
-    if num_spinup_cycledef == 1:
+    if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
-    elif num_spinup_cycledef == 2:
-        cycledefs = 'prod,spinup,spinup2'
-    elif num_spinup_cycledef == 3:
-        cycledefs = 'prod,spinup,spinup2,spinup3'
     OBSPATH_AIRNOW = os.getenv("OBSPATH_AIRNOW", 'OBSPATH_AIRNOW_not_defined')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {

--- a/workflow/rocoto_funcs/ioda_bufr.py
+++ b/workflow/rocoto_funcs/ioda_bufr.py
@@ -8,13 +8,8 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def ioda_bufr(xmlFile, expdir):
     task_id = 'ioda_bufr'
     cycledefs = 'prod'
-    num_spinup_cycledef = int(os.getenv('NUM_SPINUP_CYCLEDEF', '0'))
-    if num_spinup_cycledef == 1:
+    if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
-    elif num_spinup_cycledef == 2:
-        cycledefs = 'prod,spinup,spinup2'
-    elif num_spinup_cycledef == 3:
-        cycledefs = 'prod,spinup,spinup2,spinup3'
     OBSPATH = os.getenv("OBSPATH", 'OBSPATH_not_defined')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {

--- a/workflow/rocoto_funcs/ioda_mrms_refl.py
+++ b/workflow/rocoto_funcs/ioda_mrms_refl.py
@@ -8,13 +8,8 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def ioda_mrms_refl(xmlFile, expdir):
     task_id = 'ioda_mrms_refl'
     cycledefs = 'prod'
-    num_spinup_cycledef = int(os.getenv('NUM_SPINUP_CYCLEDEF', '0'))
-    if num_spinup_cycledef == 1:
+    if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
-    elif num_spinup_cycledef == 2:
-        cycledefs = 'prod,spinup,spinup2'
-    elif num_spinup_cycledef == 3:
-        cycledefs = 'prod,spinup,spinup2,spinup3'
     OBSPATH_NSSLMOSIAC = os.getenv("OBSPATH_NSSLMOSIAC", 'OBSPATH_NSSLMOSIAC_not_defined')
     RADARREFL_TIMELEVEL = os.getenv("RADARREFL_TIMELEVEL", 'RADARREFL_TIMELEVEL_not_defined')
     MRMS_GRIDSPACINGDEG = os.getenv("MRMS_GRIDSPACINGDEG", 'MRMS_GRIDSPACINGDEG_not_defined')

--- a/workflow/rocoto_funcs/nonvar_bufrobs.py
+++ b/workflow/rocoto_funcs/nonvar_bufrobs.py
@@ -8,13 +8,8 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def nonvar_bufrobs(xmlFile, expdir):
     task_id = 'nonvar_bufrobs'
     cycledefs = 'prod'
-    num_spinup_cycledef = int(os.getenv('NUM_SPINUP_CYCLEDEF', '0'))
-    if num_spinup_cycledef == 1:
+    if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
-    elif num_spinup_cycledef == 2:
-        cycledefs = 'prod,spinup,spinup2'
-    elif num_spinup_cycledef == 3:
-        cycledefs = 'prod,spinup,spinup2,spinup3'
     OBSPATH = os.getenv("OBSPATH", 'OBSPATH_not_defined')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {

--- a/workflow/rocoto_funcs/nonvar_reflobs.py
+++ b/workflow/rocoto_funcs/nonvar_reflobs.py
@@ -8,13 +8,8 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def nonvar_reflobs(xmlFile, expdir):
     task_id = 'nonvar_reflobs'
     cycledefs = 'prod'
-    num_spinup_cycledef = int(os.getenv('NUM_SPINUP_CYCLEDEF', '0'))
-    if num_spinup_cycledef == 1:
+    if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
-    elif num_spinup_cycledef == 2:
-        cycledefs = 'prod,spinup,spinup2'
-    elif num_spinup_cycledef == 3:
-        cycledefs = 'prod,spinup,spinup2,spinup3'
     OBSPATH_NSSLMOSIAC = os.getenv("OBSPATH_NSSLMOSIAC", 'OBSPATH_NSSLMOSIAC_not_defined')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {

--- a/workflow/rocoto_funcs/prep_chem.py
+++ b/workflow/rocoto_funcs/prep_chem.py
@@ -10,11 +10,6 @@ def prep_chem(xmlFile, expdir, do_ensemble=False, do_spinup=False):
     cycledefs = 'prod'
     if do_spinup:
         cycledefs = 'spinup'
-        num_spinup_cycledef = os.getenv('NUM_SPINUP_CYCLEDEF', '1')
-        if num_spinup_cycledef == '2':
-            cycledefs = 'spinup,spinup2'
-        elif num_spinup_cycledef == '3':
-            cycledefs = 'spinup,spinup2,spinup3'
     else:
         cycledefs = 'prod'
     realtime = os.getenv("REALTIME", "false")

--- a/workflow/rocoto_funcs/prep_lbc.py
+++ b/workflow/rocoto_funcs/prep_lbc.py
@@ -8,14 +8,9 @@ from rocoto_funcs.base import xml_task, get_cascade_env
 def prep_lbc(xmlFile, expdir, do_ensemble=False):
     meta_id = 'prep_lbc'
     cycledefs = 'prod'
-    num_spinup_cycledef = int(os.getenv('NUM_SPINUP_CYCLEDEF', '0'))
-    prep_lbc_look_back_hrs = int(os.getenv("PREP_LBC_LOOK_BACK_HRS", "6"))
-    if num_spinup_cycledef == 1:
+    if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
-    elif num_spinup_cycledef == 2:
-        cycledefs = 'prod,spinup,spinup2'
-    elif num_spinup_cycledef == 3:
-        cycledefs = 'prod,spinup,spinup2,spinup3'
+    prep_lbc_look_back_hrs = int(os.getenv("PREP_LBC_LOOK_BACK_HRS", "6"))
 
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {


### PR DESCRIPTION
The `spinup` cycle logic were developed and tested a while ago. Since then, the workflow has undergone lots of changes.
Especially PR #1389 grealy simplified the cycldefs for spinup cycles. 
However, some spinup logic in the workflow did not get updated accordingly in time.

This PR addresses those mismatches and allowes spinup cycles work correctly in the latest workflow.

Changes include:
1. spinup cycles only need 1h forecasts and we enforce this in `workflow/rocoto_funcs/fcst.py`
2. Remove the outdated `spinup2,spinup3` logic