### PR TITLE
[dev-sci] Update RDASApp and enable vader custom cookbook

### DIFF
--- a/parm/rdas-atmosphere-templates-fv3_c13.yaml
+++ b/parm/rdas-atmosphere-templates-fv3_c13.yaml
@@ -19,6 +19,7 @@ initial_condition_file: atmosphere_background
 #background_error_file: atmosphere_background_error_hybrid3denvar_mgbf
 background_error_file: atmosphere_background_error_3dvar_gsibec
 #background_error_file: atmosphere_background_error_3dvar_bumpID
+vader_custom_cookbook_file: atmosphere_vader_custom_cookbook
 
 # Global analysis things
 # ----------------------

--- a/sorc/Externals.cfg
+++ b/sorc/Externals.cfg
@@ -68,7 +68,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/RDASApp
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = 5a7cc30
+hash = 43616bd
 local_path = RDASApp
 required = True
 

--- a/sorc/_workaround_/parm/rdas-atmosphere-templates-fv3_c13.yaml
+++ b/sorc/_workaround_/parm/rdas-atmosphere-templates-fv3_c13.yaml
@@ -19,6 +19,7 @@ initial_condition_file: atmosphere_background
 #background_error_file: atmosphere_background_error_hybrid3denvar_mgbf
 background_error_file: atmosphere_background_error_3dvar_gsibec
 #background_error_file: atmosphere_background_error_3dvar_bumpID
+vader_custom_cookbook_file: atmosphere_vader_custom_cookbook
 
 # Global analysis things
 # ----------------------


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR enables the use of the custom vader cookbook in the workflow.
- RDASApp hash was updated with capability to provide a vader custom cookbook.
- Added the parameter in the 3dvar baseline jcb-configure file for the vader cookbook.

## TESTS CONDUCTED: 
Single DA cycle to confirm cookbook was used and changes to DA were minimial (only affected satwnds by changing a few nob counts)

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

