### PR TITLE
set MPASOUT_TIMELEVELS="0 1" in conus3km exp files

### DIFF
--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -50,7 +50,7 @@ for i in {0..23..12}; do arr[$i]="12"; done # 12hr fcst every 12hrs
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export DIAG_INTERVAL=1
-#export MPASOUT_TIMELEVELS="0 1"
+export MPASOUT_TIMELEVELS="0 1"
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
 
 export IC_OFFSET=3

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -43,7 +43,7 @@ for i in {0..23};    do arr[$i]="01"; done # 3hr fcst
 export FCST_LEN_HRS_CYCLES="${arr[*]}"
 export HISTORY_INTERVAL=1
 export DIAG_INTERVAL=1
-#export MPASOUT_TIMELEVELS="0 1"
+export MPASOUT_TIMELEVELS="0 1"
 export POST_GROUP_TOT_NUM=2 # num of groups, the final group absorbs leftovers, the first group contains the extra f000h file
 export DO_POST=false
 


### PR DESCRIPTION
Just changing one line of the 3 km experiment xml templates

## DESCRIPTION OF CHANGES: 
setting MPASOUT_TIMELEVELS so build does not fail

## TESTS CONDUCTED: 
Tried building the ensemble workflow while this line was commented out; it failed
Then tried building the ensemble workflow while this line was uncommented; it succeeded

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules
  - [ ] GAEA

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->
- Fixes the issue(s) mentioned in a comment on Guoqing's commit

## CONTRIBUTORS (optional): 
@guoqing-noaa 

