### PR TITLE
Removal of GOES AMV expected normalized error checks

### DIFF
--- a/parm/observers/satwnd_uv245_270.yaml
+++ b/parm/observers/satwnd_uv245_270.yaml
@@ -385,6 +385,28 @@
            action:
              name: reject
 
+#         # AMV expected error norm check
+#         - filter: Perform Action
+#           apply at iterations: 0,1
+#           identifier:
+#             name: AMVErrorNormCheck
+#             logging: false
+#             diagnostic flag new: false
+#           filter variables:
+#           - name: windEastward
+#           - name: windNorthward
+#           where:
+#           - variable: ObsFunction/Velocity
+#             minvalue: 0.1
+#           - variable: MetaData/exp_err_norm
+#             minvalue: 0.9
+#           - variable: ObsType/windEastward
+#             is_in: 245
+#           - variable: MetaData/satelliteIdentifier
+#             is_in: 270
+#           action:
+#             name: reject
+
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv245_270.yaml
+++ b/parm/observers/satwnd_uv245_270.yaml
@@ -385,28 +385,6 @@
            action:
              name: reject
 
-         # AMV expected error norm check
-         - filter: Perform Action
-           apply at iterations: 0,1
-           identifier:
-             name: AMVErrorNormCheck
-             logging: false
-             diagnostic flag new: false
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             minvalue: 0.1
-           - variable: MetaData/exp_err_norm
-             minvalue: 0.9
-           - variable: ObsType/windEastward
-             is_in: 245
-           - variable: MetaData/satelliteIdentifier
-             is_in: 270
-           action:
-             name: reject
-
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv245_272.yaml
+++ b/parm/observers/satwnd_uv245_272.yaml
@@ -385,6 +385,28 @@
            action:
              name: reject
 
+#         # AMV expected error norm check
+#         - filter: Perform Action
+#           apply at iterations: 0,1
+#           identifier:
+#             name: AMVErrorNormCheck
+#             logging: false
+#             diagnostic flag new: false
+#           filter variables:
+#           - name: windEastward
+#           - name: windNorthward
+#           where:
+#           - variable: ObsFunction/Velocity
+#             minvalue: 0.1
+#           - variable: MetaData/exp_err_norm
+#             minvalue: 0.9
+#           - variable: ObsType/windEastward
+#             is_in: 245
+#           - variable: MetaData/satelliteIdentifier
+#             is_in: 272
+#           action:
+#             name: reject
+
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv245_272.yaml
+++ b/parm/observers/satwnd_uv245_272.yaml
@@ -385,28 +385,6 @@
            action:
              name: reject
 
-         # AMV expected error norm check
-         - filter: Perform Action
-           apply at iterations: 0,1
-           identifier:
-             name: AMVErrorNormCheck
-             logging: false
-             diagnostic flag new: false
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             minvalue: 0.1
-           - variable: MetaData/exp_err_norm
-             minvalue: 0.9
-           - variable: ObsType/windEastward
-             is_in: 245
-           - variable: MetaData/satelliteIdentifier
-             is_in: 272
-           action:
-             name: reject
-
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv246_270.yaml
+++ b/parm/observers/satwnd_uv246_270.yaml
@@ -364,6 +364,28 @@
            action:
              name: reject
 
+#         # AMV expected error norm check
+#         - filter: Perform Action
+#           apply at iterations: 0,1
+#           identifier:
+#             name: AMVErrorNormCheck
+#             logging: false
+#             diagnostic flag new: false
+#           filter variables:
+#           - name: windEastward
+#           - name: windNorthward
+#           where:
+#           - variable: ObsFunction/Velocity
+#             minvalue: 0.1
+#           - variable: MetaData/exp_err_norm
+#             minvalue: 0.9
+#           - variable: ObsType/windEastward
+#             is_in: 246
+#           - variable: MetaData/satelliteIdentifier
+#             is_in: 270
+#           action:
+#             name: reject
+
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv246_270.yaml
+++ b/parm/observers/satwnd_uv246_270.yaml
@@ -364,28 +364,6 @@
            action:
              name: reject
 
-         # AMV expected error norm check
-         - filter: Perform Action
-           apply at iterations: 0,1
-           identifier:
-             name: AMVErrorNormCheck
-             logging: false
-             diagnostic flag new: false
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             minvalue: 0.1
-           - variable: MetaData/exp_err_norm
-             minvalue: 0.9
-           - variable: ObsType/windEastward
-             is_in: 246
-           - variable: MetaData/satelliteIdentifier
-             is_in: 270
-           action:
-             name: reject
-
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv246_272.yaml
+++ b/parm/observers/satwnd_uv246_272.yaml
@@ -364,6 +364,28 @@
            action:
              name: reject
 
+#         # AMV expected error norm check
+#         - filter: Perform Action
+#           apply at iterations: 0,1
+#           identifier:
+#             name: AMVErrorNormCheck
+#             logging: false
+#             diagnostic flag new: false
+#           filter variables:
+#           - name: windEastward
+#           - name: windNorthward
+#           where:
+#           - variable: ObsFunction/Velocity
+#             minvalue: 0.1
+#           - variable: MetaData/exp_err_norm
+#             minvalue: 0.9
+#           - variable: ObsType/windEastward
+#             is_in: 246
+#           - variable: MetaData/satelliteIdentifier
+#             is_in: 272
+#           action:
+#             name: reject
+
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv246_272.yaml
+++ b/parm/observers/satwnd_uv246_272.yaml
@@ -364,28 +364,6 @@
            action:
              name: reject
 
-         # AMV expected error norm check
-         - filter: Perform Action
-           apply at iterations: 0,1
-           identifier:
-             name: AMVErrorNormCheck
-             logging: false
-             diagnostic flag new: false
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             minvalue: 0.1
-           - variable: MetaData/exp_err_norm
-             minvalue: 0.9
-           - variable: ObsType/windEastward
-             is_in: 246
-           - variable: MetaData/satelliteIdentifier
-             is_in: 272
-           action:
-             name: reject
-
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv247_270.yaml
+++ b/parm/observers/satwnd_uv247_270.yaml
@@ -339,6 +339,28 @@
            action:
              name: reject
 
+#         # AMV expected error norm check
+#         - filter: Perform Action
+#           apply at iterations: 0,1
+#           identifier:
+#             name: AMVErrorNormCheck
+#             logging: false
+#             diagnostic flag new: false
+#           filter variables:
+#           - name: windEastward
+#           - name: windNorthward
+#           where:
+#           - variable: ObsFunction/Velocity
+#             minvalue: 0.1
+#           - variable: MetaData/exp_err_norm
+#             minvalue: 0.9
+#           - variable: ObsType/windEastward
+#             is_in: 247
+#           - variable: MetaData/satelliteIdentifier
+#             is_in: 270
+#           action:
+#             name: reject
+
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv247_270.yaml
+++ b/parm/observers/satwnd_uv247_270.yaml
@@ -339,28 +339,6 @@
            action:
              name: reject
 
-         # AMV expected error norm check
-         - filter: Perform Action
-           apply at iterations: 0,1
-           identifier:
-             name: AMVErrorNormCheck
-             logging: false
-             diagnostic flag new: false
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             minvalue: 0.1
-           - variable: MetaData/exp_err_norm
-             minvalue: 0.9
-           - variable: ObsType/windEastward
-             is_in: 247
-           - variable: MetaData/satelliteIdentifier
-             is_in: 270
-           action:
-             name: reject
-
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv247_272.yaml
+++ b/parm/observers/satwnd_uv247_272.yaml
@@ -339,6 +339,28 @@
            action:
              name: reject
 
+#         # AMV expected error norm check
+#         - filter: Perform Action
+#           apply at iterations: 0,1
+#           identifier:
+#             name: AMVErrorNormCheck
+#             logging: false
+#             diagnostic flag new: false
+#           filter variables:
+#           - name: windEastward
+#           - name: windNorthward
+#           where:
+#           - variable: ObsFunction/Velocity
+#             minvalue: 0.1
+#           - variable: MetaData/exp_err_norm
+#             minvalue: 0.9
+#           - variable: ObsType/windEastward
+#             is_in: 247
+#           - variable: MetaData/satelliteIdentifier
+#             is_in: 272
+#           action:
+#             name: reject
+
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1

--- a/parm/observers/satwnd_uv247_272.yaml
+++ b/parm/observers/satwnd_uv247_272.yaml
@@ -339,28 +339,6 @@
            action:
              name: reject
 
-         # AMV expected error norm check
-         - filter: Perform Action
-           apply at iterations: 0,1
-           identifier:
-             name: AMVErrorNormCheck
-             logging: false
-             diagnostic flag new: false
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             minvalue: 0.1
-           - variable: MetaData/exp_err_norm
-             minvalue: 0.9
-           - variable: ObsType/windEastward
-             is_in: 247
-           - variable: MetaData/satelliteIdentifier
-             is_in: 272
-           action:
-             name: reject
-
          # Halve the ob error (based on read_satwnd.f90)
          - filter: Perform Action
            apply at iterations: 0,1


### PR DESCRIPTION
This PR removes the expected normalized error check for GOES AMVs for all 6 observation spaces - satwnd_uv245_270, satwnd_uv245_272, satwnd_uv246_270, satwnd_uv246_272, satwnd_uv247_270, and satwnd_uv247_272.

Our IODA files do not actually have MetaData/exp_err_norm as the filter requires. The closest field is MetaData/expectedError (which is not normalized between 0 and 1 like the filter would expect), but it is not abundantly clear that including the field makes an appreciable difference in results.