### PR TITLE
remove jet-related configurations from the exp files and allow hercules use node configurations different from orion

### DIFF
--- a/workflow/config_resources/config.machines
+++ b/workflow/config_resources/config.machines
@@ -3,15 +3,7 @@
 # set default A/Q/P/R information and other options as needed
 
 export ARCHIVE_MODULE=""
-if [[ ${MACHINE} == "jet" ]]; then
-  export ACCOUNT=${ACCOUNT:-nrtrr}
-  export QUEUE=${QUEUE:-batch}
-  export PARTITION=${PARTITION:-kjet}
-  export RESERVATION=${RESERVATION:-""}
-  export NATIVE_UPP="--exclusive"
-  export NATIVE_ENSMEAN="--exclusive"
-
-elif [[ ${MACHINE} == "hera" ]]; then
+if [[ ${MACHINE} == "hera" ]]; then
   export ACCOUNT=${ACCOUNT:-rtrr}
   export QUEUE=${QUEUE:-batch}
   export PARTITION=${PARTITION:-hera}

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -130,16 +130,6 @@ case ${MACHINE} in
     export NODES_JEDIVAR="<nodes>1:ppn=80</nodes>"
     export NODES_IODA_MRMS_REFL="<nodes>1:ppn=80</nodes>"
     ;;
-  "jet")
-    export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GFS"
-    export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
-    export OBSPATH_AIRNOW="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/airnow"
-    export ACCOUNT="nrtrr"
-    export QUEUE="batch"
-    export PARTITION="kjet"
-    ;;
   "orion"|"hercules")
     export IC_EXTRN_MDL_BASEDIR="/work2/noaa/wrfruc/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -140,6 +140,15 @@ case ${MACHINE} in
     export QUEUE="batch"
     export PARTITION=${MACHINE}
     export CLUSTER=""
+    if [[ "${MACHINE}" == "hercules" ]]; then
+      export NODES_IC="<nodes>1:ppn=80</nodes>"
+      export NODES_LBC="<nodes>1:ppn=80</nodes>"
+      export NODES_FCST="<nodes>1:ppn=80</nodes>"
+      export NODES_MPASSIT="<nodes>1:ppn=80</nodes>"
+      export NODES_UPP="<nodes>1:ppn=80</nodes>"
+      export NODES_JEDIVAR="<nodes>2:ppn=40</nodes>"
+      export NODES_IODA_MRMS_REFL="<nodes>1:ppn=40</nodes>"
+    fi
     ;;
   "gaeac6")
     export IC_EXTRN_MDL_BASEDIR="/gpfs/f6/bil-fire10-oar/world-shared/RRFS2_RETRO_DATA/May2024/GFS"

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -132,16 +132,6 @@ case ${MACHINE} in
     export NODES_JEDIVAR="<nodes>20:ppn=40</nodes>"
     export NODES_MPAS_BLEND="<nodes>10:ppn=160</nodes>"
     ;;
-  "jet")
-    export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GFS"
-    export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
-    export OBSPATH_AIRNOW="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/airnow"
-    export ACCOUNT="nrtrr"
-    export QUEUE="batch"
-    export PARTITION="kjet"
-    ;;
   "orion"|"hercules")
     export IC_EXTRN_MDL_BASEDIR="/work2/noaa/wrfruc/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -142,6 +142,15 @@ case ${MACHINE} in
     export QUEUE="batch"
     export PARTITION=${MACHINE}
     export CLUSTER=""
+    if [[ "${MACHINE}" == "hercules" ]]; then
+      export NODES_IC="<nodes>20:ppn=80</nodes>"
+      export NODES_LBC="<nodes>20:ppn=80</nodes>"
+      export NODES_FCST="<nodes>20:ppn=80</nodes>"
+      export NODES_MPASSIT="<nodes>2:ppn=80</nodes>"
+      export NODES_UPP="<nodes>1:ppn=80</nodes>"
+      export NODES_JEDIVAR="<nodes>10:ppn=80</nodes>"
+      export NODES_MPAS_BLEND="<nodes>20:ppn=80</nodes>"
+    fi
     ;;
   "gaeac6")
     export IC_EXTRN_MDL_BASEDIR="/gpfs/f6/bil-fire10-oar/world-shared/RRFS2_RETRO_DATA/May2024/GFS"

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -121,16 +121,6 @@ case ${MACHINE} in
     export NODES_ENSMEAN="<nodes>1:ppn=80</nodes>"
     export NODES_GETKF="<nodes>1:ppn=160</nodes>"
     ;;
-  "jet")
-    export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GEFS"
-    export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
-    export OBSPATH_AIRNOW="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/airnow"
-    export ACCOUNT="nrtrr"
-    export QUEUE="batch"
-    export PARTITION="kjet"
-    ;;
   "orion"|"hercules")
     export IC_EXTRN_MDL_BASEDIR="/work2/noaa/wrfruc/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -131,6 +131,17 @@ case ${MACHINE} in
     export QUEUE="batch"
     export PARTITION=${MACHINE}
     export CLUSTER=""
+    if [[ "${MACHINE}" == "hercules" ]]; then
+      export NODES_IC="<nodes>1:ppn=80</nodes>"
+      export NODES_LBC="<nodes>1:ppn=80</nodes>"
+      export NODES_FCST="<nodes>1:ppn=80</nodes>"
+      export NODES_MPASSIT="<nodes>1:ppn=80</nodes>"
+      export NODES_UPP="<nodes>1:ppn=80</nodes>"
+      export NODES_GETKF="<nodes>2:ppn=40</nodes>"
+      export NODES_RECENTER="<nodes>1:ppn=32</nodes>"
+      export NODES_IODA_MRMS_REFL="<nodes>1:ppn=40</nodes>"
+      export NODES_ENSMEAN="<nodes>1:ppn=80</nodes>"
+    fi
     ;;
   "gaeac6")
     export IC_EXTRN_MDL_BASEDIR="/gpfs/f6/bil-fire10-oar/world-shared/RRFS2_RETRO_DATA/May2024/GEFS"

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -127,6 +127,15 @@ case ${MACHINE} in
     export QUEUE="batch"
     export PARTITION=${MACHINE}
     export CLUSTER=""
+    if [[ "${MACHINE}" == "hercules" ]]; then
+      export NODES_IC="<nodes>20:ppn=80</nodes>"
+      export NODES_LBC="<nodes>20:ppn=80</nodes>"
+      export NODES_FCST="<nodes>20:ppn=80</nodes>"
+      export NODES_MPASSIT="<nodes>2:ppn=80</nodes>"
+      export NODES_UPP="<nodes>1:ppn=80</nodes>"
+      export NODES_GETKF="<nodes>40:ppn=20</nodes>"
+      export NODES_RECENTER="<nodes>1:ppn=32</nodes>"
+    fi
     ;;
   "gaeac6")
     export IC_EXTRN_MDL_BASEDIR="/gpfs/f6/bil-fire10-oar/world-shared/RRFS2_RETRO_DATA/May2024/GEFS"

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -117,16 +117,6 @@ case ${MACHINE} in
     export NODES_RECENTER="<nodes>1:ppn=32</nodes>"
     export NODES_GETKF="<nodes>20:ppn=40</nodes>"
     ;;
-  "jet")
-    export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GEFS"
-    export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
-    export OBSPATH_AIRNOW="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/airnow"
-    export ACCOUNT="nrtrr"
-    export QUEUE="batch"
-    export PARTITION="kjet"
-    ;;
   "orion"|"hercules")
     export IC_EXTRN_MDL_BASEDIR="/work2/noaa/wrfruc/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}

--- a/workflow/exp/exp.ens_na12km
+++ b/workflow/exp/exp.ens_na12km
@@ -121,16 +121,6 @@ case ${MACHINE} in
     export NODES_ENSMEAN="<nodes>1:ppn=80</nodes>"
     export NODES_GETKF="<nodes>5:ppn=80</nodes>"
     ;;
-  "jet")
-    export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GEFS"
-    export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
-    export OBSPATH_AIRNOW="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/airnow"
-    export ACCOUNT="nrtrr"
-    export QUEUE="batch"
-    export PARTITION="kjet"
-    ;;
   "orion"|"hercules")
     export IC_EXTRN_MDL_BASEDIR="/work2/noaa/wrfruc/RRFS2_RETRO_DATA/May2024/GEFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}

--- a/workflow/exp/exp.na12km
+++ b/workflow/exp/exp.na12km
@@ -129,16 +129,6 @@ case ${MACHINE} in
     export NODES_JEDIVAR="<nodes>5:ppn=80</nodes>"
     export NODES_IODA_MRMS_REFL="<nodes>1:ppn=80</nodes>"
     ;;
-  "jet")
-    export IC_EXTRN_MDL_BASEDIR="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/GFS"
-    export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}
-    export OBSPATH="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/obs_rap"
-    export OBSPATH_NSSLMOSIAC="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/reflectivity"
-    export OBSPATH_AIRNOW="/lfs5/BMC/nrtrr/RRFS2_RETRO_DATA/May2024/airnow"
-    export ACCOUNT="nrtrr"
-    export QUEUE="batch"
-    export PARTITION="kjet"
-    ;;
   "orion"|"hercules")
     export IC_EXTRN_MDL_BASEDIR="/work2/noaa/wrfruc/RRFS2_RETRO_DATA/May2024/GFS"
     export LBC_EXTRN_MDL_BASEDIR=${IC_EXTRN_MDL_BASEDIR}


### PR DESCRIPTION
1. Remove jet-related configurations from the exp files and config.machines
2. Allow hercules use node configurations different from orion (hercules nodes have more cores and memories).