### PR TITLE
[rrfs-nco] Removes misleading script comments

### DIFF
--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -589,17 +589,10 @@ if [ "${DO_SMOKE_DUST}" = "TRUE" ] && [ "${CYCLE_TYPE}" = "spinup" ]; then  # cy
           done
       fi
 
-      # check if there are tracer file in continue cycle data space:
-      if [ "${bkpath_find}" = "missing" ]; then
-        # All required file should exist
-        # err_exit "FATAL: missing fv_tracer.res.tile1.nc"
-        echo "WARNING: can not find fv_tracer for smoke/dust cycling at ${HH}"
-      fi
-
       # cycle smoke/dust
       rm -f cycle_smoke_dust.done
       if [ "${bkpath_find}" = "missing" ]; then
-        print_info_msg "Warning: cannot find smoke/dust files from previous cycle"
+        print_info_msg "WARNING: did not find smoke/dust files from previous cycle, but can proceed without them."
         touch ${COMOUT}/cycle_smoke_dust_skipped.txt
       else
         checkfile=${bkpath_find}/${restart_prefix_find}fv_tracer.res.tile1.nc


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Removes a confusing if-block that seemed duplicative, and refined a warning print in exrrfs_prep_cyc.sh

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #1605 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

