### PR TITLE
[release/v1.0] add ops instruction to prep_cyc fallback emails

### DIFF
--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -89,6 +89,7 @@ Run command has not been specified for this machine:
 esac
 export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
 
+
 #
 #-----------------------------------------------------------------------
 #
@@ -312,7 +313,7 @@ else
     done
     ncatted -O -a source,global,c,c,'FV3GFS GAUSSIAN NETCDF FILE' fv_core.res.tile1.nc
   else
-
+    opsemailhead="WARNING: Missing RRFS restart files listed below. Proceeding with older restart files.\n\nOps Action: No immediate action. If this warning email continues for subsequent cycles, investigate cause of system slow down.\n\n"
   # Setup the INPUT directory for warm start cycles, which can be spin-up cycle or product cycle.
   #
   # First decide the source of the first guess (fg_restart_dirname) depending on CYCLE_TYPE and BKTYPE:
@@ -379,7 +380,7 @@ else
       if [ ${fallback_enable} == "YES" ]; then
         print_info_msg "$VERBOSE" "WARNING: cannot find restart files in previous 1 hour, proceeding fallback for older cycle"
         if [ ${SENDMAIL} == "YES" ] && [ ! ${WGF} == "enkf" ]; then
-          echo "WARNING: cannot find restart files in previous 1 hour, proceeding fallback for older cycle" | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
+          (echo -e ${opsemailhead} && echo "WARNING: cannot find restart files in previous 1 hour, proceeding fallback for older cycle") | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
         fi
         fg_restart_dirname=forecast
         restart_prefix="${YYYYMMDD}.${HH}0000."
@@ -406,7 +407,7 @@ else
            else
              print_info_msg "$VERBOSE" "WARNING: fallback cannot find restart files in previous ${n} hour"
              if [ ${SENDMAIL} == "YES" ] && [ ! ${WGF} == "enkf" ]; then
-               echo "WARNING: fallback cannot find restart files in previous ${n} hour" | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
+               (echo -e ${opsemailhead} && echo "WARNING: fallback cannot find restart files in previous ${n} hour") | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
              fi
              export missing_restart_file=${checkfile}
              export missing_restart_bkpath=${bkpath}
@@ -416,8 +417,6 @@ else
       fi
     fi
   fi
-
-
 
   # Implement prep_cyc_alert_singleton capability; all 30 members will output status in the flag file
   if [ ${WGF} == "enkf" ]; then
@@ -445,7 +444,7 @@ else
           exec 9> "${umbrella_prep_cyc_fallback}/email.lock"
           flock -x 9
           if [ ! -s ${umbrella_prep_cyc_fallback}/email.lock ]; then
-            opsemailhead="WARNING: Missing RRFS restart files listed below. Proceeding with older restart files.\n\nOps Action: No immediate action. If this warning email continues for subsequent cycles, investigate cause of system slow down.\n\n"
+
             (echo -e $opsemailhead && cat ${umbrella_prep_cyc_fallback_flag}) | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
             echo "Sent ${mem_num}" >> "${umbrella_prep_cyc_fallback}/email.lock"
           fi

--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -89,7 +89,6 @@ Run command has not been specified for this machine:
 esac
 export FIXLAM=${FIXLAM:-${FIXrrfs}/lam/${PREDEF_GRID_NAME}}
 
-
 #
 #-----------------------------------------------------------------------
 #
@@ -313,7 +312,9 @@ else
     done
     ncatted -O -a source,global,c,c,'FV3GFS GAUSSIAN NETCDF FILE' fv_core.res.tile1.nc
   else
+    #set ops email header for instances of missing restart files.
     opsemailhead="WARNING: Missing RRFS restart files listed below. Proceeding with older restart files.\n\nOps Action: No immediate action. If this warning email continues for subsequent cycles, investigate cause of system slow down.\n\n"
+
   # Setup the INPUT directory for warm start cycles, which can be spin-up cycle or product cycle.
   #
   # First decide the source of the first guess (fg_restart_dirname) depending on CYCLE_TYPE and BKTYPE:
@@ -420,7 +421,6 @@ else
 
   # Implement prep_cyc_alert_singleton capability; all 30 members will output status in the flag file
   if [ ${WGF} == "enkf" ]; then
-
     export umbrella_prep_cyc_fallback_flag=${umbrella_prep_cyc_fallback}/prep_cyc_flag.status
     if [ -f ${umbrella_prep_cyc_fallback_flag} ]; then
       # Ensure no duplicate record for each member
@@ -444,7 +444,6 @@ else
           exec 9> "${umbrella_prep_cyc_fallback}/email.lock"
           flock -x 9
           if [ ! -s ${umbrella_prep_cyc_fallback}/email.lock ]; then
-
             (echo -e $opsemailhead && cat ${umbrella_prep_cyc_fallback_flag}) | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
             echo "Sent ${mem_num}" >> "${umbrella_prep_cyc_fallback}/email.lock"
           fi

--- a/scripts/exrrfs_prep_cyc.sh
+++ b/scripts/exrrfs_prep_cyc.sh
@@ -417,8 +417,11 @@ else
     fi
   fi
 
+
+
   # Implement prep_cyc_alert_singleton capability; all 30 members will output status in the flag file
   if [ ${WGF} == "enkf" ]; then
+
     export umbrella_prep_cyc_fallback_flag=${umbrella_prep_cyc_fallback}/prep_cyc_flag.status
     if [ -f ${umbrella_prep_cyc_fallback_flag} ]; then
       # Ensure no duplicate record for each member
@@ -426,7 +429,7 @@ else
     else
       mkdir -p ${umbrella_prep_cyc_fallback}
     fi
-    if [ ! -z ${fallback_enable} ] && [ ${fallback_enable} == "YES" ];then
+    if [ ! -z ${fallback_enable} ] && [ ${fallback_enable} == "YES" ]; then
       # Output status in the flag file if the restart file not found
       flock -w 60 "${umbrella_prep_cyc_fallback}/file.lock" -c 'echo "WARNING: rrfs prep cycle member ${mem_num} in cycle ${cyc} cannot find restart files ${missing_restart_file} in previous 1 hour, it is degraded proceeding fallback in ${missing_restart_bkpath}, check rrfs enkf forecast job jrrfs_enkf_save_restart_${mem_num}_f1 from previous cycle for possible issue." >> "${umbrella_prep_cyc_fallback_flag}"'
       # Start alert action if all 30 member has registered its status and at least one member has issue
@@ -442,7 +445,8 @@ else
           exec 9> "${umbrella_prep_cyc_fallback}/email.lock"
           flock -x 9
           if [ ! -s ${umbrella_prep_cyc_fallback}/email.lock ]; then
-            mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO} < ${umbrella_prep_cyc_fallback_flag}
+            opsemailhead="WARNING: Missing RRFS restart files listed below. Proceeding with older restart files.\n\nOps Action: No immediate action. If this warning email continues for subsequent cycles, investigate cause of system slow down.\n\n"
+            (echo -e $opsemailhead && cat ${umbrella_prep_cyc_fallback_flag}) | mail.py -s "RRFS prep_cyc fallback" -c ${MAILTO}
             echo "Sent ${mem_num}" >> "${umbrella_prep_cyc_fallback}/email.lock"
           fi
           exec 9>&-


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- added a line including instructions for ops at the beginning of prep_cyc fallback emails
- edited calls to mail.py to include this line

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- Not tested in workflow.
- Tested `(echo -e "blah\nblah" && cat blah.txt) | mail.py --args` syntax on a login node.
