### PR TITLE
[release/v1.0] Adds subsetting of ensemble member products for NOMADS

### DIFF
--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -544,9 +544,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2
         $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM}_IDX $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
-        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM} $job \
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_2DFLD_NOMADS_${DBNDOM} $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2
-        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM}_IDX $job \
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_2DFLD_NOMADS_${DBNDOM}_IDX $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
       fi
     done

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -543,13 +543,13 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fi
 
       if [ "${SENDDBN}" = "YES" ] ; then
-        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS $job \
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM} $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2
-        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS_IDX $job \
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM}_IDX $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
-        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS $job \
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM} $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2
-        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS_IDX $job \
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM}_IDX $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
       fi
 

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -502,12 +502,9 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
   fi
 
   # extract subset of ensemble files for NOMADS
-  #
   if [ ${DO_ENSFCST} = "TRUE" ]; then
-
     for domain in ${domains[@]}
     do
-
       DBNDOM="${domain^^}"
 
       if [[ $domain = "conus" || $domain = "ak" ]]; then
@@ -552,9 +549,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
         $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_NOMADS_${DBNDOM}_IDX $job \
             ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
       fi
-
     done
-
   fi
 
   # create prslev and 2dfld files on 13-km North America grid

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -518,8 +518,7 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fld2d_nomads=${net4}.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2
       prslev_nomads=${net4}.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2
 
-      wgrib2 ${fld2d_loc} | grep -F -f ${FIX_UPP}/nomadsensf_fields_2dfld.txt | \ 
-        wgrib2 -i -grib ${DATA}/${fld2d_nomads} ${fld2d_loc} >>$pgmout 2>>errfile
+      wgrib2 ${fld2d_loc} | grep -F -f ${FIX_UPP}/nomadsensf_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${fld2d_nomads} ${fld2d_loc} >>$pgmout 2>>errfile
       export err=$?; err_chk
 
       cpreq ${DATA}/${fld2d_nomads} ${COMOUT}/${fld2d_nomads}

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -508,16 +508,18 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
     for domain in ${domains[@]}
     do
 
-      if [ $domain = "conus" || $domain = "ak" ]; then
-        gridspacing=3km
-      elif [  $domain = "hi" || $domain = "pr" ]; then
-        gridspacing=2p5km
+      DBNDOM="${domain^^}"
+
+      if [[ $domain = "conus" || $domain = "ak" ]]; then
+        outspacing=3km
+      elif [[  $domain = "hi" || $domain = "pr" ]]; then
+        outspacing=2p5km
       fi
 
-      fld2d_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${gridspacing}.f${fhr}.${domain}.grib2
-      prslev_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${gridspacing}.f${fhr}.${domain}.grib2
-      fld2d_nomads=${net4}.t${cyc}z.${mem_num}.2dfldnomads.${gridspacing}.f${fhr}.${gridname}.grib2
-      fld2d_prslevs=${net4}.t${cyc}z.${mem_num}.prslevnomads.${gridspacing}.f${fhr}.${gridname}.grib2
+      fld2d_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${outspacing}.f${fhr}.${domain}.grib2
+      prslev_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${outspacing}.f${fhr}.${domain}.grib2
+      fld2d_nomads=${net4}.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2
+      prslev_nomads=${net4}.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2
 
       wgrib2 ${COMOUT}/${fld2d_loc} | grep -F -f ${FIX_UPP}/nomadsensf_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${fld2d_nomads} ${COMOUT}/${fld2d_loc} >>$pgmout 2>>errfile
       export err=$?; err_chk
@@ -526,6 +528,26 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       wgrib2 ${COMOUT}/${prslev_loc} -match -match "(HGT|PRES|TMP|RH|DPT|VVEL|ABSV|CLWMR|UGRD|VGRD|SPFH)" -match "(1000 mb:|975 mb:|950 mb:|925 mb:|900 mb:|850 mb:|800 mb:|750 mb:|700 mb:|600 mb:|500 mb:|400 mb:|300 mb:|250 mb:)" -grib ${DATA}/${prslev_nomads} >>$pgmout 2>>errfile
       export err=$?; err_chk
       cpreq ${DATA}/${prslev_nomads} ${COMOUT}/${prslev_nomads}
+
+      # index files
+      if [ -s ${COMOUT}/${fld2d_nomads} ]; then
+        wgrib2 ${COMOUT}/${fld2d_nomads} -s > ${COMOUT}/${fld2d_nomads}.idx
+      fi
+      if [ -s ${COMOUT}/${prslev_nomads} ]; then
+        wgrib2 ${COMOUT}/${prslev_nomads} -s > ${COMOUT}/${prslev_nomads}.idx
+      fi
+
+      if [ "${SENDDBN}" = "YES" ] ; then
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS $job \
+            ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS_IDX $job \
+            ${COMOUT}/rrfs.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS $job \
+            ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2
+        $DBNROOT/bin/dbn_alert MODEL RRFS_ENS_${DBNDOM}_NOMADS_IDX $job \
+            ${COMOUT}/rrfs.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2.idx
+      fi
+
     done
 
   fi

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -501,6 +501,35 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
 
   fi
 
+  # extract subset of ensemble files for NOMADS
+  #
+  if [ ${DO_ENSFCST} = "TRUE" ]; then
+
+    for domain in ${domains[@]}
+    do
+
+      if [ $domain = "conus" || $domain = "ak" ]; then
+        gridspacing=3km
+      elif [  $domain = "hi" || $domain = "pr" ]; then
+        gridspacing=2p5km
+      fi
+
+      fld2d_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${gridspacing}.f${fhr}.${domain}.grib2
+      prslev_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${gridspacing}.f${fhr}.${domain}.grib2
+      fld2d_nomads=${net4}.t${cyc}z.${mem_num}.2dfldnomads.${gridspacing}.f${fhr}.${gridname}.grib2
+      fld2d_prslevs=${net4}.t${cyc}z.${mem_num}.prslevnomads.${gridspacing}.f${fhr}.${gridname}.grib2
+
+      wgrib2 ${COMOUT}/${fld2d_loc} | grep -F -f ${FIX_UPP}/nomadsensf_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${fld2d_nomads} ${COMOUT}/${fld2d_loc} >>$pgmout 2>>errfile
+      export err=$?; err_chk
+      cpreq ${DATA}/${fld2d_nomads} ${COMOUT}/${fld2d_nomads}
+
+      wgrib2 ${COMOUT}/${prslev_loc} -match -match "(HGT|PRES|TMP|RH|DPT|VVEL|ABSV|CLWMR|UGRD|VGRD|SPFH)" -match "(1000 mb:|975 mb:|950 mb:|925 mb:|900 mb:|850 mb:|800 mb:|750 mb:|700 mb:|600 mb:|500 mb:|400 mb:|300 mb:|250 mb:)" -grib ${DATA}/${prslev_nomads} >>$pgmout 2>>errfile
+      export err=$?; err_chk
+      cpreq ${DATA}/${prslev_nomads} ${COMOUT}/${prslev_nomads}
+    done
+
+  fi
+
   # create prslev and 2dfld files on 13-km North America grid
   # Deterministic cycles only for now
   if [ ${DO_ENSFCST} = "FALSE" ]; then

--- a/scripts/exrrfs_prdgen.sh
+++ b/scripts/exrrfs_prdgen.sh
@@ -517,16 +517,21 @@ if [ ${WGF} = "det" ] || [ ${WGF} = "ensf" ]; then
       fi
 
       fld2d_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${outspacing}.f${fhr}.${domain}.grib2
-      prslev_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.2dfld.${outspacing}.f${fhr}.${domain}.grib2
+      prslev_loc=${COMOUT}/${net4}.t${cyc}z.${mem_num}.prslev.${outspacing}.f${fhr}.${domain}.grib2
       fld2d_nomads=${net4}.t${cyc}z.${mem_num}.2dfldnomads.${outspacing}.f${fhr}.${domain}.grib2
       prslev_nomads=${net4}.t${cyc}z.${mem_num}.prslevnomads.${outspacing}.f${fhr}.${domain}.grib2
 
-      wgrib2 ${COMOUT}/${fld2d_loc} | grep -F -f ${FIX_UPP}/nomadsensf_fields_2dfld.txt | wgrib2 -i -grib ${DATA}/${fld2d_nomads} ${COMOUT}/${fld2d_loc} >>$pgmout 2>>errfile
+      wgrib2 ${fld2d_loc} | grep -F -f ${FIX_UPP}/nomadsensf_fields_2dfld.txt | \ 
+        wgrib2 -i -grib ${DATA}/${fld2d_nomads} ${fld2d_loc} >>$pgmout 2>>errfile
       export err=$?; err_chk
+
       cpreq ${DATA}/${fld2d_nomads} ${COMOUT}/${fld2d_nomads}
 
-      wgrib2 ${COMOUT}/${prslev_loc} -match -match "(HGT|PRES|TMP|RH|DPT|VVEL|ABSV|CLWMR|UGRD|VGRD|SPFH)" -match "(1000 mb:|975 mb:|950 mb:|925 mb:|900 mb:|850 mb:|800 mb:|750 mb:|700 mb:|600 mb:|500 mb:|400 mb:|300 mb:|250 mb:)" -grib ${DATA}/${prslev_nomads} >>$pgmout 2>>errfile
+      wgrib2 ${prslev_loc} -match "(HGT|PRES|TMP|RH|DPT|VVEL|ABSV|CLWMR|UGRD|VGRD|SPFH)" \
+        -match "(1000 mb:|975 mb:|950 mb:|925 mb:|900 mb:|850 mb:|800 mb:|750 mb:|700 mb:|600 mb:|500 mb:|400 mb:|300 mb:|250 mb:)" \
+        -grib ${DATA}/${prslev_nomads} >>$pgmout 2>>errfile
       export err=$?; err_chk
+
       cpreq ${DATA}/${prslev_nomads} ${COMOUT}/${prslev_nomads}
 
       # index files


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- Modifies exrrfs_prdgen.sh script to add a block that:

1.  Extracts records from the 2dfld file (using a new UPP fix file listing the records), and from the prslev file (using a simple -match command) for the ensemble members
2.  Copies these new  `prslevnomads` and `2dfldnomads ` files to COMOUT
3.  Adds .idx files to these new files in COMOUT
4.  Adds dbnalerts for the new products

NOTE:  New fix file added /lfs/h2/emc/lam/noscrub/emc.lam/rrfs/para/packages/fix_rrfs_nco/upp/nomadsensf_fields_2dfld.txt that would need to be incorporated into the NCO package for this new functionality to work.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->

- Thus far, just tested the new script logic in a standalone script, which revealed some minor issues that now have been resolved.

### Machines/Platforms:
<!-- Add 'x' inside the brackets (without space). -->
- WCOSS2
  - [ ] Cactus/Dogwood
  - [ ] Acorn
- RDHPCS
  - [ ] Hera
  - [ ] Jet
  - [ ] Orion
  - [ ] Hercules

### Test cases: 
<!-- Add 'x' inside the brackets (without space). -->
- [ ] Engineering tests
  - [ ] Non-DA engineering test
  - [ ] DA engineering test
    - [ ] Retro
    - [ ] Ensemble
    - [ ] Parallel
- [ ] RRFS fire weather
- [ ] RRFS_A:
- [ ] RRFS_B:
- [ ] RTMA:
- [ ] Others:

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here. -->

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

