### PR TITLE
[release/v1.0] Tranfser file changes for firewx_loc

### DIFF
--- a/parm/transfer/transfer_rrfs_misc.list
+++ b/parm/transfer/transfer_rrfs_misc.list
@@ -23,9 +23,6 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transfered.
 
-_COMROOT_/rrfs/_SHORTVER_/firewx_input/
-B 1000000
-
 _COMROOT_/rrfs/_SHORTVER_/firewx._PDY_/
 B 1000000
 

--- a/parm/transfer/transfer_rrfs_misc.list
+++ b/parm/transfer/transfer_rrfs_misc.list
@@ -23,6 +23,9 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transfered.
 
+_COMROOT_/rrfs/_SHORTVER_/firewx_input/
+B 1000000
+
 _COMROOT_/rrfs/_SHORTVER_/firewx._PDY_/
 B 1000000
 

--- a/parm/transfer/transfer_rrfs_p2o_misc.list
+++ b/parm/transfer/transfer_rrfs_p2o_misc.list
@@ -23,9 +23,6 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transfered.
 
-/lfs/h1/ops/para/com/rrfs/_SHORTVER_/firewx_input/ _COMROOT_/rrfs/_SHORTVER_/firewx_input/
-B 1000000
-
 /lfs/h1/ops/para/com/rrfs/_SHORTVER_/firewx._PDY_/ _COMROOT_/rrfs/_SHORTVER_/firewx._PDY_/
 B 1000000
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- With the new rrfs_firewx_loc, rrfs wil use it from its own COM directory. We will soft link it to production nam_firewx_loc in the first EVAl, then start rrfs setup in the second.
- Copying firewx_input from para to prod for EVAL is not needed.
