### PR TITLE
[rrfs-mpas-jedi] Hotfix for RRFSv2X

### DIFF
--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -88,7 +88,7 @@ ens_count=$(find ens -name "mem*.nc" | wc -l)
 #
 # For HYB_ENS_TYPE=0, check number of ensemble files, if not enough, default to pure 3DVar
 #
-if (( HYB_ENS_TYPE == 0 )) ; then
+if (( HYB_ENS_TYPE == 0 || HYB_ENS_TYPE == 1 )) ; then
   if (( ens_count < ens_size )); then
      echo "Number of ensemble files is ${ens_count}, less than 30, default to 3DVar"
      export HYB_WGT_ENS=0.0

--- a/scripts/exrrfs_nonvar_cldana.sh
+++ b/scripts/exrrfs_nonvar_cldana.sh
@@ -111,8 +111,10 @@ err_chk
 # Copy log files to COM directory
 if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
   cp stdout_cloudanalysis* "${COMOUT}/nonvar_cldana_spinup/${WGF}${MEMDIR}/"
+  touch "${COMOUT}/nonvar_cldana_spinup/${WGF}${MEMDIR}/nonvar_cldana.done"
 else
   cp stdout_cloudanalysis* "${COMOUT}/nonvar_cldana/${WGF}${MEMDIR}/"
+  touch "${COMOUT}/nonvar_cldana/${WGF}${MEMDIR}/nonvar_cldana.done"
 fi
 
 exit 0

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -102,7 +102,7 @@ for index in "${mem_list[@]}"; do # loop through all the members
   # do sfc cycling if no global blending
   #
   if [[ "${DO_BLENDING^^}" == "FALSE" ]]; then
-	  if [[ "${DO_SFC_UPDATE}" == "TRUE" ]] && (( spinup_mode != -1 )); then
+	if [[ "${DO_SFC_UPDATE}" == "TRUE" ]] && (( spinup_mode != -1 )); then
       for hr in ${COLDSTART_CYCS:-"99"}; do
         shr=$(printf '%02d' $((10#$hr)) )
         if [[ "${cyc}" == "${shr}" ]]; then

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -102,7 +102,7 @@ for index in "${mem_list[@]}"; do # loop through all the members
   # do sfc cycling if no global blending
   #
   if [[ "${DO_BLENDING^^}" == "FALSE" ]]; then
-    if [[ "${DO_SFC_UPDATE}" == "TRUE" ]]; then
+	  if [[ "${DO_SFC_UPDATE}" == "TRUE" ]] && (( spinup_mode != -1 )); then
       for hr in ${COLDSTART_CYCS:-"99"}; do
         shr=$(printf '%02d' $((10#$hr)) )
         if [[ "${cyc}" == "${shr}" ]]; then

--- a/scripts/exrrfs_prep_ic.sh
+++ b/scripts/exrrfs_prep_ic.sh
@@ -102,7 +102,7 @@ for index in "${mem_list[@]}"; do # loop through all the members
   # do sfc cycling if no global blending
   #
   if [[ "${DO_BLENDING^^}" == "FALSE" ]]; then
-	if [[ "${DO_SFC_UPDATE}" == "TRUE" ]] && (( spinup_mode != -1 )); then
+    if [[ "${DO_SFC_UPDATE}" == "TRUE" ]] && (( spinup_mode != -1 )); then
       for hr in ${COLDSTART_CYCS:-"99"}; do
         shr=$(printf '%02d' $((10#$hr)) )
         if [[ "${cyc}" == "${shr}" ]]; then

--- a/tests/.ignore.compare_xml_yaml_outputs
+++ b/tests/.ignore.compare_xml_yaml_outputs
@@ -1,2 +1,2 @@
-1625
+1633
 # put the exact PR number in the first line without any empty spaces

--- a/workflow/exp/rt_ursa/exp.rrfsv2x
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x
@@ -23,7 +23,7 @@ export ZETA_LEVELS="L60.txt"
 export DO_IODA=true
 export DO_JEDI=true
 export SNUDGETYPES="GGG" # G=gsd_update_soiltq from GSI; P=2022 J Hydro paper; chars=SoilT,SnowT,SoilQ
-export COLDSTART_CYCS_DO_DA=true #true
+export COLDSTART_CYCS_DO_DA=true
 export DO_NONVAR_CLOUD_ANA=true
 export DO_CHEMISTRY=false
 export DO_RADAR_REF=true  # does not work for 3DVar, only EnVar or GETKF

--- a/workflow/exp/rt_ursa/exp.rrfsv2x
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x
@@ -23,7 +23,7 @@ export ZETA_LEVELS="L60.txt"
 export DO_IODA=true
 export DO_JEDI=true
 export SNUDGETYPES="GGG" # G=gsd_update_soiltq from GSI; P=2022 J Hydro paper; chars=SoilT,SnowT,SoilQ
-export COLDSTART_CYCS_DO_DA=false #true
+export COLDSTART_CYCS_DO_DA=true #true
 export DO_NONVAR_CLOUD_ANA=true
 export DO_CHEMISTRY=false
 export DO_RADAR_REF=true  # does not work for 3DVar, only EnVar or GETKF
@@ -47,7 +47,8 @@ export GSIBEC_Y=20
 export DO_CYC=true
 export CYC_INTERVAL=1
 for i in {0..23};    do arr[$i]="03"; done # 3hr fcst
-for i in {0..23..12}; do arr[$i]="72"; done # 24hr fcst every 12hrs
+for i in {0..23..03}; do arr[$i]="12"; done # 12hr fcst every 3hrs
+for i in {0..23..12}; do arr[$i]="72"; done # 72hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export DIAG_INTERVAL=1
@@ -66,15 +67,12 @@ export RETRO_PERIOD="2024052700-2024052800"
 export LBC_CYCS="00 12"  # evenly divide 24 hours, e.g., "00 12", "00 06 12 18", etc
 export COLDSTART_CYCS="03 15"   # cycles to cold start from external models
 export SST_UPDATE_CYCS="00 12"
-
-#export DO_SPINUP=true
-#export PRODSWITCH_CYCS="06 18"  # cycles to PROD switch to the spun-up ICs
 #
 # set as follows to start spinup at 03/15z
-#export DO_SPINUP=true
+export DO_SPINUP=true
 #export IC_OFFSET=3
 #export COLDSTART_CYCS="03 15"
-#export PRODSWITCH_CYCS="09 21"
+export PRODSWITCH_CYCS="09 21"
 #
 export DO_PYDAMONITOR=true
 export DO_GRAPHICS=true
@@ -109,8 +107,8 @@ export NODES_IODA_MRMS_REFL="<nodes>1:ppn=40</nodes>"
 #
 export KEEPDATA=YES
 export MAXTRIES=3
-export STMP_RETENTION_CYCS=26
-export COM_RETENTION_CYCS='{"default": 96, "lbc,fcst": 72, "upp,nclprd,pyDAmonitor": 960}'  # use " inside and ' outside
+export STMP_RETENTION_CYCS=18
+export COM_RETENTION_CYCS='{"default": 96, "lbc,fcst": 48, "upp,nclprd,pyDAmonitor": 960}'  # use " inside and ' outside
 export CYCLETHROTTLE=3600
 export CYCLELIFESPAN=2
 #
@@ -141,7 +139,7 @@ export STARTTIME_JEDIVAR="00:40:00"
 export STARTTIME_FCST="00:10:00"
 export STARTTIME_MPASSIT="00:15:00"
 export STARTTIME_UPP="00:15:00"
-export STARTTIME_PREP_IC="03:00:00"
+export STARTTIME_PREP_IC="02:00:00"
 export STARTTIME_PREP_LBC="00:15:00"
 export MORE_XML_ENTITIES=true
 export DO_CLEAN=true

--- a/workflow/exp/rt_ursa/exp.rrfsv2x_ens
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x_ens
@@ -26,7 +26,8 @@ export ENS_METADEP_FRAC_THRESHOLD=0.5
 #
 export DO_IODA=true
 export DO_JEDI=true
-export COLDSTART_CYCS_DO_DA=false
+export GETKF_ONESTEP=true
+export COLDSTART_CYCS_DO_DA=true
 export DO_RECENTER=true
 export DO_GETKF_POST=false
 export DO_NONVAR_CLOUD_ANA=true
@@ -43,8 +44,8 @@ export DO_POST=false
 export HISTORY_INTERVAL=none
 export DIAG_INTERVAL=1
 
-export IC_OFFSET=39
-export LBC_OFFSET=39
+export IC_OFFSET=33
+export LBC_OFFSET=33
 export LBC_LENGTH=15
 export LBC_INTERVAL=1
 export LBC_UNGRIB_GROUP_TOTAL_NUM=1
@@ -52,10 +53,10 @@ export LBC_GROUP_TOTAL_NUM=2
 export PREP_LBC_LOOK_BACK_HRS=11
 
 export RETRO_PERIOD="2024052700-2024052712"
-export LBC_CYCS="03 15"
-export COLDSTART_CYCS="03 15"   # cycles to cold start from external models
+export LBC_CYCS="09 21"
+export COLDSTART_CYCS="09 21"   # cycles to cold start from external models
 export RECENTER_CYCS="${COLDSTART_CYCS}"
-export DET_RECENTERCYCS_DO_DA=false #true # whether or not do detministic DA at RECENTER_CYCS
+export DET_RECENTERCYCS_DO_DA=true #true # whether or not do detministic DA at RECENTER_CYCS
 #
 #export DO_PYDAMONITOR=true
 #export DO_GRAPHICS=true
@@ -78,7 +79,7 @@ export NODES_MPASSIT="<nodes>1:ppn=160</nodes>"
 export NODES_UPP="<nodes>1:ppn=160</nodes>"
 export NODES_RECENTER="<nodes>1:ppn=40</nodes>"
 export NODES_IODA_MRMS_REFL="<nodes>1:ppn=40</nodes>"
-export NODES_GETKF="<nodes>30:ppn=10</nodes>"
+export NODES_GETKF="<nodes>20:ppn=40</nodes>"
 export NODES_ENSMEAN="<nodes>2:ppn=60</nodes>"
 #
 export NODES_PREP_IC="<nodes>1:ppn=90</nodes>"
@@ -93,8 +94,8 @@ export KEEPDATA=YES
 export TASKTHROTTLE=60
 export MAXTRIES=3
 export CLEAN_BACK_DAYS=2
-export STMP_RETENTION_CYCS=26
-export COM_RETENTION_CYCS='{"default": 84, "lbc,fcst": 72}'   # use " inside and ' outside
+export STMP_RETENTION_CYCS=18
+export COM_RETENTION_CYCS='{"default": 48, "lbc,fcst": 36}'   # use " inside and ' outside
 export CYCLETHROTTLE=3600
 export CYCLELIFESPAN=3
 #

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -82,7 +82,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         datadep = "whatever"  # dependencies will be rewritten near the end of this file
     # sfc update dependencies
     sfc_dep = ""
-    if do_sfc_update == "TRUE":
+    if do_sfc_update == "TRUE" and spinup_mode != -1:
         dcTaskEnv['SFC_UPDATE_LOOK_BACK_HRS'] = sfc_update_look_back_hrs
         dcTaskEnv['SFC_UPDATE_SOURCE_DIR'] = os.getenv('SFC_UPDATE_SOURCE_DIR', '')
         datadep_sfc = ""
@@ -162,7 +162,6 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
         datadep_spinup = datadep_spinup.lstrip('\n')
         dependencies = f'''
   <dependency>
-  <and>{timedep}
    <or>
     <and>
       <or>
@@ -174,7 +173,6 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
 {strneqs}{datadep_prod}
     </and>
    </or>
-  </and>
   </dependency>'''
     #
     xml_task(xmlFile, expdir, task_id, cycledefs, dcTaskEnv, dependencies, command_id="PREP_IC")

--- a/workflow/rocoto_funcs/recenter.py
+++ b/workflow/rocoto_funcs/recenter.py
@@ -10,6 +10,7 @@ def recenter(xmlFile, expdir):
     cycledefs = 'recenter'
     recenter_cycs = os.getenv('RECENTER_CYCS', '99')
     det_recentercycs_do_da = os.getenv('DET_RECENTERCYCS_DO_DA', 'false')
+    do_nonvar_cldana = os.getenv('DO_NONVAR_CLOUD_ANA', 'false')
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'ENS_SIZE': os.getenv("ENS_SIZE", '5'),
@@ -25,7 +26,10 @@ def recenter(xmlFile, expdir):
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
 
     if det_recentercycs_do_da.upper() == "TRUE":
-        datadep = f'<datadep age="00:01:00"><cyclestr>&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/jedivar/det/jedivar.done</cyclestr></datadep>'
+        if do_nonvar_cldana.upper() == "TRUE":
+            datadep = f'<datadep age="00:01:00"><cyclestr>&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/nonvar_cldana/det/nonvar_cldana.done</cyclestr></datadep>'
+        else:
+            datadep = f'<datadep age="00:01:00"><cyclestr>&COMROOT;/&NET;/&rrfs_ver;/&RUN;.@Y@m@d/@H/jedivar/det/jedivar.done</cyclestr></datadep>'
     else:
         datadep = f'<datadep age="00:01:00"><cyclestr>&DATAROOT;/@Y@m@d/&RUN;_prep_ic_@H_&rrfs_ver;/det/prep_ic.done</cyclestr></datadep>'
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Some fixes for the real-time RRFSv2X, including:
- update exp files to turn on spin-up cycles for the deterministic run, change the ensemble cold start cycles to 09Z and 21Z, also turn on DA for deterministic and ensemble cold start cycles
- fix the recenter data dependency on nonvar_cldana if do_nonvar_cldana=true
- do surface cycling for spin-up cycles only, if do_spinup=true
- add option to fall back to 3DVar if no ensemble forecast files are not found for hybrid 3DEnVar. This is needed if we want to force the jedivar to run when the ensemble data dependency is not met
