### PR TITLE
PR1: sub-hourly cycling core (generic, infra only)

### DIFF
--- a/workflow/config_resources/config.base
+++ b/workflow/config_resources/config.base
@@ -15,6 +15,7 @@ export REALTIME_MONTHS=${REALTIME_MONTHS:-2}
 export DO_FCST=${DO_FCST:-true}
 export DO_POST=${DO_POST:-true}
 export DO_IC_LBC=${DO_IC_LBC:-true}
+export DO_SUBHOURLY=${DO_SUBHOURLY:-FALSE}  # enable sub-hourly (minute-resolution) cycling (see workflow/rocoto_funcs/base.py:subhourly)
 export USE_THE_LATEST_SATBIAS=${USE_THE_LATEST_SATBIAS:-false} # whether DA tasks use the latest satbias from the previous cycle
 export PHYSICS_SUITE=${PHYSICS_SUITE:-"hrrrv5"} # hrrrv5, mesoscale_reference, convection_permitting
 export KEEPDATA=${KEEPDATA:-"NO"}

--- a/workflow/rocoto_funcs/base.py
+++ b/workflow/rocoto_funcs/base.py
@@ -6,6 +6,26 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 
+# --- Sub-hourly cycling helpers --------------------------------------------
+# DO_SUBHOURLY (config.base default FALSE) enables sub-hourly cycling.  When it
+# is TRUE every per-cycle path/label token carries minute resolution (@H@M) so
+# that cycles less than an hour apart do not collide.  When it is FALSE these
+# helpers return the exact legacy tokens, keeping existing experiments
+# byte-identical.
+def subhourly():
+    return os.getenv('DO_SUBHOURLY', 'FALSE').upper() == 'TRUE'
+
+
+def tok_hm():
+    """Cycle hour(+minute) token used in directory names and labels."""
+    return '@H@M' if subhourly() else '@H'
+
+
+def tok_cdate():
+    """CDATE token (analysis time)."""
+    return '@Y@m@d@H@M' if subhourly() else '@Y@m@d@H'
+
+
 def source(bash_file, optional=False):
     """
     Source a Bash file and capture the environment variables
@@ -71,6 +91,13 @@ def header_entities(xmlFile, expdir):
     wgf = os.getenv('WGF', 'det')
     cyc_interval = os.getenv('CYC_INTERVAL', '3')
     realtime = os.getenv("REALTIME", "false").upper()
+    # Minute-aware per-cycle tokens (byte-identical when DO_SUBHOURLY is off)
+    hm = tok_hm()
+    cdate_fmt = tok_cdate()
+    if subhourly():
+        subcyc_envar = '\n<envar><name>subcyc</name><value><cyclestr>@M</cyclestr></value></envar>'
+    else:
+        subcyc_envar = ''
 
     if os.getenv('DO_CHEMISTRY', 'FALSE').upper() == "TRUE":
         chem_envar = "\n<envar><name>DO_CHEMISTRY</name><value>TRUE</value></envar>"
@@ -130,10 +157,10 @@ def header_entities(xmlFile, expdir):
 <envar><name>COMROOT</name><value>&COMROOT;</value></envar>
 <envar><name>DATAROOT</name><value><cyclestr>&DATAROOT;/@Y@m@d</cyclestr></value></envar>
 <envar><name>COMINrrfs</name><value>&COMROOT;/{net}/{rrfs_ver}</value></envar>
-<envar><name>COMOUT</name><value><cyclestr>&COMROOT;/{net}/{rrfs_ver}/{run}.@Y@m@d/@H</cyclestr></value></envar>
-<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+<envar><name>COMOUT</name><value><cyclestr>&COMROOT;/{net}/{rrfs_ver}/{run}.@Y@m@d/{hm}</cyclestr></value></envar>
+<envar><name>CDATE</name><value><cyclestr>{cdate_fmt}</cyclestr></value></envar>
 <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
-<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+<envar><name>cyc</name><value><cyclestr>{hm}</cyclestr></value></envar>{subcyc_envar}
 <envar><name>NET</name><value>{net}</value></envar>
 <envar><name>RUN</name><value>{run}</value></envar>
 <envar><name>rrfs_ver</name><value>{rrfs_ver}</value></envar>
@@ -340,8 +367,8 @@ def xml_task(
         command_id = meta_id
     dcTaskRes = {
         'command': f'&HOMErrfs;/workflow/sideload/launch.sh JRRFS_' + f'{command_id}'.upper(),
-        'join': f'&LOGROOT;/{RUN}.@Y@m@d/@H/{WGF}/{RUN}_{task_id}_{TAG}_@Y@m@d@H.log',
-        'jobname': f'{TAG}_{task_id}_c@H',
+        'join': f'&LOGROOT;/{RUN}.@Y@m@d/{tok_hm()}/{WGF}/{RUN}_{task_id}_{TAG}_{tok_cdate()}.log',
+        'jobname': f'{TAG}_{task_id}_c{tok_hm()}',
         'account': get_cascade_env(f'ACCOUNT_{task_id}'.upper()),
         'queue': get_cascade_env(f'QUEUE_{task_id}'.upper()),
         'partition': get_cascade_env(f"PARTITION_{task_id}".upper()),

--- a/workflow/rocoto_funcs/setup_xml.py
+++ b/workflow/rocoto_funcs/setup_xml.py
@@ -3,7 +3,7 @@
 import os
 import stat
 from rocoto_funcs.base import header_begin, header_entities, header_end, \
-    wflow_begin, wflow_log, wflow_cycledefs, wflow_end
+    wflow_begin, wflow_log, wflow_cycledefs, wflow_end, tok_hm
 from rocoto_funcs.smart_cycledefs import smart_cycledefs
 from rocoto_funcs.smart_post_groups import smart_post_groups
 from rocoto_funcs.smart_save4next_groups import smart_save4next_groups
@@ -64,7 +64,7 @@ def setup_xml(HOMErrfs, expdir):
         header_entities(xmlFile, expdir)
         header_end(xmlFile)
         wflow_begin(xmlFile)
-        log_fpath = f'&LOGROOT;/&RUN;.@Y@m@d/@H/&WGF;/&RUN;.log'
+        log_fpath = f'&LOGROOT;/&RUN;.@Y@m@d/{tok_hm()}/&WGF;/&RUN;.log'
         wflow_log(xmlFile, log_fpath)
         wflow_cycledefs(xmlFile, dcCycledef)
 


### PR DESCRIPTION
## Summary

Adds an **opt-in, workflow-agnostic sub-hourly cycling primitive**, gated on a new `DO_SUBHOURLY` switch (`config.base` default `FALSE`). This is the foundation for any workflow that needs cycles less than an hour apart — it is deliberately **not** tied to a specific application.

When `DO_SUBHOURLY=TRUE`, per-cycle path/label tokens carry minute resolution (`@H@M`) and a `subcyc` (minute-of-cycle) envar is exported, so sub-hourly cycles do not collide. When it is `FALSE` (default), every token reduces to the legacy value.

**Byte-identical guarantee:** with `DO_SUBHOURLY=FALSE`, XML output is unchanged — verified against all 13 CI baseline exps (`tests/generate_xml_files.sh`) → 0 diffs vs the base branch (ignoring the `ENTITY HOMErrfs` line).

## Changes (3 files)

- **`workflow/rocoto_funcs/base.py`** — `subhourly()` switch; `tok_hm()`/`tok_cdate()` minute-aware tokens used in `COMOUT`/`CDATE`/`cyc`/log path/jobname; conditional `subcyc` envar.
- **`workflow/config_resources/config.base`** — add `DO_SUBHOURLY` switch (default `FALSE`).
- **`workflow/rocoto_funcs/setup_xml.py`** — minute-aware workflow log path via `tok_hm()`.

## What `DO_SUBHOURLY` changes

It flips per-cycle **time tokens** from hour-resolution to hour+minute and exports a new `subcyc` envar. Nothing else in the XML changes:

| Field | `FALSE` (default) | `TRUE` |
|---|---|---|
| `COMOUT` dir | `…/rrfs.@Y@m@d/@H` | `…/rrfs.@Y@m@d/@H@M` |
| `CDATE` | `@Y@m@d@H` | `@Y@m@d@H@M` |
| `cyc` | `@H` | `@H@M` |
| `subcyc` | *(absent)* | `@M` ← **new envar** |
| workflow log dir | `…/@Y@m@d/@H/…` | `…/@Y@m@d/@H@M/…` |
| every task `<join>` log | `…_@Y@m@d@H.log` | `…_@Y@m@d@H@M.log` |
| every task `<jobname>` | `…_c@H` | `…_c@H@M` |

`@M` is the minute-of-cycle. For an hourly workflow every cycle lands on `:00`, so these tokens would collide if two cycles ever shared an hour. With the flag on, the minute is embedded everywhere a cycle is uniquely identified (COMOUT dir, log file, jobname) and exported as `subcyc` for the job scripts — so e.g. `1500` and `1515` stay distinct.

**Important:** `DO_SUBHOURLY=TRUE` does **not** by itself create sub-hourly cycles. The cadence still comes from the cycledef. The flag only makes the workflow *able* to represent sub-hourly cycles without collisions. To actually cycle faster than hourly, supply a minute-stride cycledef (below).

## Supplying a minute-stride cycledef

`smart_cycledefs` has an explicit-override mode: once `CYCLEDEF_IC` is set to anything other than `not_defined`, it stops auto-computing and uses the `CYCLEDEF_*` strings verbatim. Each is a raw Rocoto cycledef string `"START END STRIDE"`, where `START`/`END` are `YYYYMMDDHHMM` (minute precision) and `STRIDE` is `HH:MM:SS` (minutes allowed).

Example — add to an exp file for 15-min DA cycling:

```bash
export DO_SUBHOURLY=true
export CYCLEDEF_IC="202405270000 202405270000 24:00:00"   # single cold start
export CYCLEDEF_LBC="202405270000 202405280000 12:00:00"  # 12-hourly LBCs
export CYCLEDEF_PROD="202405270000 202405270300 00:15:00" # 15-min prod cycling
```

Produces:

```xml
<cycledef group="ic">202405270000 202405270000 24:00:00</cycledef>
<cycledef group="lbc">202405270000 202405280000 12:00:00</cycledef>
<cycledef group="prod">202405270000 202405270300 00:15:00</cycledef>
```

Once you set `CYCLEDEF_IC` you own all groups: define at least `IC`, `LBC`, `PROD` (plus `CYCLEDEF_SPINUP`/`CYCLEDEF_RECENTER`/`CYCLEDEF_DOMAIN` when `DO_SPINUP`/`DO_RECENTER`/`DO_CREATE_DOMAIN` are enabled), otherwise the undefined groups emit the literal `not_defined`.

> Note: there is a **pre-existing** issue (independent of this PR) where the explicit-cycledef path does not parse `COLDSTART_CYCS`, so with `DO_JEDI=true` (or `DO_NONVAR_CLOUD_ANA=true`) **and** `COLDSTART_CYCS_DO_DA=false` generation raises `UnboundLocalError: cold_cycs` in `smart_cycledefs.py`. Workaround: set `COLDSTART_CYCS_DO_DA=true`. A proper one-line fix will be proposed separately.

## Scope

- **No new tasks, no exp, no application-specific logic** — this is a pure, reusable primitive.
- Higher-level switches and windowed-mode machinery (event-anchored cycledefs, per-application obs/mesh wiring, etc.) build **on top of** this primitive in later PRs.

## Testing

- Regenerated all 13 CI baseline XMLs with `DO_SUBHOURLY` off → **0 diffs** vs base.
- Verified `DO_SUBHOURLY=true` on `exp.conus12km` produces the token changes above; verified a 15-min `CYCLEDEF_PROD` stride generates sub-hourly `prod` cycles.
- All modified Python files `py_compile` clean.
