### PR TITLE
[rrfs-nco] Add exception handling to prdgen job to prevent wgrib2 errors

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -180,7 +180,9 @@ fi
 # extract the output fields for the subset files
 if [ "${PREDEF_GRID_NAME}" != "RRFS_FIREWX_1.5km" ]; then
   wgrib2 ${COMOUT}/${fld2d} | grep -F -f ${FIX_UPP}/subset_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${subset} ${COMOUT}/${fld2d} >>$pgmout 2>>errfile
+  export err=$?; err_chk
   wgrib2 ${COMOUT}/${prslev} | grep -F -f ${FIX_UPP}/subset_fields_prslev.txt | wgrib2 -i -append -grib ${DATA}/${subset} ${COMOUT}/${prslev} >>$pgmout 2>>errfile
+  export err=$?; err_chk
 
   if [ ${DO_ENSFCST} != "TRUE" ]; then
     wgrib2 ${COMOUT}/${natlev} | grep -F -f ${FIX_UPP}/subset_fields_natlev.txt | wgrib2 -i -append -grib ${DATA}/${subset} ${COMOUT}/${natlev} >>$pgmout 2>>errfile
@@ -395,6 +397,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
           -new_grid_interpolation neighbor \
           -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
           -new_grid ${gridspecs} ${COMOUT}/${fld2d_subh_dom} >>$pgmout 2>>errfile
+        export err=$?; err_chk
         wgrib2 ${COMOUT}/${fld2d_subh_dom} -s > ${COMOUT}/${fld2d_subh_dom}.idx
 
 	if [[ $SENDDBN = 'YES' ]]; then
@@ -422,6 +425,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       -new_grid_interpolation neighbor \
       -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
       -new_grid ${gridspecs} ${COMOUT}/${subset_conus} >>$pgmout 2>>errfile
+    export err=$?; err_chk
     wgrib2 ${COMOUT}/${subset_conus} -s > ${COMOUT}/${subset_conus}.idx
 
     if [ "${SENDDBN}" = "YES" ] ; then
@@ -466,6 +470,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         -new_grid_interpolation neighbor \
         -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
         -new_grid ${gridspecs_13} ${COMOUT}/${prslev_na_13km} >>$pgmout 2>>errfile
+      export err=$?; err_chk
       wgrib2 ${COMOUT}/${prslev_na_13km} -s > ${COMOUT}/${prslev_na_13km}.idx
 
       wgrib2 inputs.grib2dfldna.uv -set_bitmap 1 -set_grib_type c3 \
@@ -473,6 +478,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         -new_grid_interpolation neighbor \
         -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
         -new_grid ${gridspecs_13} ${COMOUT}/${fld2d_na_13km} >>$pgmout 2>>errfile
+      export err=$?; err_chk
       wgrib2 ${COMOUT}/${fld2d_na_13km} -s > ${COMOUT}/${fld2d_na_13km}.idx
 
 
@@ -563,6 +569,7 @@ EOF
    -new_grid_interpolation neighbor \
    -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
    -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 >>$pgmout 2>>errfile
+  export err=$?; err_chk
 
   wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
 
@@ -575,6 +582,7 @@ EOF
    -new_grid_interpolation neighbor \
    -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
    -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2 >>$pgmout 2>>errfile
+  export err=$?; err_chk
 
   wgrib2 ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
 

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -x
+set -o pipefail
 
 source ${FIXrrfs}/workflow/${WGF}/workflow.conf
 

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -179,11 +179,11 @@ fi
 
 # extract the output fields for the subset files
 if [ "${PREDEF_GRID_NAME}" != "RRFS_FIREWX_1.5km" ]; then
-  wgrib2 ${COMOUT}/${fld2d} | grep -F -f ${FIX_UPP}/subset_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${subset} ${COMOUT}/${fld2d}
-  wgrib2 ${COMOUT}/${prslev} | grep -F -f ${FIX_UPP}/subset_fields_prslev.txt | wgrib2 -i -append -grib ${DATA}/${subset} ${COMOUT}/${prslev}
+  wgrib2 ${COMOUT}/${fld2d} | grep -F -f ${FIX_UPP}/subset_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${subset} ${COMOUT}/${fld2d} >>$pgmout 2>>errfile
+  wgrib2 ${COMOUT}/${prslev} | grep -F -f ${FIX_UPP}/subset_fields_prslev.txt | wgrib2 -i -append -grib ${DATA}/${subset} ${COMOUT}/${prslev} >>$pgmout 2>>errfile
 
   if [ ${DO_ENSFCST} != "TRUE" ]; then
-    wgrib2 ${COMOUT}/${natlev} | grep -F -f ${FIX_UPP}/subset_fields_natlev.txt | wgrib2 -i -append -grib ${DATA}/${subset} ${COMOUT}/${natlev}
+    wgrib2 ${COMOUT}/${natlev} | grep -F -f ${FIX_UPP}/subset_fields_natlev.txt | wgrib2 -i -append -grib ${DATA}/${subset} ${COMOUT}/${natlev} >>$pgmout 2>>errfile
     export err=$?; err_chk
   fi
 
@@ -394,7 +394,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
           -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
           -new_grid_interpolation neighbor \
           -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-          -new_grid ${gridspecs} ${COMOUT}/${fld2d_subh_dom}
+          -new_grid ${gridspecs} ${COMOUT}/${fld2d_subh_dom} >>$pgmout 2>>errfile
         wgrib2 ${COMOUT}/${fld2d_subh_dom} -s > ${COMOUT}/${fld2d_subh_dom}.idx
 
 	if [[ $SENDDBN = 'YES' ]]; then
@@ -421,7 +421,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
       -new_grid_interpolation neighbor \
       -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-      -new_grid ${gridspecs} ${COMOUT}/${subset_conus}
+      -new_grid ${gridspecs} ${COMOUT}/${subset_conus} >>$pgmout 2>>errfile
     wgrib2 ${COMOUT}/${subset_conus} -s > ${COMOUT}/${subset_conus}.idx
 
     if [ "${SENDDBN}" = "YES" ] ; then
@@ -465,14 +465,14 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
         -new_grid_interpolation neighbor \
         -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-        -new_grid ${gridspecs_13} ${COMOUT}/${prslev_na_13km}
+        -new_grid ${gridspecs_13} ${COMOUT}/${prslev_na_13km} >>$pgmout 2>>errfile
       wgrib2 ${COMOUT}/${prslev_na_13km} -s > ${COMOUT}/${prslev_na_13km}.idx
 
       wgrib2 inputs.grib2dfldna.uv -set_bitmap 1 -set_grib_type c3 \
         -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
         -new_grid_interpolation neighbor \
         -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-        -new_grid ${gridspecs_13} ${COMOUT}/${fld2d_na_13km}
+        -new_grid ${gridspecs_13} ${COMOUT}/${fld2d_na_13km} >>$pgmout 2>>errfile
       wgrib2 ${COMOUT}/${fld2d_na_13km} -s > ${COMOUT}/${fld2d_na_13km}.idx
 
 
@@ -562,7 +562,7 @@ EOF
    -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
    -new_grid_interpolation neighbor \
    -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2
+   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 >>$pgmout 2>>errfile
 
   wgrib2 ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.prslev.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
 
@@ -574,7 +574,7 @@ EOF
    -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
    -new_grid_interpolation neighbor \
    -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2
+   -new_grid ${grid_specs_firewx} ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2 >>$pgmout 2>>errfile
 
   wgrib2 ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2 -s > ${COMOUT}/rrfs.t${cyc}z.2dfld.${gridspacing}.f${fhr}.firewx_lcc.grib2.idx
 

--- a/ush/prdgen/rrfs_prdgen_subpiece.sh
+++ b/ush/prdgen/rrfs_prdgen_subpiece.sh
@@ -46,7 +46,7 @@ fi
 
 # Use different parm file for each subpiece
 if [[ "$inputfile" =~ "prslev" ]]; then
-  wgrib2 $comout/${inputfile} | grep -F -f ${parmfile} | wgrib2 -i -grib inputs.grib${domain} $comout/${inputfile}
+  wgrib2 $comout/${inputfile} | grep -F -f ${parmfile} | wgrib2 -i -grib inputs.grib${domain} $comout/${inputfile} >>$pgmout 2>>errfile
   wgrib2 inputs.grib${domain} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
 else
   wgrib2 $comout/${inputfile} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
@@ -56,7 +56,7 @@ wgrib2 inputs.grib${domain}.uv -set_bitmap 1 -set_grib_type ${compress_type} \
   -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
   -new_grid_interpolation neighbor \
   -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-  -new_grid ${gridspecs} ${domain}_${subpiece}.grib2
+  -new_grid ${gridspecs} ${domain}_${subpiece}.grib2 >>$pgmout 2>>errfile
 
 #export err=$?; err_chk
 

--- a/ush/prdgen/rrfs_prdgen_subpiece.sh
+++ b/ush/prdgen/rrfs_prdgen_subpiece.sh
@@ -47,6 +47,7 @@ fi
 # Use different parm file for each subpiece
 if [[ "$inputfile" =~ "prslev" ]]; then
   wgrib2 $comout/${inputfile} | grep -F -f ${parmfile} | wgrib2 -i -grib inputs.grib${domain} $comout/${inputfile} >>$pgmout 2>>errfile
+  export err=$?; err_chk
   wgrib2 inputs.grib${domain} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
 else
   wgrib2 $comout/${inputfile} -new_grid_vectors "UGRD:VGRD:USTM:VSTM" -submsg_uv inputs.grib${domain}.uv
@@ -58,7 +59,7 @@ wgrib2 inputs.grib${domain}.uv -set_bitmap 1 -set_grib_type ${compress_type} \
   -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
   -new_grid ${gridspecs} ${domain}_${subpiece}.grib2 >>$pgmout 2>>errfile
 
-#export err=$?; err_chk
+export err=$?; err_chk
 
 # Send data to COMOUT in the ex-script after the grid is re-assembled
 

--- a/ush/prdgen/rrfs_prdgen_subpiece.sh
+++ b/ush/prdgen/rrfs_prdgen_subpiece.sh
@@ -44,6 +44,8 @@ elif [ $domain == "pr" ]; then
   parmfile=${DATA}/hi_pr_${subpiece}.txt
 fi
 
+set -o pipefail
+
 # Use different parm file for each subpiece
 if [[ "$inputfile" =~ "prslev" ]]; then
   wgrib2 $comout/${inputfile} | grep -F -f ${parmfile} | wgrib2 -i -grib inputs.grib${domain} $comout/${inputfile} >>$pgmout 2>>errfile
@@ -60,6 +62,8 @@ wgrib2 inputs.grib${domain}.uv -set_bitmap 1 -set_grib_type ${compress_type} \
   -new_grid ${gridspecs} ${domain}_${subpiece}.grib2 >>$pgmout 2>>errfile
 
 export err=$?; err_chk
+
+set +o pipefail
 
 # Send data to COMOUT in the ex-script after the grid is re-assembled
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- One of the RRFS ensemble forecast prdgen jobs experienced silent failures that were related to wgrib2, resulting in bad GRIB2 output files.  In this PR, exception handling is added to several critical wgrib2 commands within the prdgen job in order to hopefully prevent similar errors from occurring in the future.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
No tests have been conducted with these changes, but I don't anticipate any issues with implementing them in the workflow since the same script logic is already utilized with wgrib2 commands in exrrfs_post.sh.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes issue #1584 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

