### PR TITLE
[rrfs-dev] add prod_clone utility to simulate operational upstream jobs

### DIFF
--- a/ush/prod_clone/ecf/defs.def
+++ b/ush/prod_clone/ecf/defs.def
@@ -1,0 +1,395 @@
+suite prod_clone
+  # Explicitly define the home and output directories to fix the pathing error
+  edit ECF_HOME "/lfs/h2/emc/lam/noscrub/emc.lam/ecflow/submit"
+  edit ECF_OUT  "/lfs/h2/emc/lam/noscrub/emc.lam/ecflow/output"
+  edit OUTPUTDIR "/lfs/f2/t2o/ptmp/emc/para/output/prod_clone"
+  edit ENVIR 'prod'
+  edit MACHINE_SITE 'production'
+  
+  # Base directory for your package
+  edit PACKAGEHOME "/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/prod_clone.v0.0.2"
+  
+  # Use the absolute path for ECF_FILES to avoid expansion issues
+  edit ECF_FILES "/lfs/h2/emc/lam/noscrub/emc.lam/rrfs/prod_clone.v0.0.2/ecf"
+
+  task jupdateprodclonestatuses
+    defstatus complete
+    cron 00:00 23:59 00:01
+
+  family primary
+    family 00
+      family gfs
+        family v16.3
+          family gfs
+            family atmos
+              family post
+                task jgfs_atmos_post_f003
+                task jgfs_atmos_post_f102
+              endfamily
+            endfamily
+          endfamily
+          family enkfgdas
+            family post
+              task jenkfgdas_post_f007
+            endfamily
+          endfamily
+        endfamily # v16.3
+      endfamily # gfs
+      family gefs
+        family v12.3
+          family members
+            family d0_16
+              task jgefs_pgrb2abp5_f192_done
+            endfamily
+          endfamily
+        endfamily # v12.3
+      endfamily # gefs
+      family obsproc
+        family v1.2
+          family rrfs
+            family 00z
+              family prep
+                task jobsproc_rrfs_prep
+                task jobsproc_rrfs_prep_erly
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+                task jobsproc_rrfs_dump_erly
+              endfamily
+            endfamily # 00z
+            family 01z 
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 01z
+            family 02z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 02z
+            family 03z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 03z
+            family 04z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 04z
+            family 05z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 05z
+          endfamily #rrfs
+        endfamily #v1.2
+      endfamily #obsproc
+      family nosofs
+        family v3.6
+          family leofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # leofs
+          family lmhofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # lmhofs
+          family loofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # loofs
+          family lsofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # lsofs
+        endfamily # v3.6
+      endfamily # nosofs
+    endfamily # 00
+    family 06
+      family gfs
+        family v16.3
+          family gfs
+            family atmos
+              family post
+                task jgfs_atmos_post_f003
+                task jgfs_atmos_post_f102
+              endfamily
+            endfamily
+          endfamily
+          family enkfgdas
+            family post
+              task jenkfgdas_post_f007
+            endfamily
+          endfamily
+        endfamily # v16.3
+      endfamily # gfs
+      family gefs
+        family v12.3
+          family members
+            family d0_16
+              task jgefs_pgrb2abp5_f192_done
+            endfamily
+          endfamily
+        endfamily # v12.3
+      endfamily # gefs
+      family obsproc
+        family v1.2
+          family rrfs
+            family 06z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 06z
+            family 07z 
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 07z
+            family 08z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 08z
+            family 09z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 09z
+            family 10z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 10z
+            family 11z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 11z
+          endfamily #rrfs
+        endfamily #v1.2
+      endfamily #obsproc
+      family nosofs
+        family v3.6
+          family leofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # leofs
+        endfamily # v3.6
+      endfamily # nosofs
+    endfamily # 06
+    family 12 
+      family nsst
+        family v1.2
+          task jnsst
+        endfamily
+      endfamily
+      family gfs
+        family v16.3
+          family gfs
+            family atmos
+              family post
+                task jgfs_atmos_post_f003
+                task jgfs_atmos_post_f102
+              endfamily
+            endfamily
+          endfamily
+          family enkfgdas
+            family post
+              task jenkfgdas_post_f007
+            endfamily
+          endfamily
+        endfamily # v16.3
+      endfamily # gfs
+      family gefs
+        family v12.3
+          family members
+            family d0_16
+              task jgefs_pgrb2abp5_f192_done
+            endfamily
+          endfamily
+        endfamily # v12.3
+      endfamily # gefs
+      family obsproc
+        family v1.2
+          family rrfs
+            family 12z
+              family prep
+                task jobsproc_rrfs_prep
+                task jobsproc_rrfs_prep_erly
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+                task jobsproc_rrfs_dump_erly
+              endfamily
+            endfamily # 12z
+            family 13z 
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 13z
+            family 14z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 14z
+            family 15z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 15z
+            family 16z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 16z
+            family 17z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 17z
+          endfamily #rrfs
+        endfamily #v1.2
+      endfamily #obsproc
+      family nosofs
+        family v3.6
+          family leofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # leofs
+        endfamily # v3.6
+      endfamily # nosofs
+    endfamily #12 
+    family 18
+      family gfs
+        family v16.3
+          family gfs
+            family atmos
+              family post
+                task jgfs_atmos_post_f003
+                task jgfs_atmos_post_f102
+              endfamily
+            endfamily   
+          endfamily
+          family enkfgdas
+            family post
+              task jenkfgdas_post_f007
+            endfamily
+          endfamily
+        endfamily # v16.3
+      endfamily # gfs
+      family gefs
+        family v12.3
+          family members
+            family d0_16
+              task jgefs_pgrb2abp5_f192_done
+            endfamily
+          endfamily
+        endfamily # v12.3
+      endfamily # gefs
+      family obsproc
+        family v1.2
+          family rrfs
+            family 18z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 18z
+            family 19z 
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 19z
+            family 20z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 20z
+            family 21z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 21z
+            family 22z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 22z
+            family 23z
+              family prep
+                task jobsproc_rrfs_prep
+              endfamily
+              family dump
+                task jobsproc_rrfs_dump
+              endfamily
+            endfamily # 23z
+          endfamily #rrfs
+        endfamily #v1.2
+      endfamily #obsproc
+      family nosofs
+        family v3.6
+          family leofs
+            task jnos_ofs_nowcst_fcst
+          endfamily # leofs
+        endfamily # v3.6
+      endfamily # nosofs
+    endfamily #18
+  endfamily # primary
+endsuite

--- a/ush/prod_clone/ecf/jupdateprodclonestatuses.ecf
+++ b/ush/prod_clone/ecf/jupdateprodclonestatuses.ecf
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+model=prod_clone
+%include <head.h>
+
+set +x
+#module load ecflow/$ecflow_ver
+module load intel/$intel_ver
+module load python/$python_ver
+set -x
+
+#export envir=prod
+export envir=%ENVIR%
+export jobid=prod_clone.$$
+export DATA=/lfs/f2/t2o/ptmp/emc/para/stmp/prod_clone/$jobid
+rm -rf $DATA
+#mkdir -m 755 $DATA
+mkdir -p $DATA
+cd $DATA
+export PRODCLONEPREFIX=/prod_clone
+
+#PRODCHECKPOINTFILE=/lfs/h1/ops/test/com/ecflow/ecf.check.prod
+PRODCHECKPOINTFILE=/lfs/h2/emc/lam/noscrub/emc.lam/Shun.Liu/mirrior/prod_clone/ecf.check.prod
+PARACHECKPOINTFILE=/lfs/h2/emc/lam/noscrub/emc.lam/ecflow/submit/ecf.check
+#PARACHECKPOINTFILE=/lfs/h2/emc/lam/noscrub/emc.lam/ecflow/submit/ddecflow02.32035.ecf.check
+
+
+# If we're less than 25 seconds from the next prod checkpoint write, just wait:
+%nopp
+#nextcheckpointtime=$(($(stat -c %Y $PRODCHECKPOINTFILE)+60))  #( last modified time seconds since Epoch )
+nextcheckpointtime=$(($(stat -c %Z $PRODCHECKPOINTFILE)+60))   #( last changed time seconds since Epoch )
+#waittime=$(($(date +%s)-$nextcheckpointtime))
+waittime=$(($nextcheckpointtime-$(date +%s)))
+sleeptime=$((waittime+2))
+%end
+#if [[ $waittime -lt 25 && $waittime -gt 0 ]]; then sleep $waittime; fi
+if [[ $waittime -lt 25 && $waittime -gt 0 ]]; then sleep $sleeptime; fi
+if [ $waittime -eq 60 ]; then sleep 2; fi
+echo $LD_LIBRARY_PATH
+cp $PRODCHECKPOINTFILE ecf.check.prod
+cp $PARACHECKPOINTFILE ecf.check.para
+
+#$HOMEprod_clone/scripts/exupdateprodclonestatuses.py $PRODCHECKPOINTFILE $PARACHECKPOINTFILE
+$HOMEprod_clone/scripts/exupdateprodclonestatuses.py ecf.check.prod ecf.check.para
+python $HOMEprod_clone/scripts/clean.py
+python $HOMEprod_clone/scripts/complete_enkf_save_f1.py
+python $HOMEprod_clone/scripts/complete_enkf_save_f3.py
+python $HOMEprod_clone/scripts/complete_post.py
+
+export err=$?
+
+if [ $err -eq 0 -a $KEEPDATA != YES ]; then
+  mkdir -p /lfs/f2/t2o/ptmp/emc/ptmp/emc.lam/$envir/tmp
+  cd /lfs/f2/t2o/ptmp/emc/ptmp/emc.lam/$envir/tmp
+  rm -rf $jobid
+fi
+
+%include <tail.h>
+
+%manual
+# This job compares the prod and para ecflow checkpoint files once per minute and
+# updates tasks under the para server's /prod_clone suite accordingly.
+#
+# When adding jobs under the /prod_clone suite, remove all variables, cron's,
+# time dependencies, triggers, etc. from the definitions.
+%end

--- a/ush/prod_clone/include/head.h
+++ b/ush/prod_clone/include/head.h
@@ -1,0 +1,95 @@
+date
+hostname
+set -xe  # print commands as they are executed and enable signal trapping
+
+# Define error handler
+ERROR() {
+  set +ex
+  if [ "$1" -eq 0 ]; then
+     msg="Killed by signal (likely via qdel)"
+  else
+     msg="Killed by signal $1"
+  fi
+  ecflow_client --abort="$msg"
+  echo $msg
+#  if [[ " ops.prod ops.para " =~ " $(whoami) " ]]; then
+#    echo "# Trap Caught" >>$POST_OUT
+#  fi
+  trap 0                      # Remove the trap
+  exit $1
+}
+# Trap all error and exit signals
+trap 'ERROR $?' ERR EXIT
+
+export PS4='+ $SECONDS + ' 
+
+# Variables needed for communication with ecFlow
+export ECF_NAME=%ECF_NAME%
+export ECF_HOST=%ECF_LOGHOST%
+export ECF_PORT=%ECF_PORT%
+export ECF_PASS=%ECF_PASS%
+export ECF_TRYNO=%ECF_TRYNO%
+export ECF_RID=${ECF_RID:-${PBS_JOBID:-$(hostname -s).$$}}
+export ECF_JOB=%ECF_JOB%
+export ECF_JOBOUT=%ECF_JOBOUT%
+export ecflow_ver=%ecflow_ver%
+
+if [ -d /apps/ops/prod ]; then # On WCOSS2
+  set +x
+  echo "Running 'module reset'"
+  module reset
+  set -x
+fi
+
+modelhome=%PACKAGEHOME:%
+eval "export HOME${model:?'model undefined'}=$modelhome"
+eval "versionfile=\$HOME${model}/versions/run.ver"
+if [ -f "$versionfile" ]; then . $versionfile ; fi
+modelver=$(echo ${modelhome} | perl -pe "s:.*?/${model}\.(v[\d\.a-z]+).*:\1:")
+eval "export ${model}_ver=$modelver"
+
+export envir=%ENVIR%
+export MACHINE_SITE=%MACHINE_SITE%
+export RUN_ENVIR=${RUN_ENVIR:-nco}
+export SENDECF=${SENDECF:-YES}
+export SENDCOM=${SENDCOM:-YES}
+if [ -n "%PDY:%" ]; then export PDY=${PDY:-%PDY:%}; fi
+if [ -n "%PARATEST:%" ]; then export PARATEST=${PARATEST:-%PARATEST:%}; fi
+export PARATEST=${PARATEST:-"NO"}
+if [ -n "%COMPATH:%" ]; then export COMPATH=${COMPATH:-%COMPATH:%}; fi
+if [ -n "%MAILTO:%" ]; then export MAILTO=${MAILTO:-%MAILTO:%}; fi
+if [ -n "%DBNLOG:%" ]; then export DBNLOG=${DBNLOG:-%DBNLOG:%}; fi
+if [ -n "%DATAFS:%" ]; then export DATAFS=${DATAFS:-%DATAFS:%}; fi
+export KEEPDATA=${KEEPDATA:-%KEEPDATA:NO%}
+export SENDDBN=${SENDDBN:-%SENDDBN:YES%}
+export SENDDBN_NTC=${SENDDBN_NTC:-%SENDDBN_NTC:YES%}
+
+if [ -d /apps/ops/prod ]; then # On WCOSS2
+  set +x
+  if [ $(whoami) == ops.para ]; then
+    module use -a /apps/ops/para/nco/modulefiles/core
+  fi
+  echo "Running module load ecflow/$ecflow_ver"
+  module load ecflow/$ecflow_ver
+  echo "ecflow module location: $(module display ecflow |& head -2 | tail -1 | sed 's/:$//')"
+  set -x
+  . ${ECF_ROOT}/versions/run.ver
+  set +x
+  module load prod_util/${prod_util_ver}
+  module load prod_envir/${prod_envir_ver}
+  echo "Listing modules from head.h:"
+  module list
+  set -x
+fi
+
+#if [[ " ops.prod ops.para " =~ " $(whoami) " ]]; then
+#  POST_OUT=${POST_OUT:-/lfs/h1/ops/%ENVIR%/tmp/posts/ecflow_post_in.${ECF_RID}}
+#  echo 'export ECF_NAME=${ECF_NAME}' > $POST_OUT
+#  echo 'export ECF_HOST=${ECF_HOST}' >> $POST_OUT
+#  echo 'export ECF_PORT=${ECF_PORT}' >> $POST_OUT
+#  echo 'export ECF_PASS=${ECF_PASS}' >> $POST_OUT
+#  echo 'export ECF_TRYNO=${ECF_TRYNO}' >> $POST_OUT
+#  echo 'export ECF_RID=${ECF_RID}' >> $POST_OUT
+#fi
+
+timeout 300 ecflow_client --init=${ECF_RID}

--- a/ush/prod_clone/include/tail.h
+++ b/ush/prod_clone/include/tail.h
@@ -1,0 +1,3 @@
+timeout 300 ecflow_client --complete  # Notify ecFlow of a normal end
+trap 0                    # Remove all traps
+exit 0                    # End the shell

--- a/ush/prod_clone/scripts/clean.py
+++ b/ush/prod_clone/scripts/clean.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import ecflow
+import datetime
+import os
+
+HOST = "ddecflow02"
+PORT = 32035
+RRFS_DIR = "/lfs/f2/t2o/ptmp/emc/para/stmp"
+
+# Mapping Parent Family to (Target Child Task, Cleanup Hour Range)
+cycles = {
+    "00": ("05z", "00 05"),
+    "06": ("11z", "06 11"),
+    "12": ("17z", "12 17"),
+    "18": ("23z", "18 23")
+}
+
+def run_cleanup(parent_cyc, hour_range):
+    """Executes the specific rm commands for the given cycle range"""
+    start, end = hour_range.split()
+    print(f"---> Running cleanup for cycle {parent_cyc} (Hours {start} to {end})...")
+    
+    # Constructing the bash command exactly as you provided
+    cleanup_cmd = f"""
+    cd {RRFS_DIR} && \
+    for cyc in $(seq -w {start} {end}); do \
+        rm -fr *_${{cyc}}.*.d* ; \
+        rm -fr *_${{cyc}}_v1.0_prod* ; \
+    done
+    """
+    # Execute the command
+    os.system(cleanup_cmd)
+
+def check_and_clean(ci, parent, child, hr_range):
+    node_path = f"/para/primary/{parent}/rrfs/v1.0/{child}"
+    
+    try:
+        defs = ci.get_defs()
+        node = defs.find_abs_node(node_path)
+        
+        if node is None:
+            return f"SKIP: {node_path} not found."
+
+        status = node.get_state()
+        is_complete = (status == ecflow.State.complete)
+        
+        # Parse ecFlow ISO time
+        state_change_str = node.get_state_change_time()
+        state_change_time = datetime.datetime.strptime(state_change_str, "%Y-%m-%dT%H:%M:%S")
+        
+        duration = datetime.datetime.now() - state_change_time
+        hours_old = duration.total_seconds() / 3600
+        
+        if is_complete and hours_old >= 6.0:
+            print(f"SUCCESS: {node_path} is {hours_old:.2f} hrs old.")
+            run_cleanup(parent, hr_range)
+            return f"DONE: Cleanup finished for {parent}z."
+        else:
+            return f"PENDING: {node_path} is {status} (Age: {hours_old:.2f} hrs). No cleanup."
+
+    except Exception as e:
+        return f"ERROR: {e}"
+
+# --- Main Execution ---
+try:
+    client = ecflow.Client(HOST, PORT)
+    client.sync_local()
+    
+    print(f"--- RRFS Cleanup Task ({datetime.datetime.now()}) ---")
+    for parent, (child, hr_range) in cycles.items():
+        result = check_and_clean(client, parent, child, hr_range)
+        print(result)
+
+except Exception as e:
+    print(f"Connection Error: {e}")

--- a/ush/prod_clone/scripts/complete.py
+++ b/ush/prod_clone/scripts/complete.py
@@ -1,0 +1,66 @@
+import ecflow
+import os
+
+# Connection details for WCOSS2
+HOST = "ddecflow02"
+PORT = 32035
+
+# List of major primary cycles to check
+MAJOR_CYCLES = ["00", "06", "12", "18"]
+
+def force_complete_major_cycles():
+    try:
+        ci = ecflow.Client(HOST, PORT)
+        ci.sync_local() # Pull latest status from server
+
+        server_defs = ci.get_defs()
+        if server_defs is None:
+            print("Error: Could not retrieve definitions from server.")
+            return
+
+        for cyc in MAJOR_CYCLES:
+            # Dynamically build path: e.g., /para/primary/00/rrfs/v1.0/00z/enkf/forecast
+            family_path = f"/para/primary/{cyc}/rrfs/v1.0/{cyc}z/enkf/forecast"
+            
+            print(f"\n--- Checking EnKF Members for {cyc}z ---")
+
+            all_finished = True
+            missing_count = 0
+
+            # 1. Check member range 1 to 30
+            for i in range(1, 31):
+                task_name = f"jrrfs_enkf_save_restart_mem{i:03d}_f2"
+                task_path = f"{family_path}/{task_name}"
+
+                node = server_defs.find_abs_node(task_path)
+
+                if node is None:
+                    all_finished = False
+                    missing_count += 1
+                    continue
+
+                if str(node.get_state()) != "complete":
+                    all_finished = False
+                    missing_count += 1
+                    # Optional: Print lagging members for debugging
+                    if missing_count <= 3:
+                        print(f"  > Member {i:03d} is {node.get_state()}")
+
+            # 2. If all 30 are done, force the parent family to complete
+            if all_finished:
+                parent_node = server_defs.find_abs_node(family_path)
+                
+                # Check if it actually needs forcing (not already green)
+                if parent_node and str(parent_node.get_state()) != "complete":
+                    print(f"Success: All 30 members (_f2) complete. Forcing {family_path}...")
+                    ci.force_state_recursive(family_path, ecflow.State.complete)
+                else:
+                    print(f"Status: {cyc}z is already complete or not found.")
+            else:
+                print(f"Action: {cyc}z has {missing_count} member(s) incomplete. No change.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    force_complete_major_cycles()

--- a/ush/prod_clone/scripts/complete_enkf_save.py
+++ b/ush/prod_clone/scripts/complete_enkf_save.py
@@ -1,0 +1,55 @@
+import ecflow
+import os
+
+# Updated connection details for WCOSS2
+HOST = "ddecflow02"
+PORT = 32035
+# Your specific suite path
+FAMILY_PATH = "/para/primary/00/rrfs/v1.0/00z/enkf/forecast"
+
+def force_complete_if_finished():
+    try:
+        ci = ecflow.Client(HOST, PORT)
+        ci.sync_local() # Pull latest status from server
+        
+        server_defs = ci.get_defs()
+        if server_defs is None:
+            print("Error: Could not retrieve definitions from server.")
+            return
+
+        # 1. Check member range 1 to 30
+        all_finished = True
+        missing_tasks = []
+        
+        for i in range(1, 31):
+            # Formats number as 001, 002, ... 030
+            task_name = f"jrrfs_enkf_save_restart_mem{i:03d}_f2"
+            task_path = f"{FAMILY_PATH}/{task_name}"
+            
+            node = server_defs.find_abs_node(task_path)
+            
+            if node is None:
+                print(f"Warning: Task not found: {task_path}")
+                all_finished = False
+                missing_tasks.append(task_name)
+                continue
+            
+            # Check if the individual task is actually 'complete'
+            if str(node.get_state()) != "complete":
+                all_finished = False
+                print(f"Member {i:03d} is still {node.get_state()}")
+
+        # 2. If all 30 are done, force the parent "forecast" family to complete
+        if all_finished:
+            print(f"Success: All 30 members are complete. Forcing {FAMILY_PATH} to complete...")
+            #ci.alter(FAMILY_PATH, "force", "complete")
+            ci.force_state_recursive(FAMILY_PATH, ecflow.State.complete)
+            print("Status updated in ecFlow.")
+        else:
+            print(f"Action: No change made. Some members are still running or aborted.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    force_complete_if_finished()

--- a/ush/prod_clone/scripts/complete_enkf_save_f1.py
+++ b/ush/prod_clone/scripts/complete_enkf_save_f1.py
@@ -1,0 +1,67 @@
+import ecflow
+import os
+
+# Server connection details
+HOST = "ddecflow02"
+PORT = 32035
+
+# Mapping: Primary Folder -> List of Cycles to check within that folder
+primary_to_cycles = {
+    "00": ["02z", "04z"],
+    "06": ["08z", "10z"],
+    "12": ["14z", "16z"],
+    "18": ["20z", "22z"]
+}
+
+def sync_enkf_forecasts():
+    try:
+        ci = ecflow.Client(HOST, PORT)
+        ci.sync_local()
+        server_defs = ci.get_defs()
+        
+        if server_defs is None:
+            print("Error: Could not retrieve definitions.")
+            return
+
+        # Loop through each Primary folder
+        for primary, cycles in primary_to_cycles.items():
+            # Loop through each specific Cycle in that Primary folder
+            for cyc in cycles:
+                family_path = f"/para/primary/{primary}/rrfs/v1.0/{cyc}/enkf/forecast"
+                
+                print(f"--- Checking {cyc} (Primary {primary}) ---")
+
+                all_members_finished = True
+                
+                # Check all 30 members for the _f1 task
+                for i in range(1, 31):
+                    task_name = f"jrrfs_enkf_save_restart_mem{i:03d}_f1"
+                    task_path = f"{family_path}/{task_name}"
+                    
+                    node = server_defs.find_abs_node(task_path)
+                    
+                    if node is None:
+                        all_members_finished = False
+                        continue
+
+                    if str(node.get_state()) != "complete":
+                        all_members_finished = False
+                        # Optional: break early if one is found incomplete to save time
+                        break 
+
+                # If all 30 members are done, force the forecast family to complete
+                if all_members_finished:
+                    parent_node = server_defs.find_abs_node(family_path)
+                    if parent_node and str(parent_node.get_state()) != "complete":
+                        print(f"  > All 30 members (_f1) COMPLETE. Forcing {family_path}...")
+                        ci.force_state_recursive(family_path, ecflow.State.complete)
+                    else:
+                        print(f"  > Status: Already complete or path not found.")
+                else:
+                    print(f"  > Status: Some members still pending.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    sync_enkf_forecasts()

--- a/ush/prod_clone/scripts/complete_enkf_save_f3.py
+++ b/ush/prod_clone/scripts/complete_enkf_save_f3.py
@@ -1,0 +1,66 @@
+import ecflow
+import os
+
+# Connection details for WCOSS2
+HOST = "ddecflow02"
+PORT = 32035
+
+# List of major primary cycles to check
+MAJOR_CYCLES = ["00", "06", "12", "18"]
+
+def force_complete_major_cycles():
+    try:
+        ci = ecflow.Client(HOST, PORT)
+        ci.sync_local() # Pull latest status from server
+
+        server_defs = ci.get_defs()
+        if server_defs is None:
+            print("Error: Could not retrieve definitions from server.")
+            return
+
+        for cyc in MAJOR_CYCLES:
+            # Dynamically build path: e.g., /para/primary/00/rrfs/v1.0/00z/enkf/forecast
+            family_path = f"/para/primary/{cyc}/rrfs/v1.0/{cyc}z/enkf/forecast"
+            
+            print(f"\n--- Checking EnKF Members for {cyc}z ---")
+
+            all_finished = True
+            missing_count = 0
+
+            # 1. Check member range 1 to 30
+            for i in range(1, 31):
+                task_name = f"jrrfs_enkf_save_restart_mem{i:03d}_f2"
+                task_path = f"{family_path}/{task_name}"
+
+                node = server_defs.find_abs_node(task_path)
+
+                if node is None:
+                    all_finished = False
+                    missing_count += 1
+                    continue
+
+                if str(node.get_state()) != "complete":
+                    all_finished = False
+                    missing_count += 1
+                    # Optional: Print lagging members for debugging
+                    if missing_count <= 3:
+                        print(f"  > Member {i:03d} is {node.get_state()}")
+
+            # 2. If all 30 are done, force the parent family to complete
+            if all_finished:
+                parent_node = server_defs.find_abs_node(family_path)
+                
+                # Check if it actually needs forcing (not already green)
+                if parent_node and str(parent_node.get_state()) != "complete":
+                    print(f"Success: All 30 members (_f2) complete. Forcing {family_path}...")
+                    ci.force_state_recursive(family_path, ecflow.State.complete)
+                else:
+                    print(f"Status: {cyc}z is already complete or not found.")
+            else:
+                print(f"Action: {cyc}z has {missing_count} member(s) incomplete. No change.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    force_complete_major_cycles()

--- a/ush/prod_clone/scripts/complete_fcst.py
+++ b/ush/prod_clone/scripts/complete_fcst.py
@@ -1,0 +1,67 @@
+import ecflow
+import os
+
+# Server connection details
+HOST = "ddecflow02"
+PORT = 32035
+
+# Mapping: Primary Folder -> List of Cycles to check within that folder
+primary_to_cycles = {
+    "00": ["02z", "04z"],
+    "06": ["08z", "10z"],
+    "12": ["14z", "16z"],
+    "18": ["20z", "22z"]
+}
+
+def sync_enkf_forecasts():
+    try:
+        ci = ecflow.Client(HOST, PORT)
+        ci.sync_local()
+        server_defs = ci.get_defs()
+        
+        if server_defs is None:
+            print("Error: Could not retrieve definitions.")
+            return
+
+        # Loop through each Primary folder
+        for primary, cycles in primary_to_cycles.items():
+            # Loop through each specific Cycle in that Primary folder
+            for cyc in cycles:
+                family_path = f"/para/primary/{primary}/rrfs/v1.0/{cyc}/enkf/forecast"
+                
+                print(f"--- Checking {cyc} (Primary {primary}) ---")
+
+                all_members_finished = True
+                
+                # Check all 30 members for the _f1 task
+                for i in range(1, 31):
+                    task_name = f"jrrfs_enkf_save_restart_mem{i:03d}_f1"
+                    task_path = f"{family_path}/{task_name}"
+                    
+                    node = server_defs.find_abs_node(task_path)
+                    
+                    if node is None:
+                        all_members_finished = False
+                        continue
+
+                    if str(node.get_state()) != "complete":
+                        all_members_finished = False
+                        # Optional: break early if one is found incomplete to save time
+                        break 
+
+                # If all 30 members are done, force the forecast family to complete
+                if all_members_finished:
+                    parent_node = server_defs.find_abs_node(family_path)
+                    if parent_node and str(parent_node.get_state()) != "complete":
+                        print(f"  > All 30 members (_f1) COMPLETE. Forcing {family_path}...")
+                        ci.force_state_recursive(family_path, ecflow.State.complete)
+                    else:
+                        print(f"  > Status: Already complete or path not found.")
+                else:
+                    print(f"  > Status: Some members still pending.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    sync_enkf_forecasts()

--- a/ush/prod_clone/scripts/complete_post.py
+++ b/ush/prod_clone/scripts/complete_post.py
@@ -1,0 +1,67 @@
+import ecflow
+import os
+
+# Server connection details
+HOST = "ddecflow02"
+PORT = 32035
+
+# Configuration
+PRIMARY_START_HOURS = [0, 6, 12, 18]
+EXCLUDED_CYCLES = ["00z", "06z", "12z", "18z"]
+
+def sync_rrfs_suites():
+    try:
+        # Initialize ecFlow Client
+        ci = ecflow.Client(HOST, PORT)
+        ci.sync_local()
+        server_defs = ci.get_defs()
+        
+        if server_defs is None:
+            print("Error: Could not retrieve definitions from server.")
+            return
+
+        # Outer Loop: Primary Folders (00, 06, 12, 18)
+        for p in PRIMARY_START_HOURS:
+            primary_num = f"{p:02d}"
+            
+            # Inner Loop: Cycles (P to P+5)
+            # Example: If p=0, c goes 0, 1, 2, 3, 4, 5
+            for c in range(p, p + 6):
+                cycle_name = f"{c:02d}z"
+                
+                # 1. Skip the big 6-hourly cycles as requested
+                if cycle_name in EXCLUDED_CYCLES:
+                    continue
+                
+                # 2. Build the paths
+                base_path = f"/para/primary/{primary_num}/rrfs/v1.0/{cycle_name}/det"
+                prdgen_task = f"{base_path}/prdgen/jrrfs_det_prdgen_f006_00_00"
+                prdgen_fam  = f"{base_path}/prdgen"
+                post_fam    = f"{base_path}/post"
+
+                # 3. Check the f006 task status
+                node = server_defs.find_abs_node(prdgen_task)
+                
+                if node is None:
+                    # Skip if the cycle isn't loaded in the server
+                    continue
+
+                if str(node.get_state()) == "complete":
+                    print(f"[{cycle_name}] f006 is COMPLETE. Syncing families...")
+                    
+                    # 4. Recursive force for both families
+                    for fam_path in [prdgen_fam, post_fam]:
+                        fam_node = server_defs.find_abs_node(fam_path)
+                        # Only force if not already complete
+                        if fam_node and str(fam_node.get_state()) != "complete":
+                            ci.force_state_recursive(fam_path, ecflow.State.complete)
+                            print(f"  > {fam_path} forced to complete.")
+                else:
+                    # Optional: print status of lagging cycles
+                    print(f"[{cycle_name}] f006 is {node.get_state()}. Waiting...")
+
+    except Exception as e:
+        print(f"An execution error occurred: {e}")
+
+if __name__ == "__main__":
+    sync_rrfs_suites()

--- a/ush/prod_clone/scripts/exupdateprodclonestatuses.py
+++ b/ush/prod_clone/scripts/exupdateprodclonestatuses.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+debug = 0
+
+import os, sys
+import ecflow
+
+PRODCLONEPREFIX = os.getenv("PRODCLONEPREFIX")
+assert PRODCLONEPREFIX, "$PRODCLONEPREFIX not defined!"
+
+assert os.getenv("ECF_PORT")=="32035", "ECF_PORT is not 31419. Quitting!"
+assert os.getenv("ECF_HOST") is not None, "ECF_HOST is not set. Quitting!"
+assert len(sys.argv)==3, "%s takes two and only two arguments. Quitting!"%os.path.basename(sys.argv[0])
+
+ci = ecflow.Client()
+if debug == 1:
+  print("ecf client host, port: %s, %s"%(ci.get_host(),ci.get_port()))
+
+# Get prod checkpoint files"
+prod = ecflow.Defs(sys.argv[1])
+# Get para checkpoint file
+para = ecflow.Defs(sys.argv[2])
+prodtasks = prod.get_all_tasks()
+paratasks = para.get_all_tasks()
+parapaths_all = [t.get_abs_node_path() for t in paratasks]
+parapaths = [p for p in parapaths_all if p.startswith(PRODCLONEPREFIX)]
+
+if debug: print("Parapaths: %s"%", ".join(parapaths))
+
+# Loop over prod tasks, see if it appears in prod_clone suite on para server, and update if needed
+for prodtask in prodtasks:
+  ## Check whether job exists:
+  prodpath = prodtask.get_abs_node_path()
+  #prodclonepath = (PRODCLONEPREFIX+prodpath).replace("//","/")
+  #prodclonepath = (PRODCLONEPREFIX+prodpath).replace("/prod_clone/prod/","/prod_clone/")
+  prodclonepath = prodpath.replace("/prod/","/prod_clone/")
+  if prodclonepath not in parapaths:
+    if debug == 2: print("Skipping %s"%prodclonepath)
+    continue # We only want to update the statuses of jobs that are under the /prod_cloned suite on the para server
+  ## Force status of job under para if the statuses don't match:
+  paratask = para.find_abs_node(prodclonepath)
+  if paratask.get_state() != prodtask.get_state():
+    if debug: print("Updating status for %s"%prodclonepath)
+    # The following lines are the only direct communication with any server in this job:
+    ci.force_state(prodclonepath,prodtask.get_state()) # FORCE PROD_CLONE JOB STATE
+  # FORCE PROD_CLONE JOB EVENTS:
+  prodevents_dict = {}
+  for prodevent in prodtask.events: prodevents_dict[prodevent.name()] = prodevent.value()
+  for paraevent in paratask.events:
+    paraeventname = paraevent.name()
+    if paraeventname in prodevents_dict.keys():
+      prodeventvalue = prodevents_dict[paraeventname]
+      if prodeventvalue != paraevent.value():
+        if prodeventvalue: ci.alter(prodclonepath,"change","event",paraeventname,"set")
+        else: ci.alter(prodclonepath,"change","event",paraeventname,"clear")

--- a/ush/prod_clone/versions/run.ver
+++ b/ush/prod_clone/versions/run.ver
@@ -1,0 +1,3 @@
+#export ecflow_ver=5.6.0.1
+export intel_ver=19.1.3.304
+export python_ver=3.8.6


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Added the prod_clone utility, originally developed by @WeiWei-NCO.
- Modified the utility to support rrfs parallel experiments.
- Added the initial version of prod_clone to the rrfs-dev branch, allowing developers to use it to test FV3-JEDI with the ecFlow version of rrfs-workflow.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in #9999

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

