### PR TITLE
Add checks to nonvar cld ana obs processing tasks

### DIFF
--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -84,7 +84,7 @@ else
 if [[ ${STRICT_CHECK} == 1 ]]; then
   echo "ERROR: Missing satellite cloud-top observations"
   exit 1
-else	
+else
   echo "WARNING: Missing satellite cloud-top observations"
   echo "Cloud-top observations will NOT be processed for the nonvar cloud analysis"
 fi
@@ -135,7 +135,7 @@ else
 if [[ ${STRICT_CHECK} == 1 ]]; then
   echo "ERROR: Missing lightning observations"
   exit 1
-else	
+else
   echo "WARNING: Missing lightning observations"
   echo "Lightning observations will NOT be processed for the nonvar cloud analysis"
 fi
@@ -184,7 +184,7 @@ else
 if [[ ${STRICT_CHECK} == 1 ]]; then
   echo "ERROR: Missing METAR observations"
   exit 1
-else	
+else
   echo "WARNING: Missing METAR observations"
   echo "METAR observations will NOT be processed for the nonvar cloud analysis"
 fi

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -81,9 +81,13 @@ ${cpreq} NASALaRC_cloud4mpas.bin "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud
 
 else
 
-echo "WARNING: Missing satellite cloud-top observations"
-echo "Cloud-top observations will NOT be processed for the nonvar cloud analysis"
-echo "File: ${lgycld_bufr}"
+if [[ ${STRICT_CHECK} -eq 1 ]]; then
+  echo "ERROR: Missing satellite cloud-top observations"
+  exit 1
+else	
+  echo "WARNING: Missing satellite cloud-top observations"
+  echo "Cloud-top observations will NOT be processed for the nonvar cloud analysis"
+fi
 
 fi
 
@@ -128,9 +132,13 @@ ${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.da
 
 else
 
-echo "WARNING: Missing lightning observations"
-echo "Lightning observations will NOT be processed for the nonvar cloud analysis"
-echo "File: ${lghtng_bufr}"
+if [[ ${STRICT_CHECK} -eq 1 ]]; then
+  echo "ERROR: Missing lightning observations"
+  exit 1
+else	
+  echo "WARNING: Missing lightning observations"
+  echo "Lightning observations will NOT be processed for the nonvar cloud analysis"
+fi
 
 fi
 
@@ -173,9 +181,13 @@ ${cpreq} mpas_metarcloud.bin "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bi
 
 else
 
-echo "WARNING: Missing METAR observations"
-echo "METAR observations will NOT be processed for the nonvar cloud analysis"
-echo "File: ${metar_bufr}"
+if [[ ${STRICT_CHECK} -eq 1 ]]; then
+  echo "ERROR: Missing METAR observations"
+  exit 1
+else	
+  echo "WARNING: Missing METAR observations"
+  echo "METAR observations will NOT be processed for the nonvar cloud analysis"
+fi
 
 fi
 

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -56,17 +56,17 @@ if [[ -s ${lgycld_bufr} ]]; then
   fi
 
   cat << EOF > namelist.nasalarc
-   &setup
-    analysis_time = ${CDATE},
-    bufrfile='NASALaRCCloudInGSI_bufr.bufr',
-    npts_rad=${NONVAR_LARC_NPTS},
-    ioption=2,
-    userDX=${NONVAR_USER_DX},
-    proj_name="${NONVAR_PROJ_NAME}",
-    satidgoeswest=${satidgoeswest},
-    satidgoeseast=${satidgoeseast},
-    debug=0,
-   /
+ &setup
+  analysis_time = ${CDATE},
+  bufrfile='NASALaRCCloudInGSI_bufr.bufr',
+  npts_rad=${NONVAR_LARC_NPTS},
+  ioption=2,
+  userDX=${NONVAR_USER_DX},
+  proj_name="${NONVAR_PROJ_NAME}",
+  satidgoeswest=${satidgoeswest},
+  satidgoeseast=${satidgoeseast},
+  debug=0,
+ /
 EOF
 
   module list
@@ -108,16 +108,16 @@ if [[ -s ${lghtng_bufr} ]]; then
   ${cpreq} ${lghtng_bufr} lghtngbufr
 
   cat << EOF > namelist.lightning
-   &setup
-    analysis_time = ${CDATE},
-    minute=00,
-    trange_start=-10,
-    trange_end=10,
-    obs_type = "bufr",
-    proj_name = '${NONVAR_PROJ_NAME}',
-    search_rad = ${NONVAR_SEARCH_RAD},
-    debug=0
-   /
+ &setup
+  analysis_time = ${CDATE},
+  minute=00,
+  trange_start=-10,
+  trange_end=10,
+  obs_type = "bufr",
+  proj_name = '${NONVAR_PROJ_NAME}',
+  search_rad = ${NONVAR_SEARCH_RAD},
+  debug=0
+ /
 EOF
 
   module list
@@ -159,14 +159,14 @@ if [[ -s ${metar_bufr} ]]; then
   ${cpreq} ${metar_bufr} prepbufr
 
   cat << EOF > namelist.metarcld
-   &setup
-    analysis_time = ${CDATE},
-    prepbufrfile='prepbufr',
-    twindin=0.5,
-    metar_impact_radius=${NONVAR_METAR_IMPACT},
-    proj_name="${NONVAR_PROJ_NAME}",
-    debug=0,
-   /
+ &setup
+  analysis_time = ${CDATE},
+  prepbufrfile='prepbufr',
+  twindin=0.5,
+  metar_impact_radius=${NONVAR_METAR_IMPACT},
+  proj_name="${NONVAR_PROJ_NAME}",
+  debug=0,
+ /
 EOF
 
   module list

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -29,7 +29,11 @@ ${cpreq} "${meshgriddir}"/"${MESH_NAME}".grid.nc mesh.nc
 #-----------------------------------------------------------------------
 #
 
-${cpreq} "${OBSPATH}/${CDATE}.rap.t${cyc}z.lgycld.tm00.bufr_d" lgycld.bufr_d
+lgycld_bufr="${OBSPATH}/${CDATE}.rap.t${cyc}z.lgycld.tm00.bufr_d"
+
+if [[ -s ${lgycld_bufr} ]]; then
+
+${cpreq} ${lgycld_bufr} lgycld.bufr_d
 
 # Determine appropriate GOES IDs
 if (( CDATE > 2023010419 )); then
@@ -75,6 +79,14 @@ err_chk
 
 ${cpreq} NASALaRC_cloud4mpas.bin "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud4mpas.bin"
 
+else
+
+echo "WARNING: Missing satellite cloud-top observations"
+echo "Cloud-top observations will NOT be processed for the nonvar cloud analysis"
+echo "File: ${lgycld_bufr}"
+
+fi
+
 #
 #-----------------------------------------------------------------------
 #
@@ -85,7 +97,11 @@ ${cpreq} NASALaRC_cloud4mpas.bin "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud
 #-----------------------------------------------------------------------
 #
 
-${cpreq} "${OBSPATH}/${CDATE}.rap.t${cyc}z.lghtng.tm00.bufr_d" lghtngbufr
+lghtng_bufr="${OBSPATH}/${CDATE}.rap.t${cyc}z.lghtng.tm00.bufr_d"
+
+if [[ -s ${lghtng_bufr} ]]; then
+
+${cpreq} ${lghtng_bufr} lghtngbufr
 
 cat << EOF > namelist.lightning
  &setup
@@ -110,6 +126,14 @@ err_chk
 
 ${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.dat"
 
+else
+
+echo "WARNING: Missing lightning observations"
+echo "Lightning observations will NOT be processed for the nonvar cloud analysis"
+echo "File: ${lghtng_bufr}"
+
+fi
+
 #
 #-----------------------------------------------------------------------
 #
@@ -120,7 +144,11 @@ ${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.da
 #-----------------------------------------------------------------------
 #
 
-${cpreq} "${OBSPATH}/${CDATE}.rap.t${cyc}z.prepbufr.tm00" prepbufr
+metar_bufr="${OBSPATH}/${CDATE}.rap.t${cyc}z.prepbufr.tm00"
+
+if [[ -s ${metar_bufr} ]]; then
+
+${cpreq} ${metar_bufr} prepbufr
 
 cat << EOF > namelist.metarcld
  &setup
@@ -142,5 +170,13 @@ export err=$?
 err_chk
 
 ${cpreq} mpas_metarcloud.bin "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bin"
+
+else
+
+echo "WARNING: Missing METAR observations"
+echo "METAR observations will NOT be processed for the nonvar cloud analysis"
+echo "File: ${metar_bufr}"
+
+fi
 
 exit 0

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -105,40 +105,40 @@ lghtng_bufr="${OBSPATH}/${CDATE}.rap.t${cyc}z.lghtng.tm00.bufr_d"
 
 if [[ -s ${lghtng_bufr} ]]; then
 
-${cpreq} ${lghtng_bufr} lghtngbufr
+  ${cpreq} ${lghtng_bufr} lghtngbufr
 
-cat << EOF > namelist.lightning
- &setup
-  analysis_time = ${CDATE},
-  minute=00,
-  trange_start=-10,
-  trange_end=10,
-  obs_type = "bufr",
-  proj_name = '${NONVAR_PROJ_NAME}',
-  search_rad = ${NONVAR_SEARCH_RAD},
-  debug=0
- /
+  cat << EOF > namelist.lightning
+   &setup
+    analysis_time = ${CDATE},
+    minute=00,
+    trange_start=-10,
+    trange_end=10,
+    obs_type = "bufr",
+    proj_name = '${NONVAR_PROJ_NAME}',
+    search_rad = ${NONVAR_SEARCH_RAD},
+    debug=0
+   /
 EOF
 
-module list
-export pgm="process_Lightning.exe"
-${cpreq} "${EXECrrfs}/${pgm}" .
-source prep_step
-${MPI_RUN_CMD} ./${pgm}
-export err=$?
-err_chk
+  module list
+  export pgm="process_Lightning.exe"
+  ${cpreq} "${EXECrrfs}/${pgm}" .
+  source prep_step
+  ${MPI_RUN_CMD} ./${pgm}
+  export err=$?
+  err_chk
 
-${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.dat"
+  ${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.dat"
 
 else
 
-if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
-  echo "ERROR: Missing lightning observations"
-  exit 1
-else
-  echo "WARNING: Missing lightning observations"
-  echo "Lightning observations will NOT be processed for the nonvar cloud analysis"
-fi
+  if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
+    echo "ERROR: Missing lightning observations"
+    exit 1
+  else
+    echo "WARNING: Missing lightning observations"
+    echo "Lightning observations will NOT be processed for the nonvar cloud analysis"
+  fi
 
 fi
 
@@ -156,38 +156,38 @@ metar_bufr="${OBSPATH}/${CDATE}.rap.t${cyc}z.prepbufr.tm00"
 
 if [[ -s ${metar_bufr} ]]; then
 
-${cpreq} ${metar_bufr} prepbufr
+  ${cpreq} ${metar_bufr} prepbufr
 
-cat << EOF > namelist.metarcld
- &setup
-  analysis_time = ${CDATE},
-  prepbufrfile='prepbufr',
-  twindin=0.5,
-  metar_impact_radius=${NONVAR_METAR_IMPACT},
-  proj_name="${NONVAR_PROJ_NAME}",
-  debug=0,
- /
+  cat << EOF > namelist.metarcld
+   &setup
+    analysis_time = ${CDATE},
+    prepbufrfile='prepbufr',
+    twindin=0.5,
+    metar_impact_radius=${NONVAR_METAR_IMPACT},
+    proj_name="${NONVAR_PROJ_NAME}",
+    debug=0,
+   /
 EOF
 
-module list
-export pgm="process_metarcld.exe"
-${cpreq} "${EXECrrfs}/${pgm}" .
-source prep_step
-${MPI_RUN_CMD} ./${pgm}
-export err=$?
-err_chk
+  module list
+  export pgm="process_metarcld.exe"
+  ${cpreq} "${EXECrrfs}/${pgm}" .
+  source prep_step
+  ${MPI_RUN_CMD} ./${pgm}
+  export err=$?
+  err_chk
 
-${cpreq} mpas_metarcloud.bin "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bin"
+  ${cpreq} mpas_metarcloud.bin "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bin"
 
 else
 
-if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
-  echo "ERROR: Missing METAR observations"
-  exit 1
-else
-  echo "WARNING: Missing METAR observations"
-  echo "METAR observations will NOT be processed for the nonvar cloud analysis"
-fi
+  if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
+    echo "ERROR: Missing METAR observations"
+    exit 1
+  else
+    echo "WARNING: Missing METAR observations"
+    echo "METAR observations will NOT be processed for the nonvar cloud analysis"
+  fi
 
 fi
 

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -33,61 +33,61 @@ lgycld_bufr="${OBSPATH}/${CDATE}.rap.t${cyc}z.lgycld.tm00.bufr_d"
 
 if [[ -s ${lgycld_bufr} ]]; then
 
-${cpreq} ${lgycld_bufr} lgycld.bufr_d
+  ${cpreq} ${lgycld_bufr} lgycld.bufr_d
 
-# Determine appropriate GOES IDs
-if (( CDATE > 2023010419 )); then
-  satidgoeswest=272
-else
-  satidgoeswest=271
-fi
+  # Determine appropriate GOES IDs
+  if (( CDATE > 2023010419 )); then
+    satidgoeswest=272
+  else
+    satidgoeswest=271
+  fi
 
-if (( CDATE > 2025040716 )); then
-  satidgoeseast=273
-else
-  satidgoeseast=270
-fi
+  if (( CDATE > 2025040716 )); then
+    satidgoeseast=273
+  else
+    satidgoeseast=270
+  fi
 
-if (( CDATE < 2021010118 )); then
-  echo "ERROR: This is an old retro. Please check whether the GOES IDs used by" 
-  echo "the nonvariational cloud analysis (larccld.fd) are appropriate for" 
-  echo "this time period"
-  exit 1
-fi
+  if (( CDATE < 2021010118 )); then
+    echo "ERROR: This is an old retro. Please check whether the GOES IDs used by" 
+    echo "the nonvariational cloud analysis (larccld.fd) are appropriate for" 
+    echo "this time period"
+    exit 1
+  fi
 
-cat << EOF > namelist.nasalarc
- &setup
-  analysis_time = ${CDATE},
-  bufrfile='NASALaRCCloudInGSI_bufr.bufr',
-  npts_rad=${NONVAR_LARC_NPTS},
-  ioption=2,
-  userDX=${NONVAR_USER_DX},
-  proj_name="${NONVAR_PROJ_NAME}",
-  satidgoeswest=${satidgoeswest},
-  satidgoeseast=${satidgoeseast},
-  debug=0,
- /
+  cat << EOF > namelist.nasalarc
+   &setup
+    analysis_time = ${CDATE},
+    bufrfile='NASALaRCCloudInGSI_bufr.bufr',
+    npts_rad=${NONVAR_LARC_NPTS},
+    ioption=2,
+    userDX=${NONVAR_USER_DX},
+    proj_name="${NONVAR_PROJ_NAME}",
+    satidgoeswest=${satidgoeswest},
+    satidgoeseast=${satidgoeseast},
+    debug=0,
+   /
 EOF
 
-module list
-export pgm="process_larccld.exe"
-${cpreq} "${EXECrrfs}/${pgm}" .
-source prep_step
-${MPI_RUN_CMD} ./${pgm}
-export err=$?
-err_chk
+  module list
+  export pgm="process_larccld.exe"
+  ${cpreq} "${EXECrrfs}/${pgm}" .
+  source prep_step
+  ${MPI_RUN_CMD} ./${pgm}
+  export err=$?
+  err_chk
 
-${cpreq} NASALaRC_cloud4mpas.bin "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud4mpas.bin"
+  ${cpreq} NASALaRC_cloud4mpas.bin "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud4mpas.bin"
 
 else
 
-if [[ ${STRICT_CHECK} == 1 ]]; then
-  echo "ERROR: Missing satellite cloud-top observations"
-  exit 1
-else
-  echo "WARNING: Missing satellite cloud-top observations"
-  echo "Cloud-top observations will NOT be processed for the nonvar cloud analysis"
-fi
+  if [[ ${STRICT_CHECK} == 1 ]]; then
+    echo "ERROR: Missing satellite cloud-top observations"
+    exit 1
+  else
+    echo "WARNING: Missing satellite cloud-top observations"
+    echo "Cloud-top observations will NOT be processed for the nonvar cloud analysis"
+  fi
 
 fi
 

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -81,7 +81,7 @@ EOF
 
 else
 
-  if [[ ${STRICT_CHECK} == 1 ]]; then
+  if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
     echo "ERROR: Missing satellite cloud-top observations"
     exit 1
   else
@@ -132,7 +132,7 @@ ${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.da
 
 else
 
-if [[ ${STRICT_CHECK} == 1 ]]; then
+if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
   echo "ERROR: Missing lightning observations"
   exit 1
 else
@@ -181,7 +181,7 @@ ${cpreq} mpas_metarcloud.bin "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bi
 
 else
 
-if [[ ${STRICT_CHECK} == 1 ]]; then
+if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
   echo "ERROR: Missing METAR observations"
   exit 1
 else

--- a/scripts/exrrfs_nonvar_bufrobs.sh
+++ b/scripts/exrrfs_nonvar_bufrobs.sh
@@ -81,7 +81,7 @@ ${cpreq} NASALaRC_cloud4mpas.bin "${COMOUT}/nonvar_bufrobs/${WGF}/NASALaRC_cloud
 
 else
 
-if [[ ${STRICT_CHECK} -eq 1 ]]; then
+if [[ ${STRICT_CHECK} == 1 ]]; then
   echo "ERROR: Missing satellite cloud-top observations"
   exit 1
 else	
@@ -132,7 +132,7 @@ ${cpreq} LightningInMPAS.dat "${COMOUT}/nonvar_bufrobs/${WGF}/LightningInMPAS.da
 
 else
 
-if [[ ${STRICT_CHECK} -eq 1 ]]; then
+if [[ ${STRICT_CHECK} == 1 ]]; then
   echo "ERROR: Missing lightning observations"
   exit 1
 else	
@@ -181,7 +181,7 @@ ${cpreq} mpas_metarcloud.bin "${COMOUT}/nonvar_bufrobs/${WGF}/mpas_metarcloud.bi
 
 else
 
-if [[ ${STRICT_CHECK} -eq 1 ]]; then
+if [[ ${STRICT_CHECK} == 1 ]]; then
   echo "ERROR: Missing METAR observations"
   exit 1
 else	

--- a/scripts/exrrfs_nonvar_reflobs.sh
+++ b/scripts/exrrfs_nonvar_reflobs.sh
@@ -101,7 +101,7 @@ if [[ -s filelist_mrms ]]; then
   echo "Using radar data from: $(head -1 filelist_mrms | cut -c10-15)"
   echo "NSSL grib2 file levels = ${numgrib2}"
 else
-  if [[ ${STRICT_CHECK} -eq 1 ]]; then
+  if [[ ${STRICT_CHECK} == 1 ]]; then
     echo "ERROR: Not enough radar reflectivity files were found"
     err_exit
   else

--- a/scripts/exrrfs_nonvar_reflobs.sh
+++ b/scripts/exrrfs_nonvar_reflobs.sh
@@ -102,7 +102,7 @@ if [[ -s filelist_mrms ]]; then
   echo "NSSL grib2 file levels = ${numgrib2}"
 else
   if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
-    echo "ERROR: Not enough radar reflectivity files were found"
+    echo "FATAL ERROR: Not enough radar reflectivity files were found"
     err_exit
   else
     echo "WARNING: Not enough radar reflectivity files were found"

--- a/scripts/exrrfs_nonvar_reflobs.sh
+++ b/scripts/exrrfs_nonvar_reflobs.sh
@@ -101,9 +101,14 @@ if [[ -s filelist_mrms ]]; then
   echo "Using radar data from: $(head -1 filelist_mrms | cut -c10-15)"
   echo "NSSL grib2 file levels = ${numgrib2}"
 else
-  echo "WARNING: Not enough radar reflectivity files were found"
-  echo "Radar reflectivity will not be processed for the nonvar cloud analysis"
-  exit 0
+  if [[ ${STRICT_CHECK} -eq 1 ]]; then
+    echo "ERROR: Not enough radar reflectivity files were found"
+    err_exit
+  else
+    echo "WARNING: Not enough radar reflectivity files were found"
+    echo "Radar reflectivity will not be processed for the nonvar cloud analysis"
+    exit 0
+  fi
 fi
 
 cat << EOF > namelist.mosaic

--- a/scripts/exrrfs_nonvar_reflobs.sh
+++ b/scripts/exrrfs_nonvar_reflobs.sh
@@ -101,8 +101,9 @@ if [[ -s filelist_mrms ]]; then
   echo "Using radar data from: $(head -1 filelist_mrms | cut -c10-15)"
   echo "NSSL grib2 file levels = ${numgrib2}"
 else
-  echo "FATAL ERROR: Not enough radar reflectivity files were found"
-  err_exit
+  echo "WARNING: Not enough radar reflectivity files were found"
+  echo "Radar reflectivity will not be processed for the nonvar cloud analysis"
+  exit 0
 fi
 
 cat << EOF > namelist.mosaic

--- a/scripts/exrrfs_nonvar_reflobs.sh
+++ b/scripts/exrrfs_nonvar_reflobs.sh
@@ -101,7 +101,7 @@ if [[ -s filelist_mrms ]]; then
   echo "Using radar data from: $(head -1 filelist_mrms | cut -c10-15)"
   echo "NSSL grib2 file levels = ${numgrib2}"
 else
-  if [[ ${STRICT_CHECK} == 1 ]]; then
+  if [[ ${STOP_IF_NO_OBS} == 1 ]]; then
     echo "ERROR: Not enough radar reflectivity files were found"
     err_exit
   else

--- a/tests/.ignore.compare_xml_yaml_outputs
+++ b/tests/.ignore.compare_xml_yaml_outputs
@@ -1,2 +1,2 @@
-1676
+1684
 # put the exact PR number in the first line without any empty spaces

--- a/workflow/rocoto_funcs/nonvar_bufrobs.py
+++ b/workflow/rocoto_funcs/nonvar_bufrobs.py
@@ -11,6 +11,11 @@ def nonvar_bufrobs(xmlFile, expdir):
     if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
     OBSPATH = os.getenv("OBSPATH", 'OBSPATH_not_defined')
+    realtime = os.getenv("REALTIME", "false")
+    if realtime:
+        strict_check = 0
+    else:
+        strict_check = 1
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'REFERENCE_TIME': '@Y-@m-@dT@H:00:00Z',
@@ -18,7 +23,8 @@ def nonvar_bufrobs(xmlFile, expdir):
         'NONVAR_LARC_NPTS': os.getenv('NONVAR_LARC_NPTS', 'NONVAR_LARC_NPTS_not_defined'),
         'NONVAR_METAR_IMPACT': os.getenv('NONVAR_METAR_IMPACT', 'NONVAR_METAR_IMPACT_not_defined'),
         'NONVAR_PROJ_NAME': os.getenv('NONVAR_PROJ_NAME', 'NONVAR_PROJ_NAME_not_defined'),
-        'NONVAR_USERDX': os.getenv('NONVAR_USERDX', 'NONVAR_USERDX_not_defined')
+        'NONVAR_USERDX': os.getenv('NONVAR_USERDX', 'NONVAR_USERDX_not_defined'),
+        'STRICT_CHECK': f'{strict_check}'
     }
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()
@@ -29,7 +35,6 @@ def nonvar_bufrobs(xmlFile, expdir):
 
     timedep = ""
     datadep = ""
-    realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
         starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
         timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'

--- a/workflow/rocoto_funcs/nonvar_bufrobs.py
+++ b/workflow/rocoto_funcs/nonvar_bufrobs.py
@@ -13,9 +13,9 @@ def nonvar_bufrobs(xmlFile, expdir):
     OBSPATH = os.getenv("OBSPATH", 'OBSPATH_not_defined')
     realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
-        strict_check = 0
+        stop_if_no_obs = 0
     else:
-        strict_check = 1
+        stop_if_no_obs = 1
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'REFERENCE_TIME': '@Y-@m-@dT@H:00:00Z',
@@ -24,7 +24,7 @@ def nonvar_bufrobs(xmlFile, expdir):
         'NONVAR_METAR_IMPACT': os.getenv('NONVAR_METAR_IMPACT', 'NONVAR_METAR_IMPACT_not_defined'),
         'NONVAR_PROJ_NAME': os.getenv('NONVAR_PROJ_NAME', 'NONVAR_PROJ_NAME_not_defined'),
         'NONVAR_USERDX': os.getenv('NONVAR_USERDX', 'NONVAR_USERDX_not_defined'),
-        'STRICT_CHECK': f'{strict_check}'
+        'STOP_IF_NO_OBS': f'{stop_if_no_obs}'
     }
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()

--- a/workflow/rocoto_funcs/nonvar_bufrobs.py
+++ b/workflow/rocoto_funcs/nonvar_bufrobs.py
@@ -33,17 +33,17 @@ def nonvar_bufrobs(xmlFile, expdir):
     lght_path = f'{OBSPATH}/@Y@m@d@H.rap.t@Hz.lghtng.tm00.bufr_d'
     metar_path = f'{OBSPATH}/@Y@m@d@H.rap.t@Hz.prepbufr.tm00'
 
-    timedep = ""
-    datadep = ""
     if realtime.upper() == "TRUE":
         starttime = get_cascade_env(f"STARTTIME_{task_id}".upper())
-        timedep = f'\n    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
-    else:
-        datadep = f'\n    <datadep age="00:02:00"><cyclestr>{lght_path}</cyclestr></datadep>'
-    #
-    dependencies = f'''
+        dependencies = f'''
   <dependency>
-  <and>{timedep}{datadep}
+    <timedep><cyclestr offset="{starttime}">@Y@m@d@H@M00</cyclestr></timedep>'
+  </dependency>'''
+    else:
+        dependencies = f'''
+  <dependency>
+  <and>
+    <datadep age="00:02:00"><cyclestr>{lght_path}</cyclestr></datadep>
     <datadep age="00:02:00"><cyclestr>{larc_path}</cyclestr></datadep>
     <datadep age="00:02:00"><cyclestr>{metar_path}</cyclestr></datadep>
   </and>

--- a/workflow/rocoto_funcs/nonvar_bufrobs.py
+++ b/workflow/rocoto_funcs/nonvar_bufrobs.py
@@ -12,7 +12,7 @@ def nonvar_bufrobs(xmlFile, expdir):
         cycledefs = 'prod,spinup'
     OBSPATH = os.getenv("OBSPATH", 'OBSPATH_not_defined')
     realtime = os.getenv("REALTIME", "false")
-    if realtime:
+    if realtime.upper() == "TRUE":
         strict_check = 0
     else:
         strict_check = 1

--- a/workflow/rocoto_funcs/nonvar_reflobs.py
+++ b/workflow/rocoto_funcs/nonvar_reflobs.py
@@ -12,7 +12,7 @@ def nonvar_reflobs(xmlFile, expdir):
         cycledefs = 'prod,spinup'
     OBSPATH_NSSLMOSIAC = os.getenv("OBSPATH_NSSLMOSIAC", 'OBSPATH_NSSLMOSIAC_not_defined')
     realtime = os.getenv("REALTIME", "false")
-    if realtime:
+    if realtime.upper() == "TRUE":
         strict_check = 0
     else:
         strict_check = 1

--- a/workflow/rocoto_funcs/nonvar_reflobs.py
+++ b/workflow/rocoto_funcs/nonvar_reflobs.py
@@ -11,10 +11,16 @@ def nonvar_reflobs(xmlFile, expdir):
     if os.getenv("DO_SPINUP", "FALSE").upper() == "TRUE":
         cycledefs = 'prod,spinup'
     OBSPATH_NSSLMOSIAC = os.getenv("OBSPATH_NSSLMOSIAC", 'OBSPATH_NSSLMOSIAC_not_defined')
+    realtime = os.getenv("REALTIME", "false")
+    if realtime:
+        strict_check = 0
+    else:
+        strict_check = 1
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'REFERENCE_TIME': '@Y-@m-@dT@H:00:00Z',
-        'OBSPATH_NSSLMOSIAC': f'{OBSPATH_NSSLMOSIAC}'
+        'OBSPATH_NSSLMOSIAC': f'{OBSPATH_NSSLMOSIAC}',
+        'STRICT_CHECK': f'{strict_check}'
     }
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()

--- a/workflow/rocoto_funcs/nonvar_reflobs.py
+++ b/workflow/rocoto_funcs/nonvar_reflobs.py
@@ -13,14 +13,14 @@ def nonvar_reflobs(xmlFile, expdir):
     OBSPATH_NSSLMOSIAC = os.getenv("OBSPATH_NSSLMOSIAC", 'OBSPATH_NSSLMOSIAC_not_defined')
     realtime = os.getenv("REALTIME", "false")
     if realtime.upper() == "TRUE":
-        strict_check = 0
+        stop_if_no_obs = 0
     else:
-        strict_check = 1
+        stop_if_no_obs = 1
     # Task-specific EnVars beyond the task_common_vars
     dcTaskEnv = {
         'REFERENCE_TIME': '@Y-@m-@dT@H:00:00Z',
         'OBSPATH_NSSLMOSIAC': f'{OBSPATH_NSSLMOSIAC}',
-        'STRICT_CHECK': f'{strict_check}'
+        'STOP_IF_NO_OBS': f'{stop_if_no_obs}'
     }
 
     dcTaskEnv['KEEPDATA'] = get_cascade_env(f"KEEPDATA_{task_id}".upper()).upper()


### PR DESCRIPTION
Implement changes to help avoid dead tasks during realtime when input observation files to the nonvar cloud analysis are missing.

## DESCRIPTION OF CHANGES: 
- Implement a `STOP_IF_NO_OBS` flag in the `nonvar_bufrobs` and `nonvar_reflobs` tasks. If `STOP_IF_NO_OBS = 1`, the task terminates with an error if an input observation file is missing. If `STOP_IF_NO_OBS = 0`, task continues to execute if an observation file is missing, but a warning is issued.
- Set `STOP_IF_NO_OBS = 0` for realtime experiments and `STOP_IF_NO_OBS = 1` for retros.

## TESTS CONDUCTED: 
Following tests were run, and the output was as expected:
- Default `exp.conus3km` setup: Both the `nonvar_bufrobs` and `nonvar_reflobs` tasks run properly without error.
- Default `exp.conus3km` setup, but with incorrect `OBSPATH` in `nonvar_bufrobs`: The `nonvar_bufrobs` task crashes owing to missing observation files.
- Default `exp.conus3km` setup, but with incorrect `OBSPATH` in `nonvar_bufrobs` and `STOP_IF_NO_OBS = 0`: The `nonvar_bufrobs` task runs without error even though no processed observation files are created.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules
  - [x] Gaea C6

