### PR TITLE
[release/v1.0] Alerting the interpolated 3 km AWIPS product unheaded

### DIFF
--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -52,8 +52,7 @@ then
      cpreq rrfs.t${cyc}z.${inputfile}.${gridspacing}.f${fhr}.na.grib2 ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
      wgrib2 ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2 -s > \
                ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
-     if [ $SENDDBN = YES ]
-     then
+     if [ $SENDDBN = YES ]; then
       $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
       $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA_IDX ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
      fi
@@ -71,8 +70,7 @@ then
 
   cpreq -p grib2.rrfs.t${cyc}z.${gridspacing}.f${fhr}.na ${COMOUT}/wmo
 
- if [ $SENDDBN_NTC = YES ]
- then
+ if [ $SENDDBN_NTC = YES ]; then
    $DBNROOT/bin/dbn_alert NTC_LOW $NET $job ${COMOUT}/wmo/grib2.rrfs.t${cyc}z.${gridspacing}.f${fhr}.na
  fi
 

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -56,6 +56,7 @@ then
      then
       $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
       $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA_IDX ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
+     fi
   fi
 
   # Run tocgrib2

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -50,7 +50,7 @@ then
 
   if [ $gridspacing == "3km" ]; then
      cpreq rrfs.t${cyc}z.${inputfile}.${gridspacing}.f${fhr}.na.grib2 ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
-     wgrib2 -s ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2 > \
+     wgrib2 ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2 -s > \
                ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
      if [ $SENDDBN = YES ]
      then

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -48,6 +48,16 @@ then
   -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
   -new_grid ${gridspecs} rrfs.t${cyc}z.${inputfile}.${gridspacing}.f${fhr}.na.grib2
 
+  if [ $gridspacing == "3km" ]; then
+     cpreq rrfs.t${cyc}z.${inputfile}.${gridspacing}.f${fhr}.na.grib2 ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
+     wgrib2 -s ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2 > \
+               ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
+     if [ $SENDDBN = YES ]
+     then
+      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
+      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA_IDX ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
+  fi
+
   # Run tocgrib2
 
   export pgm="tocgrib2"

--- a/ush/prdgen/rrfs_mkawp.sh
+++ b/ush/prdgen/rrfs_mkawp.sh
@@ -53,8 +53,8 @@ then
      wgrib2 ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2 -s > \
                ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
      if [ $SENDDBN = YES ]; then
-      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
-      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_AWIPSUBSET_2DFLD_NA_IDX ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
+      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA3 ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2
+      $DBNROOT/bin/dbn_alert MODEL RRFS_DET_2DFLD_NA3_IDX ${job} ${COMOUT}/rrfs.t${cyc}z.${inputfile}_awipsubset.${gridspacing}.f${fhr}.na.grib2.idx
      fi
   fi
 


### PR DESCRIPTION

<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
-  Some changes to ush/prdgen/rrfs_mkawp.sh to copy the AWIPS 3 km file to COM before header is attached, and to alert it.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- Not yet tested.
- 
### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

