### PR TITLE
[release/v1.0] Fix file copy permission issue by removing -p from cp in setup_firewx.sh

### DIFF
--- a/ush/setup_firewx.sh
+++ b/ush/setup_firewx.sh
@@ -156,7 +156,7 @@ do
   done
 
   if [ -s $COMOUT/rrfs_firewx_loc ]; then
-    cp -p $COMOUT/rrfs_firewx_loc $COMOUT/rrfs_firewx_loc_prev
+    cp $COMOUT/rrfs_firewx_loc $COMOUT/rrfs_firewx_loc_prev
   fi
   cp rrfs_firewx_loc $COMOUT/rrfs_firewx_loc
 


### PR DESCRIPTION
<!-- Use this template to give a detailed message describing the change you want to make to the code. -->
<!-- You may delete any sections labeled "optional". -->
<!-- Use the "Preview" tab to see what your PR will look like when you hit "Create pull request" -->

## DESCRIPTION OF CHANGES: 
<!-- One or more bullet points describing the changes. -->
- During SDM testings, `cp -p $COMOUT/rrfs_firewx_loc $COMOUT/rrfs_firewx_loc_prev` returned an error: ` cp: preserving times for '/lfs/h1/ops/para/com/rrfs/v1.0/firewx_input/rrfs_firewx_loc_prev': Operation not permitted`
- This PR removes `-p` flag from the copy command.

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes. -->
- Tested in /test space.
