### PR TITLE
Correct ozone variable in 'control_variables" section 

### DIFF
--- a/fix/jedi/RRFS_CONUS_13km/gsiparm_regional.anl
+++ b/fix/jedi/RRFS_CONUS_13km/gsiparm_regional.anl
@@ -63,7 +63,7 @@ state_vector::
  tv       65      0     met_guess    tv
 # tsen     65      0     met_guess    tv,q
  q        65      1     met_guess    q
-#oz       65      1     met_guess    oz
+ oz       65      1     met_guess    oz
  prse     66      0     met_guess    prse
  ps        1      0     met_guess    ps
 # sst       1      0     met_guess    sst
@@ -76,6 +76,7 @@ control_vector::
  ps        1      0       1.00        -1.0     state    prse
  t        65      0       1.40        -1.0     state    tv
  q        65      1       0.80        -1.0     state    q
+ oz       65      1       0.80        -1.0     state    oz
 # sst       1      0       1.00        -1.0     state    sst
 # stl       1      0       1.00        -1.0     motley   sst
 # sti       1      0       1.00        -1.0     motley   sst

--- a/fix/jedi/RRFS_CONUS_3km/gsiparm_regional.anl
+++ b/fix/jedi/RRFS_CONUS_3km/gsiparm_regional.anl
@@ -63,7 +63,7 @@ state_vector::
  tv       65      0     met_guess    tv
 # tsen     65      0     met_guess    tv,q
  q        65      1     met_guess    q
-#oz       65      1     met_guess    oz
+ oz       65      1     met_guess    oz
  prse     66      0     met_guess    prse
  ps        1      0     met_guess    ps
 # sst       1      0     met_guess    sst
@@ -76,6 +76,7 @@ control_vector::
  ps        1      0       1.00        -1.0     state    prse
  t        65      0       1.40        -1.0     state    tv
  q        65      1       0.80        -1.0     state    q
+ oz       65      1       0.80        -1.0     state    oz
 # sst       1      0       1.00        -1.0     state    sst
 # stl       1      0       1.00        -1.0     motley   sst
 # sti       1      0       1.00        -1.0     motley   sst

--- a/fix/jedi/RRFS_NA_3km/gsiparm_regional.anl
+++ b/fix/jedi/RRFS_NA_3km/gsiparm_regional.anl
@@ -63,7 +63,7 @@ state_vector::
  tv       65      0     met_guess    tv
 # tsen     65      0     met_guess    tv,q
  q        65      1     met_guess    q
-#oz       65      1     met_guess    oz
+ oz       65      1     met_guess    oz
  prse     66      0     met_guess    prse
  ps        1      0     met_guess    ps
 # sst       1      0     met_guess    sst
@@ -76,6 +76,7 @@ control_vector::
  ps        1      0       1.00        -1.0     state    prse
  t        65      0       1.40        -1.0     state    tv
  q        65      1       0.80        -1.0     state    q
+ oz       65      1       0.80        -1.0     state    oz
 # sst       1      0       1.00        -1.0     state    sst
 # stl       1      0       1.00        -1.0     motley   sst
 # sti       1      0       1.00        -1.0     motley   sst

--- a/parm/rdas-atmosphere-templates-fv3_c13.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13.yaml
@@ -45,7 +45,7 @@ control_variables:
 - northward_wind
 - virtual_temperature
 - water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
+- mole_fraction_of_ozone_in_air
 - air_pressure_at_surface
 
 state_variables_to_inverse:

--- a/parm/rdas-atmosphere-templates-fv3_c13_dbz.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13_dbz.yaml
@@ -51,7 +51,7 @@ control_variables:
 - northward_wind
 - virtual_temperature
 - water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
+- mole_fraction_of_ozone_in_air
 - cloud_liquid_water
 - cloud_liquid_ice
 - rain_water

--- a/parm/rdas-atmosphere-templates-fv3_na3km.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_na3km.yaml
@@ -46,7 +46,7 @@ control_variables:
 - northward_wind
 - virtual_temperature
 - water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
+- mole_fraction_of_ozone_in_air
 - air_pressure_at_surface
 
 state_variables_to_inverse:

--- a/sorc/_workaround_/fix/jedi/RRFS_CONUS_13km/gsiparm_regional.anl
+++ b/sorc/_workaround_/fix/jedi/RRFS_CONUS_13km/gsiparm_regional.anl
@@ -63,7 +63,7 @@ state_vector::
  tv       65      0     met_guess    tv
 # tsen     65      0     met_guess    tv,q
  q        65      1     met_guess    q
-#oz       65      1     met_guess    oz
+ oz       65      1     met_guess    oz
  prse     66      0     met_guess    prse
  ps        1      0     met_guess    ps
 # sst       1      0     met_guess    sst
@@ -76,6 +76,7 @@ control_vector::
  ps        1      0       1.00        -1.0     state    prse
  t        65      0       1.40        -1.0     state    tv
  q        65      1       0.80        -1.0     state    q
+ oz       65      1       0.80        -1.0     state    oz
 # sst       1      0       1.00        -1.0     state    sst
 # stl       1      0       1.00        -1.0     motley   sst
 # sti       1      0       1.00        -1.0     motley   sst

--- a/sorc/_workaround_/parm/rdas-atmosphere-templates-fv3_c13.yaml
+++ b/sorc/_workaround_/parm/rdas-atmosphere-templates-fv3_c13.yaml
@@ -49,7 +49,7 @@ control_variables:
 - northward_wind
 - virtual_temperature
 - water_vapor_mixing_ratio_wrt_moist_air
-- ozone_mass_mixing_ratio
+- mole_fraction_of_ozone_in_air
 - air_pressure_at_surface
 
 state_variables_to_inverse:


### PR DESCRIPTION
This PR is updating the JCB template files that related to RDASApp P[R#590 ](https://github.com/NOAA-EMC/RDASApp/pull/590) about fixing the incorrect ozone variable was used in the Control2Analysis linear variable change section, and in the SABER block, which fixed the minimization problem occurred in the satellite radiance data being assimilated. 

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Modified  'control_variables" section to change "ozone_mass_mixing_ratio" "mole_fraction_of_ozone_in_air" in the following files

> -  rdas-atmosphere-templates-fv3_na3km.yaml

> -  rdas-atmosphere-templates-fv3_c13_dbz.yaml

> -  rdas-atmosphere-templates-fv3_c13.yaml

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
Tested the changes with Retro experiments on the following Platforms:
### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

