### PR TITLE
[rrfs-mpas-jedi] Fixing missing namelist do_sppt in getkf and jedivar

### DIFF
--- a/scripts/exrrfs_getkf.sh
+++ b/scripts/exrrfs_getkf.sh
@@ -67,6 +67,7 @@ nsoillevels=${NSOIL_LEVELS:-9}
 jedi_da=true #true
 pio_stride=${PIO_STRIDE:-${PPN}}
 pio_num_iotasks=$(( NODES * PPN / pio_stride ))
+do_sppt=${DO_SPPT:-'false'} 
 
 # We set dt, substeps, radt values to avoid errors in reading namelist.atmosphere
 # but they will NOT be used since no model integration in DA steps

--- a/scripts/exrrfs_jedivar.sh
+++ b/scripts/exrrfs_jedivar.sh
@@ -115,6 +115,7 @@ nsoillevels=${NSOIL_LEVELS:-9}
 jedi_da=true #true
 pio_num_iotasks=${NODES}
 pio_stride=${PPN}
+do_sppt=${DO_SPPT:-'false'} 
 
 # We set dt, substeps, radt values to avoid errors in reading namelist.atmosphere
 # but they will NOT be used since no model integration in DA steps


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Fix missing namelist entry,  `do_sppt=${DO_SPPT:-'false'}`,  in getkf and jedivar.

## TESTS CONDUCTED: 
Tested in retro. 

