### PR TITLE
Fix UnboundLocalError in explicit-cycledef path (parse COLDSTART_CYCS)

### DIFF
--- a/workflow/rocoto_funcs/smart_cycledefs.py
+++ b/workflow/rocoto_funcs/smart_cycledefs.py
@@ -15,6 +15,11 @@ def smart_cycledefs():
         cycledef_prod = os.getenv('CYCLEDEF_PROD', 'not_defined')
         cycledef_spinup = os.getenv('CYCLEDEF_SPINUP', 'not_defined')
         cycledef_recenter = os.getenv('CYCLEDEF_RECENTER', 'not_defined')
+        # Needed by the da_nocold block below, which excludes the cold-start
+        # cycles from DA.  The auto-compute branch parses this too; the explicit
+        # branch must as well, otherwise cold_cycs is undefined whenever
+        # (DO_JEDI or DO_NONVAR_CLOUD_ANA) and COLDSTART_CYCS_DO_DA=false.
+        cold_cycs = os.getenv('COLDSTART_CYCS', '03 15').strip().split()
     else:  # compute cycledef automatically if no CYCLEDEF_* environment variables
         lbc_cycs = os.getenv('LBC_CYCS', '00 12').strip().split()
         lbc_step = str(int(24 / len(lbc_cycs)))


### PR DESCRIPTION
## Summary

Fixes an `UnboundLocalError` that makes the **explicit-cycledef path unusable for DA experiments**.

When a user sets `CYCLEDEF_*` variables explicitly in the experiment file, `smart_cycledefs()` takes the explicit-override branch and never parses `COLDSTART_CYCS` into `cold_cycs`. The later `da_nocold` block — built whenever `DO_JEDI=true` (or `DO_NONVAR_CLOUD_ANA=true`) **and** `COLDSTART_CYCS_DO_DA=false` — references `cold_cycs` and raises:

```
UnboundLocalError: local variable 'cold_cycs' referenced before assignment
  File "workflow/rocoto_funcs/smart_cycledefs.py", line ~102, in smart_cycledefs
    exclude_cycs.extend(list(map(int, cold_cycs)))
```

That configuration (DA, skipping DA at the cold-start cycles) is common, so explicit cycledefs currently cannot be used with it.

## Fix

Parse `COLDSTART_CYCS` in the explicit-override branch too, using the same default (`'03 15'`) as the auto-compute branch, so `da_nocold` can exclude the cold-start cycles.

## Impact

- Experiments using the **auto-compute** path (no `CYCLEDEF_*` set) never enter the modified branch → **all existing XML output is unchanged**.
- Experiments using **explicit** cycledefs with DA now generate correctly instead of crashing.

## Reproducer / verification

Append to `workflow/exp/exp.conus12km` (which has `DO_JEDI=true`, `COLDSTART_CYCS_DO_DA=false`, `COLDSTART_CYCS="00 12"`):

```bash
export CYCLEDEF_IC="202405270000 202405270000 24:00:00"
export CYCLEDEF_LBC="202405270000 202405280000 12:00:00"
export CYCLEDEF_PROD="202405270000 202405270300 01:00:00"
```

- **Before:** `./setup_rocoto.py` aborts with the `UnboundLocalError` above.
- **After:** generation succeeds and emits the expected `da_nocold` cycledef, e.g.:

```xml
<cycledef group="da_nocold" exclude_hours="0 12">202405270000 202405270300 01:00:00</cycledef>
```

`py_compile` clean.
