### PR TITLE
A few miscellaneous updates

### DIFF
--- a/.github/workflows/compare_yaml_outputs.yaml
+++ b/.github/workflows/compare_yaml_outputs.yaml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'parm/jedivar.yaml'
-      - 'parm/getkf.yaml'
+      - 'parm/observers/*'
       - 'parm/bec*.yaml'
       - 'ush/yaml_finalize'
       - 'ush/yamltools4rrfs.py'
       - 'ush/hifiyaml4rrfs.py'
+      - 'workflow/rocoto_funcs/smart_superyaml.py'
 
 jobs:
   compare-YAML-outputs:

--- a/workflow/exp/exp.conus12km
+++ b/workflow/exp/exp.conus12km
@@ -9,7 +9,7 @@ export EXP_NAME=hrly_12km
 export VERSION=$(cat ./VERSION)
 export TAG=d12km
 export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
-export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
+export EXPDIR=${OPSROOT}/exp/${NET}${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=YES
 #

--- a/workflow/exp/exp.conus3km
+++ b/workflow/exp/exp.conus3km
@@ -9,7 +9,7 @@ export EXP_NAME=conus3km
 export VERSION=$(cat ./VERSION)
 export TAG=d3km
 export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
-export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
+export EXPDIR=${OPSROOT}/exp/${NET}${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=YES
 #

--- a/workflow/exp/exp.ens_conus12km
+++ b/workflow/exp/exp.ens_conus12km
@@ -9,7 +9,7 @@ export EXP_NAME=hrly_12km
 export VERSION=$(cat ./VERSION)
 export TAG=e12km
 export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
-export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
+export EXPDIR=${OPSROOT}/exp/${NET}${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=YES
 #

--- a/workflow/exp/exp.ens_conus3km
+++ b/workflow/exp/exp.ens_conus3km
@@ -9,7 +9,7 @@ export EXP_NAME=conus3km
 export VERSION=$(cat ./VERSION)
 export TAG=e3km
 export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
-export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
+export EXPDIR=${OPSROOT}/exp/${NET}${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=YES
 #

--- a/workflow/exp/exp.ens_na12km
+++ b/workflow/exp/exp.ens_na12km
@@ -9,7 +9,7 @@ export EXP_NAME=hrly_12km
 export VERSION=$(cat ./VERSION)
 export TAG=e12km
 export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
-export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
+export EXPDIR=${OPSROOT}/exp/${NET}${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=yes
 #

--- a/workflow/exp/exp.na12km
+++ b/workflow/exp/exp.na12km
@@ -9,7 +9,7 @@ export EXP_NAME=hrly_12km
 export VERSION=$(cat ./VERSION)
 export TAG=d12km
 export OPSROOT=/scratch3/BMC/wrfruc/gge/OPSROOT/${EXP_NAME}
-export EXPDIR=${OPSROOT}/exp/rrfs${WGF}
+export EXPDIR=${OPSROOT}/exp/${NET}${WGF}
 export COMROOT=${OPSROOT}/com      # task input and output data as well as logs
 export DATAROOT=${OPSROOT}/stmp    # task workdirs ($DATA) which to be removed immediately upon task completion unless KEEPDATA=YES
 #

--- a/workflow/rocoto_funcs/prep_ic.py
+++ b/workflow/rocoto_funcs/prep_ic.py
@@ -15,7 +15,7 @@ def prep_ic(xmlFile, expdir, do_ensemble=False, spinup_mode=0):
     else:
         cycledefs = 'prod'
     coldhrs = os.getenv('COLDSTART_CYCS', '03 15')
-    cyc_interval = os.getenv('CYC_INTERVAL')
+    cyc_interval = os.getenv('CYC_INTERVAL', '1')
     do_sfc_update = os.getenv('DO_SFC_UPDATE', 'false').upper()
     sst_update_cycs = os.getenv('SST_UPDATE_CYCS', '99')
     sfc_update_look_back_hrs = os.getenv('SFC_UPDATE_LOOK_BACK_HRS', cyc_interval)


### PR DESCRIPTION
1. bugfix for coldstart-only experiments where CYC_INTERVAL is not defined
2. minor updates to template exp files so that the NET part comes from the `${NET}` variable as expected.
3. update .github/workflows/compare_yaml_outputs.yaml to match the recent changes.
