### PR TITLE
[release v1.0] add dbn_alert for non-WMO-headed AWIPS file

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -224,6 +224,11 @@ if [ -s ${COMOUT}/${fld2d} ]; then
           ${COMOUT}/${fld2d}
       $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_2DFLD_NA_IDX $job \
           ${COMOUT}/${fld2d}.idx
+    elif [[ "${PREDEF_GRID_NAME}" = "RRFS_NA_3km" ]]; then
+      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA3 $job \
+          ${COMOUT}/${fld2d}
+      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA3_IDX $job \
+          ${COMOUT}/${fld2d}.idx
     fi
   fi
 fi

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -60,9 +60,11 @@ then
 
   cpreq -p grib2.rrfs.t${cyc}z.${gridspacing}.f${fhr}.na ${COMOUT}/wmo
 
- if [ $SENDDBN_NTC = YES ]
- then
+ if [ $SENDDBN_NTC = YES ]; then
    $DBNROOT/bin/dbn_alert NTC_LOW $NET $job ${COMOUT}/wmo/grib2.rrfs.t${cyc}z.${gridspacing}.f${fhr}.na
+   if [ $gridspacing == "3km" ]; then
+     $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA3 $NET $job $INPUTfile
+   fi
  fi
 
 else

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -62,9 +62,6 @@ then
 
  if [ $SENDDBN_NTC = YES ]; then
    $DBNROOT/bin/dbn_alert NTC_LOW $NET $job ${COMOUT}/wmo/grib2.rrfs.t${cyc}z.${gridspacing}.f${fhr}.na
-   if [ $gridspacing == "3km" ]; then
-     $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA3 $NET $job $INPUTfile
-   fi
  fi
 
 else


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Adds a dbn_alert for the non-WMO-headed, 3-km grid, AWIPS product.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- not tested, needs discussion/review.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

