### PR TITLE
[dev-sci] Disable hdf5 file locking and set `rdas_ua2u.x` to use one rank

### DIFF
--- a/scripts/exrrfs_analysis_jedi.sh
+++ b/scripts/exrrfs_analysis_jedi.sh
@@ -101,31 +101,27 @@ case $MACHINE in
     ppn=${PPN_HYBRID_RADAR_REF_JEDI}
   fi
   APRUN="mpirun -n ${ncores} -ppn ${ppn} --cpu-bind core --depth 1"
-  if [ ${ncores} -gt 480 ]; then
-    APRUN_UA="mpirun -n 480 -ppn ${ppn} --cpu-bind core --depth 1"
-  else
-    APRUN_UA="mpirun -n ${ncores} -ppn ${ppn} --cpu-bind core --depth 1"
-  fi
+  APRUN_UA="mpirun -n 1 -ppn 1 --cpu-bind core --depth 1"
   ;;
 #
 "HERA")
   APRUN="srun"
-  APRUN_UA="srun"
+  APRUN_UA="srun -n 1"
   ;;
   #
 "GAEA")
   APRUN="srun"
-  APRUN_UA="srun"
+  APRUN_UA="srun -n 1"
   ;;
 #
 "JET")
   APRUN="srun"
-  APRUN_UA="srun"
+  APRUN_UA="srun -n 1"
   ;;
 #
 "ORION")
   APRUN="srun"
-  APRUN_UA="srun"
+  APRUN_UA="srun -n 1"
   ;;
 #
 esac
@@ -719,6 +715,8 @@ mv errfile errfile_jedi
 # 2. Convert A-grid wind increments to D-grid wind increments
 #####################################################################
 export LD_LIBRARY_PATH="/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/hdf5-1.14.3-umtw5lv/lib:${LD_LIBRARY_PATH}"
+# Disable HDF5's advisory file locking similar to avoid intermittent failures
+export HDF5_USE_FILE_LOCKING=FALSE
 export pgm="rdas_ua2u.x"
 ua2u_exec="${EXECdir}/bin/${pgm}"
 cp "${ua2u_exec}" "${analworkdir}/${pgm}"

--- a/scripts/exrrfs_forecast.sh
+++ b/scripts/exrrfs_forecast.sh
@@ -112,31 +112,27 @@ case $MACHINE in
     export MPICH_OFI_VERBOSE=1
     export MPICH_OFI_NIC_VERBOSE=1
     APRUN="mpiexec -n ${PE_MEMBER01} -ppn ${PPN_RUN_FCST} --cpu-bind core --depth ${OMP_NUM_THREADS}"
-    if [ ${PE_MEMBER01} -gt 480 ]; then
-      APRUN_UA="mpiexec -n 480 -ppn ${PPN_RUN_FCST} --cpu-bind core --depth 1"
-    else
-      APRUN_UA="mpiexec -n ${PE_MEMBER01} -ppn ${PPN_RUN_FCST} --cpu-bind core --depth 1"
-    fi
+    APRUN_UA="mpiexec -n 1 -ppn 1 --cpu-bind core --depth 1"
     ;;
 
   "HERA")
     APRUN="srun --export=ALL --mem=0"
-    APRUN_UA="srun"
+    APRUN_UA="srun -n 1"
     ;;
 
   "GAEA")
     APRUN="srun --export=ALL --mem=0"
-    APRUN_UA="srun"
+    APRUN_UA="srun -n 1"
     ;;
 
   "ORION")
     APRUN="srun --export=ALL --mem=0"
-    APRUN_UA="srun"
+    APRUN_UA="srun -n 1"
     ;;
 
   "HERCULES")
     APRUN="srun --export=ALL"
-    APRUN_UA="srun"
+    APRUN_UA="srun -n 1"
     ;;
 
   "JET")
@@ -146,7 +142,7 @@ case $MACHINE in
     else
       OMP_NUM_THREADS=2
     fi
-    APRUN_UA="srun"
+    APRUN_UA="srun -n 1"
     ;;
 
   *)
@@ -216,6 +212,8 @@ if [[ "${DA_SYSTEM}" = "JEDI" || "${DO_PARALLEL_DA}" = "TRUE" ]]; then
     fi
 
     export LD_LIBRARY_PATH="${RDASAPP_DIR}/build/lib64:${LD_LIBRARY_PATH}"
+    # Disable HDF5's advisory file locking similar to avoid intermittent failures
+    export HDF5_USE_FILE_LOCKING=FALSE
     pgm="rdas_ua2u.x"
     ua2u_exec="${EXECdir}/bin/${pgm}"
     cp "${ua2u_exec}" "./${pgm}"


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

When running the new version of `rdas_ua2u.x`, @delippi noticed some sporadic, non-reproducible errors when writing the analysis files at the end: 

```
--- computing wind analysis in place from fv3_dynvars
  domain dims:     (1:1) --> (420:1) --> (420:252) --> (1:252)
       T-cell: 236.50  20.76---> 288.50  20.76---> 299.99  47.66---> 225.01  47.66
   grid_lont : 225.01: 299.99 grid_latt :  20.76:  53.17
  domain dims:     (1:1) --> (421:1) --> (421:253) --> (1:253)
             : 236.45  20.69---> 288.55  20.69---> 300.10  47.68---> 224.90  47.68
   grid_lon  : 224.90: 300.10 grid_lat  :  20.69:  53.23
u dimensions:          420=         420:         252=         252:          65
---getting ua :  420  252   65    1
---getting va :  420  252   65    1
---getting ua_anl :  420  252   65    1
---getting va_anl :  420  252   65    1
 --- adding u/v increments to background u/v in fv3_dynvars
---getting u :  420  253   65    1
---getting v :  421  252   65    1
 --- updating u/v in place in fv3_dynvars
NetCDF: HDF error   wrong in open fv3_dynvars
```

It was found that setting `export HDF5_USE_FILE_LOCKING=FALSE` before running `rdas_ua2u.x` can help with this. This is also set in `exrrfs_analysis_enkf.sh` with the comment "helps avoid recenter's error "NetCDF: HDF error". 

This PR also sets `rdas_ua2u.x` to only run on one MPI rank given that the program is serial.

It is hard to say if the problem is fully resolved now, but things seem more stable now from some limited retro testing. 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [x] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [x] Engineering tests
  - [ ] Non-DA engineering test
  - [x] DA engineering test
    - [x] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
None

## CONTRIBUTORS (optional): 
@delippi 
