### PR TITLE
[release/v1.0] default FHR to 000 in exrrfs_save_restart.sh

### DIFF
--- a/scripts/exrrfs_save_restart.sh
+++ b/scripts/exrrfs_save_restart.sh
@@ -47,7 +47,7 @@ This is the ex-script for the task that saves restart files to nwges.
 #
 yyyymmdd=${CDATE:0:8}
 hh=${CDATE:8:2}
-fhr=${FHR:-}
+fhr=${FHR:-000}
 
 save_time=$($NDATE ${fhr} ${yyyymmdd}${hh})
 save_yyyy=${save_time:0:4}


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Similar to PR #1620, but instead of hardwiring `FHR` in ecf script, this change sets a default value of 000 for the `FHR` variable in `/scripts/exrrfs_save_restart.sh`.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- Running in NCO realtime parallel.

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
Credit goes to @ShunLiu-NOAA and @lgannoaa  for this change. 

