### PR TITLE
Smoke cycling fix in chem_prep_smoke

### DIFF
--- a/scripts/exrrfs_prep_chem.sh
+++ b/scripts/exrrfs_prep_chem.sh
@@ -57,7 +57,7 @@ current_hh="${HH}"
 #
 #prev_hh=$(date -d "$current_hh -24 hour" +"%H")
 previous_day=$(date '+%C%y%m%d' -d "$current_day-1 days")
-previous_day="${previous_day} ${HH}"
+#previous_day="${previous_day} ${HH}"
 #
 if [[ ${DOW} -le 5 ]]; then
    DOW_STRING=weekdy

--- a/ush/chem_prep_smoke.sh
+++ b/ush/chem_prep_smoke.sh
@@ -24,37 +24,40 @@ mv ./*.log ./*.ESMF_LogFile logs || echo "could not move logs"
 #
 # Loop through the hours and link the files so they have the correct filename and variable names 
 # TODO - Update variable names via outside script or within regrid.py -- mapping table?
-for ihour in $(seq 0 "${my_fcst_length}");
-do
-  if (( ihour > 24 )); then
-    ihour2=$((ihour-24))
+for ihour in $(seq 0 "$((my_fcst_length))");
+do 
+  current_fcst_time="${current_day} ${HH} + ${ihour} hours"
+  # For persistence 
+  if (( ihour > 0 && ihour % 24 == 0 )); then
+     offset=24
   else
-    ihour2=${ihour}
+     offset=$((ihour % 24))
   fi
-  if [[ "${EBB_DCYCLE}" == -1 ]]; then
-     # Peristence emissions, only 24 forecasts are possible
-     # Beyond that we need to repeat the emissions
-     timestr1=$(date +%Y%m%d%H -d "${previous_day} + ${ihour2} hours")
-  else
+  
+  if [[ "${EBB_DCYCLE}" == 1 ]]; then
      # Either NOWcast (1 emission file per current forecast hour) or
      # Forecasted emissions requiring the previous 24 hours
-     timestr1=$(date +%Y%m%d%H -d "${current_day} + ${ihour} hours")
+     timestr1=$(date +%Y%m%d%H -d "${current_fcst_time}")
+  else
+     # Peristence emissions, only 24 forecasts are possible
+     # Beyond that we need to repeat the emissions
+     timestr1=$(date +%Y%m%d%H -d "${previous_day} ${HH} + ${offset} hours")
   fi
 
-  timestr2=$(date +%Y-%m-%d_%H -d "${current_day} + ${ihour} hours")
-  timestr3=$(date +%Y-%m-%d_%H:00:00 -d "${current_day} + ${ihour} hours")
+  timestr2=$(date +%Y-%m-%d_%H -d "${current_fcst_time}")
+  timestr3=$(date +%Y-%m-%d_%H:00:00 -d "${current_fcst_time}")
   #
   EMISFILE="${UMBRELLA_PREP_CHEM_DATA}/smoke.init.retro.${timestr2}.00.00.nc"
   EMISFILE2="${RAVE_OUTPUTDIR}/${MESH_NAME}-${FIRE_DATASET}-${timestr1}.nc"
   if [[ -r "${EMISFILE2}" ]]; then
-    ncrename -v PM25,e_bb_in_smoke_fine "${EMISFILE2}"
-    ncrename -v FRP_MEAN,frp_in -v FRE,fre_in "${EMISFILE2}"
-    ncrename -v SO2,e_bb_in_so2 "${EMISFILE2}"
-    ncrename -v CH4,e_bb_in_ch4 "${EMISFILE2}"
-    ncrename -v PM10,e_bb_in_smoke_coarse "${EMISFILE2}"
-    ncrename -v CO,e_bb_in_co "${EMISFILE2}"
-    ncrename -v NH3,e_bb_in_nh3 "${EMISFILE2}"
-    ncrename -v NOx,e_bb_in_nox "${EMISFILE2}"
+    ncrename -v .PM25,e_bb_in_smoke_fine "${EMISFILE2}"
+    ncrename -v .FRP_MEAN,frp_in -v FRE,fre_in "${EMISFILE2}"
+    ncrename -v .SO2,e_bb_in_so2 "${EMISFILE2}"
+    ncrename -v .CH4,e_bb_in_ch4 "${EMISFILE2}"
+    ncrename -v .PM10,e_bb_in_smoke_coarse "${EMISFILE2}"
+    ncrename -v .CO,e_bb_in_co "${EMISFILE2}"
+    ncrename -v .NH3,e_bb_in_nh3 "${EMISFILE2}"
+    ncrename -v .NOx,e_bb_in_nox "${EMISFILE2}"
     ln -sf "${EMISFILE2}" "${EMISFILE}"
     ncap2 -O -s 'frp_in=frp_in.ttl($nkwildfire)' -s 'fre_in=fre_in.ttl($nkwildfire)' "${EMISFILE}" "${EMISFILE}"
   else
@@ -76,13 +79,13 @@ done
 #
 echo "Concatenating hourly files for use in forecast mode"
 # Concatenate for ebb2
-ncrcat -v frp_in,fre_in,e_bb_in_so2,e_bb_in_ch4,e_bb_in_smoke_coarse,e_bb_in_nh3,e_bb_in_co,e_bb_in_nox "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.retro.*.00.00.nc "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
+ncrcat -v '^(frp_in|fre_in|e_bb_in_so2|e_bb_in_ch4|e_bb_in_smoke_coarse|e_bb_in_nh3|e_bb_in_co|e_bb_in_nox)$' "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.retro.*.00.00.nc "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
 #
 # Calculate previous 24 hour average HWP
 #
 # TODO - presently hwp and totprcp have constant values
 ncap2 -O -s 'hwp_prev24=0.0*frp_in+30.' -s 'totprcp_prev24=0.0*frp_in+0.1' "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
-ncrename -v frp_in,frp_prev24 -v fre_in,fre_prev24 "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
+ncrename -v .frp_in,frp_prev24 -v .fre_in,fre_prev24 "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
 #
 # Emissions to be calculated inside of model
 if [[ ! -r "${ECO_OUTPUTDIR}/ecoregions_${MESH_NAME}_mpas.nc" ]] && [[ -r "${ECO_INPUTDIR}/veg_map.nc" ]]; then
@@ -112,7 +115,7 @@ if (( n_fmc > 0 )); then
   # Average for ebb2
   ncrcat "${FMC_OUTPUTDIR}"/fmc*"${MESH_NAME}"*nc "${UMBRELLA_PREP_CHEM_DATA}"/fmc.init.nc
   ncks -A -v 10h_dead_fuel_moisture_content "${UMBRELLA_PREP_CHEM_DATA}"/fmc.init.nc "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
-  ncrename -v 10h_dead_fuel_moisture_content,fmc_prev24 "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
+  ncrename -v .10h_dead_fuel_moisture_content,fmc_prev24 "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc
 else
   echo "No soil moisture information available, using static value of 0.2"
   ncap2 -O -s 'fmc_prev24=0*frp_prev24+0.2' "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc "${UMBRELLA_PREP_CHEM_DATA}"/smoke.init.nc


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Modified smoke cycling for non-00z cycles
- Modified ncrcat and ncrename to not error out when variables are missing from the smoke pre-processed files 

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue 4 mentioned in #1649 

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

