### PR TITLE
[rrfs-nco] mem003 input.nml file update for use with latest model code

### DIFF
--- a/parm/config/ensf/input.nml_restart_stoch_ensphy3
+++ b/parm/config/ensf/input.nml_restart_stoch_ensphy3
@@ -303,7 +303,7 @@
 &nam_sppperts
     iseed_spp = 4, 5, 6, 7
     spp_lscale = 150000.0, 150000.0, 150000.0, 150000.0
-    spp_prt_list = 0.16, 0.16, 0.2, 0.2
+    spp_prt_list = 0.14, 0.14, 0.2, 0.2
     spp_sigtop1 = 0.1, 0.1, 0.1, 0.1
     spp_sigtop2 = 0.025, 0.025, 0.025, 0.025
     spp_stddev_cutoff = 1.5, 1.5, 1.5, 1.5


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Drops the SPP perturbation amplitude from 0.16 to 0.14 for PBL/SFCLAY in mem003 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [x] Others:  This configuration as well as the updated model code was run across ~12 cycles that experienced a failure in one of the members, including 5 failed mem003 runs.

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

@JiliDong-NOAA did the testing that showed that this change was needed.  